### PR TITLE
Args refactor

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -2,7 +2,10 @@ use std::any::TypeId;
 use value::{RuntimeValue, FromRuntimeValue};
 use {TrapKind, Trap};
 
-/// Safe wrapper for list of arguments.
+/// Wrapper around slice of [`RuntimeValue`] for using it
+/// as an argument list conveniently.
+///
+/// [`RuntimeValue`]: enum.RuntimeValue.html
 #[derive(Debug)]
 pub struct RuntimeArgs<'a>(&'a [RuntimeValue]);
 
@@ -33,6 +36,8 @@ impl<'a> RuntimeArgs<'a> {
 	/// # Errors
 	///
 	/// Returns `Err` if this list has not enough arguments.
+	///
+	/// [`RuntimeValue`]: enum.RuntimeValue.html
 	pub fn nth_value_checked(&self, idx: usize) -> Result<RuntimeValue, Trap> {
 		if self.0.len() <= idx {
 			return Err(TrapKind::UnexpectedSignature.into());

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,5 @@
 use std::any::TypeId;
-use value::{RuntimeValue, TryInto};
+use value::{RuntimeValue, FromRuntimeValue};
 use {TrapKind, Trap};
 
 /// Safe wrapper for list of arguments.
@@ -18,8 +18,8 @@ impl<'a> RuntimeArgs<'a> {
 	/// # Errors
 	///
 	/// Returns `Err` if cast is invalid or not enough arguments.
-	pub fn nth_checked<T>(&self, idx: usize) -> Result<T, Trap> where RuntimeValue: TryInto<T, ::value::Error> {
-		Ok(self.nth_value_checked(idx)?.try_into().map_err(|_| TrapKind::UnexpectedSignature)?)
+	pub fn nth_checked<T>(&self, idx: usize) -> Result<T, Trap> where T: FromRuntimeValue {
+		Ok(self.nth_value_checked(idx)?.try_into().ok_or_else(|| TrapKind::UnexpectedSignature)?)
 	}
 
 	/// Extract argument as a [`RuntimeValue`] by index `idx`.
@@ -39,7 +39,7 @@ impl<'a> RuntimeArgs<'a> {
 	/// # Panics
 	///
 	/// Panics if cast is invalid or not enough arguments.
-	pub fn nth<T>(&self, idx: usize) -> T where RuntimeValue: TryInto<T, ::value::Error> {
+	pub fn nth<T>(&self, idx: usize) -> T where T: FromRuntimeValue {
 		let value = self.nth_value_checked(idx).expect("Invalid argument index");
 		value.try_into().expect("Unexpected argument type")
 	}

--- a/src/host.rs
+++ b/src/host.rs
@@ -12,6 +12,12 @@ impl<'a> From<&'a [RuntimeValue]> for RuntimeArgs<'a> {
 	}
 }
 
+impl<'a> AsRef<[RuntimeValue]> for RuntimeArgs<'a> {
+	fn as_ref(&self) -> &[RuntimeValue] {
+		self.0
+	}
+}
+
 impl<'a> RuntimeArgs<'a> {
 	/// Extract argument by index `idx`.
 	///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ mod tests;
 
 pub use self::memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
 pub use self::table::{TableInstance, TableRef};
-pub use self::value::RuntimeValue;
+pub use self::value::{RuntimeValue, FromRuntimeValue};
 pub use self::host::{Externals, NopExternals, HostError, RuntimeArgs};
 pub use self::imports::{ModuleImportResolver, ImportResolver, ImportsBuilder};
 pub use self::module::{ModuleInstance, ModuleRef, ExternVal, NotStartedModuleRef};

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,14 +1,10 @@
 use std::{i32, i64, u32, u64, f32};
 use std::io;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use parity_wasm::elements::ValueType;
 use TrapKind;
 
 #[derive(Debug)]
 pub enum Error {
-	UnexpectedType {
-		expected: ValueType,
-	},
 	InvalidLittleEndianBuffer,
 }
 
@@ -31,10 +27,23 @@ pub enum RuntimeValue {
 	F64(f64),
 }
 
-/// Try to convert into trait.
-pub trait TryInto<T, E> {
-	/// Try to convert self into other value.
-	fn try_into(self) -> Result<T, E>;
+/// Trait for creating value from a [`RuntimeValue`].
+///
+/// Typically each implementation can create a value from the specific type.
+/// For example, values of type `bool` or `u32` are both represented by [`I32`] and `f64` values are represented by
+/// [`F64`].
+///
+/// [`I32`]: enum.RuntimeValue.html#variant.I32
+/// [`F64`]: enum.RuntimeValue.html#variant.F64
+/// [`RuntimeValue`]: enum.RuntimeValue.html
+pub trait FromRuntimeValue where Self: Sized {
+	/// Create a value of type `Self` from a given [`RuntimeValue`].
+	///
+	/// Returns `None` if the [`RuntimeValue`] is of type different than
+	/// expected by the conversion in question.
+	///
+	/// [`RuntimeValue`]: enum.RuntimeValue.html
+	fn from_runtime_value(val: RuntimeValue) -> Option<Self>;
 }
 
 /// Convert one type to another by wrapping.
@@ -151,6 +160,17 @@ impl RuntimeValue {
 			RuntimeValue::F64(_) => ::types::ValueType::F64,
 		}
 	}
+
+	/// Returns `T` if this particular [`RuntimeValue`] contains
+	/// appropriate type.
+	///
+	/// See [`FromRuntimeValue`] for details.
+	///
+	/// [`FromRuntimeValue`]: trait.FromRuntimeValue.html
+	/// [`RuntimeValue`]: enum.RuntimeValue.html
+	pub fn try_into<T: FromRuntimeValue>(self) -> Option<T> {
+		FromRuntimeValue::from_runtime_value(self)
+	}
 }
 
 impl From<i32> for RuntimeValue {
@@ -189,68 +209,38 @@ impl From<f64> for RuntimeValue {
 	}
 }
 
-impl TryInto<bool, Error> for RuntimeValue {
-	fn try_into(self) -> Result<bool, Error> {
-		match self {
-			RuntimeValue::I32(val) => Ok(val != 0),
-			_ => Err(Error::UnexpectedType { expected: ValueType::I32 }),
+macro_rules! impl_from_runtime_value {
+	($expected_rt_ty: ident, $into: ty) => {
+		impl FromRuntimeValue for $into {
+			fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+				match val {
+					RuntimeValue::$expected_rt_ty(val) => Some(val as $into),
+					_ => None,
+				}
+			}
+		}
+	};
+}
+
+/// This conversion assumes that boolean values are represented by
+/// [`I32`] type.
+///
+/// [`I32`]: enum.RuntimeValue.html#variant.I32
+impl FromRuntimeValue for bool {
+	fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+		match val {
+			RuntimeValue::I32(val) => Some(val != 0),
+			_ => None,
 		}
 	}
 }
 
-impl TryInto<i32, Error> for RuntimeValue {
-	fn try_into(self) -> Result<i32, Error> {
-		match self {
-			RuntimeValue::I32(val) => Ok(val),
-			_ => Err(Error::UnexpectedType { expected: ValueType::I32 }),
-		}
-	}
-}
-
-impl TryInto<i64, Error> for RuntimeValue {
-	fn try_into(self) -> Result<i64, Error> {
-		match self {
-			RuntimeValue::I64(val) => Ok(val),
-			_ => Err(Error::UnexpectedType { expected: ValueType::I64 }),
-		}
-	}
-}
-
-impl TryInto<f32, Error> for RuntimeValue {
-	fn try_into(self) -> Result<f32, Error> {
-		match self {
-			RuntimeValue::F32(val) => Ok(val),
-			_ => Err(Error::UnexpectedType { expected: ValueType::F32 }),
-		}
-	}
-}
-
-impl TryInto<f64, Error> for RuntimeValue {
-	fn try_into(self) -> Result<f64, Error> {
-		match self {
-			RuntimeValue::F64(val) => Ok(val),
-			_ => Err(Error::UnexpectedType { expected: ValueType::F64 }),
-		}
-	}
-}
-
-impl TryInto<u32, Error> for RuntimeValue {
-	fn try_into(self) -> Result<u32, Error> {
-		match self {
-			RuntimeValue::I32(val) => Ok(val as u32),
-			_ => Err(Error::UnexpectedType { expected: ValueType::I32 }),
-		}
-	}
-}
-
-impl TryInto<u64, Error> for RuntimeValue {
-	fn try_into(self) -> Result<u64, Error> {
-		match self {
-			RuntimeValue::I64(val) => Ok(val as u64),
-			_ => Err(Error::UnexpectedType { expected: ValueType::I64 }),
-		}
-	}
-}
+impl_from_runtime_value!(I32, i32);
+impl_from_runtime_value!(I64, i64);
+impl_from_runtime_value!(F32, f32);
+impl_from_runtime_value!(F64, f64);
+impl_from_runtime_value!(I32, u32);
+impl_from_runtime_value!(I64, u64);
 
 macro_rules! impl_wrap_into {
 	($from: ident, $into: ident) => {


### PR DESCRIPTION
When working on a integration of sandbox into a polkadot, I've encountered a situation when I needed to use `RuntimeArgs::nth` in a generic context but was unable to do so since it is impossible to call `nth` with type `T` without a `TryInto` constraint and it is also impossible to specify such constraint since `TryInto` is not exported.

Furthermore, even though `TryInto` is just a utility and user can always define conversion operations by himself, it is infeasible to extract `[RuntimeValue]` from the `RuntimeArgs` since it's not public.

