### PR TITLE
Prepare for 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "wasmi"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+repository = "https://github.com/paritytech/wasmi"
+documentation = "https://paritytech.github.io/wasmi/"
 description = "WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
-exclude = [ "res/*", "tests/*", "fuzz/*" ]
+exclude = [ "/res/*", "/tests/*", "/fuzz/*" ]
 
 [dependencies]
 parity-wasm = "0.27"


### PR DESCRIPTION
1. Version bump to 0.1.0,
2. Add fields like repository and documentation,
3. Migrated to `ignore` like excludes (see https://github.com/rust-lang/cargo/issues/4268)
