### PR TITLE
Export nan_preserving_float.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,8 @@ extern crate assert_matches;
 extern crate parity_wasm;
 extern crate byteorder;
 extern crate memory_units as memory_units_crate;
-extern crate nan_preserving_float;
+
+pub extern crate nan_preserving_float;
 
 use std::fmt;
 use std::error;


### PR DESCRIPTION
Export nan_preserving_float crate.

It might come in handy since `RuntimeValue` directly references `nan_preserving_float::{F32, F64}` types. Otherwise, user code will have to depend on the nan_preserving_float crate explicitly.

