### PR TITLE
Require func_type (not func) for func import.

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -195,7 +195,7 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 		for import in import_section.entries() {
 			match *import.external() {
 				External::Function(function_type_index) => {
-					context.require_function(function_type_index)?;
+					context.require_function_type(function_type_index)?;
 				}
 				External::Global(ref global_type) => {
 					if global_type.is_mutable() {


### PR DESCRIPTION
Fixes #78 