### PR TITLE
Resumable function invocation

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -266,6 +266,13 @@ impl<'args> FuncInvocation<'args> {
 	}
 
 	/// Resume an execution if a previous trap of Host kind happened.
+	///
+	/// `return_val` must be of the value type [`resumable_value_type`], defined by the host function import. Otherwise,
+	/// `UnexpectedSignature` trap will be returned. The current invocation must also be resumable
+	/// [`is_resumable`]. Otherwise, a `NotResumable` error will be returned.
+	///
+	/// [`resumable_value_type`]: struct.FuncInvocation.html#method.resumable_value_type
+	/// [`is_resumable`]: struct.FuncInvocation.html#method.is_resumable
 	pub fn resume_execution<'externals, E: Externals + 'externals>(&mut self, return_val: Option<RuntimeValue>, externals: &'externals mut E) -> Result<Option<RuntimeValue>, ResumableError> {
 		match self.kind {
 			FuncInvocationKind::Internal(ref mut interpreter) => {

--- a/src/func.rs
+++ b/src/func.rs
@@ -155,9 +155,11 @@ impl FuncInstance {
 		}
 	}
 
-	/// Invoke the function, get a resumable handle.  This handle can then be used to actually start the execution. If a
-	/// Host trap happens, caller can use `resume_execution` to feed the expected return value back in, and then
+	/// Invoke the function, get a resumable handle. This handle can then be used to [`start_execution`]. If a
+	/// Host trap happens, caller can use [`resume_execution`] to feed the expected return value back in, and then
 	/// continue the execution.
+	///
+	/// This is an experimental API, and this functionality may not be available in other WebAssembly engines.
 	///
 	/// # Errors
 	///
@@ -165,6 +167,8 @@ impl FuncInstance {
 	///
 	/// [`signature`]: #method.signature
 	/// [`Trap`]: #enum.Trap.html
+	/// [`start_execution`]: struct.FuncInvocation.html#method.start_execution
+	/// [`resume_execution`]: struct.FuncInvocation.html#method.resume_execution
 	pub fn invoke_resumable<'args>(
 		func: &FuncRef,
 		args: &'args [RuntimeValue],

--- a/src/func.rs
+++ b/src/func.rs
@@ -144,8 +144,8 @@ impl FuncInstance {
 		check_function_args(func.signature(), &args).map_err(|_| TrapKind::UnexpectedSignature)?;
 		match *func.as_internal() {
 			FuncInstanceInternal::Internal { .. } => {
-				let mut interpreter = Interpreter::new(externals);
-				interpreter.start_execution(func, args)
+				let mut interpreter = Interpreter::new(func, args, externals)?;
+				interpreter.start_execution()
 			}
 			FuncInstanceInternal::Host {
 				ref host_func_index,

--- a/src/func.rs
+++ b/src/func.rs
@@ -199,8 +199,21 @@ pub enum ResumableError {
 	/// Trap happened.
 	Trap(Trap),
 	/// The invocation is not resumable.
+	///
+	/// Invocations are only resumable if a host function is called, and the host function returns a trap of `Host` kind. For other cases, this error will be returned. This includes:
+	/// - The invocation is directly a host function.
+	/// - The invocation has not been started.
+	/// - The invocation returns normally or returns any trap other than `Host` kind.
+	///
+	/// This error is returned by [`resume_execution`].
+	///
+	/// [`resume_execution`]: struct.FuncInvocation.html#method.resume_execution
 	NotResumable,
 	/// The invocation has already been started.
+	///
+	/// This error is returned by [`start_execution`].
+	///
+	/// [`start_execution`]: struct.FuncInvocation.html#method.start_execution
 	AlreadyStarted,
 }
 
@@ -271,8 +284,8 @@ impl<'args> FuncInvocation<'args> {
 	/// `UnexpectedSignature` trap will be returned. The current invocation must also be resumable
 	/// [`is_resumable`]. Otherwise, a `NotResumable` error will be returned.
 	///
-	/// [`resumable_value_type`]: struct.FuncInvocation.html#method.resumable_value_type
-	/// [`is_resumable`]: struct.FuncInvocation.html#method.is_resumable
+	/// [`resumable_value_type`]: #method.resumable_value_type
+	/// [`is_resumable`]: #method.is_resumable
 	pub fn resume_execution<'externals, E: Externals + 'externals>(&mut self, return_val: Option<RuntimeValue>, externals: &'externals mut E) -> Result<Option<RuntimeValue>, ResumableError> {
 		match self.kind {
 			FuncInvocationKind::Internal(ref mut interpreter) => {

--- a/src/func.rs
+++ b/src/func.rs
@@ -210,6 +210,7 @@ impl From<Trap> for ResumableError {
 	}
 }
 
+/// A resumable invocation handle. This struct is returned by `FuncInstance::invoke_resumable`.
 pub struct FuncInvocation<'args, 'externals, E: Externals + 'externals> {
 	kind: FuncInvocationKind<'args, 'externals, E>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ pub use self::host::{Externals, NopExternals, HostError, RuntimeArgs};
 pub use self::imports::{ModuleImportResolver, ImportResolver, ImportsBuilder};
 pub use self::module::{ModuleInstance, ModuleRef, ExternVal, NotStartedModuleRef};
 pub use self::global::{GlobalInstance, GlobalRef};
-pub use self::func::{FuncInstance, FuncRef};
+pub use self::func::{FuncInstance, FuncRef, FuncInvocation, ResumableError};
 pub use self::types::{Signature, ValueType, GlobalDescriptor, TableDescriptor, MemoryDescriptor};
 
 /// WebAssembly-specific sizes and units.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,16 @@ pub enum TrapKind {
 	Host(Box<host::HostError>),
 }
 
+impl TrapKind {
+	/// Whether this trap is specified by the host.
+	pub fn is_host(&self) -> bool {
+		match self {
+			&TrapKind::Host(_) => true,
+			_ => false,
+		}
+	}
+}
+
 /// Internal interpreter error.
 #[derive(Debug)]
 pub enum Error {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -116,7 +116,7 @@ impl Interpreter {
 			self.value_stack.pop()
 		});
 
-		// Ensure that stack is empty after the execution.
+		// Ensure that stack is empty after the execution. This is guaranteed by the validation properties.
 		assert!(self.value_stack.len() == 0);
 
 		Ok(opt_return_value)
@@ -150,7 +150,7 @@ impl Interpreter {
 			self.value_stack.pop()
 		});
 
-		// Ensure that stack is empty after the execution.
+		// Ensure that stack is empty after the execution. This is guaranteed by the validation properties.
 		assert!(self.value_stack.len() == 0);
 
 		Ok(opt_return_value)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -106,7 +106,7 @@ impl Interpreter {
 	}
 
 	pub fn start_execution<'a, E: Externals + 'a>(&mut self, externals: &'a mut E) -> Result<Option<RuntimeValue>, Trap> {
-		// Ensure that the VM has not been executed.
+		// Ensure that the VM has not been executed. This is checked in `FuncInvocation::start_execution`.
 		assert!(self.state == InterpreterState::Initialized);
 
 		self.state = InterpreterState::Started;
@@ -125,7 +125,7 @@ impl Interpreter {
 	pub fn resume_execution<'a, E: Externals + 'a>(&mut self, return_val: Option<RuntimeValue>, externals: &'a mut E) -> Result<Option<RuntimeValue>, Trap> {
 		use std::mem::swap;
 
-		// Ensure that the VM is resumable.
+		// Ensure that the VM is resumable. This is checked in `FuncInvocation::resume_execution`.
 		assert!(self.state.is_resumable());
 
 		let mut resumable_state = InterpreterState::Started;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -103,6 +103,10 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 		})
 	}
 
+	pub fn state(&self) -> &InterpreterState {
+		&self.state
+	}
+
 	pub fn start_execution(&mut self) -> Result<Option<RuntimeValue>, Trap> {
 		// Ensure that the VM has not been executed.
 		assert!(self.state == InterpreterState::Initialized);

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -1,7 +1,7 @@
 use {
 	Error, Signature, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder,
 	MemoryInstance, MemoryRef, TableInstance, TableRef, ModuleImportResolver, ModuleInstance, ModuleRef,
-	RuntimeValue, RuntimeArgs, TableDescriptor, MemoryDescriptor, Trap, TrapKind, ResumableError, ExternVal,
+	RuntimeValue, RuntimeArgs, TableDescriptor, MemoryDescriptor, Trap, TrapKind, ResumableError,
 };
 use types::ValueType;
 use memory_units::Pages;
@@ -274,10 +274,8 @@ fn resume_call_host_func() {
 		.expect("Failed to instantiate module")
 		.assert_no_start();
 
-	let func_instance = match instance.export_by_name("test").unwrap() {
-		ExternVal::Func(func_instance) => func_instance,
-		_ => panic!(),
-	};
+	let export = instance.export_by_name("test").unwrap();
+	let func_instance = export.as_func().unwrap();
 
 	let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[]).unwrap();
 	let result = invocation.start_execution(&mut env);

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -1,7 +1,7 @@
 use {
 	Error, Signature, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder,
 	MemoryInstance, MemoryRef, TableInstance, TableRef, ModuleImportResolver, ModuleInstance, ModuleRef,
-	RuntimeValue, RuntimeArgs, TableDescriptor, MemoryDescriptor, Trap, TrapKind,
+	RuntimeValue, RuntimeArgs, TableDescriptor, MemoryDescriptor, Trap, TrapKind, ResumableError, ExternVal,
 };
 use types::ValueType;
 use memory_units::Pages;
@@ -32,6 +32,8 @@ impl HostError for HostErrorWithCode {}
 struct TestHost {
 	memory: Option<MemoryRef>,
 	instance: Option<ModuleRef>,
+
+	trap_sub_result: Option<RuntimeValue>,
 }
 
 impl TestHost {
@@ -39,6 +41,8 @@ impl TestHost {
 		TestHost {
 			memory: Some(MemoryInstance::alloc(Pages(1), Some(Pages(1))).unwrap()),
 			instance: None,
+
+			trap_sub_result: None,
 		}
 	}
 }
@@ -74,6 +78,11 @@ const GET_MEM_FUNC_INDEX: usize = 3;
 /// Note that this function is polymorphic over type T.
 /// This function requires attached module instance.
 const RECURSE_FUNC_INDEX: usize = 4;
+
+/// trap_sub(a: i32, b: i32) -> i32
+///
+/// This function is the same as sub(a, b), but it will send a Host trap which pauses the interpreter execution.
+const TRAP_SUB_FUNC_INDEX: usize = 5;
 
 impl Externals for TestHost {
 	fn invoke_index(
@@ -136,6 +145,14 @@ impl Externals for TestHost {
 				}
 				Ok(Some(result))
 			}
+			TRAP_SUB_FUNC_INDEX => {
+				let a: i32 = args.nth(0);
+				let b: i32 = args.nth(1);
+
+				let result: RuntimeValue = (a - b).into();
+				self.trap_sub_result = Some(result);
+				return Err(TrapKind::Host(Box::new(HostErrorWithCode { error_code: 301 })).into());
+			}
 			_ => panic!("env doesn't provide function at index {}", index),
 		}
 	}
@@ -157,6 +174,7 @@ impl TestHost {
 			ERR_FUNC_INDEX => (&[ValueType::I32], None),
 			INC_MEM_FUNC_INDEX => (&[ValueType::I32], None),
 			GET_MEM_FUNC_INDEX => (&[ValueType::I32], Some(ValueType::I32)),
+			TRAP_SUB_FUNC_INDEX => (&[ValueType::I32, ValueType::I32], Some(ValueType::I32)),
 			_ => return false,
 		};
 
@@ -172,6 +190,7 @@ impl ModuleImportResolver for TestHost {
 			"inc_mem" => INC_MEM_FUNC_INDEX,
 			"get_mem" => GET_MEM_FUNC_INDEX,
 			"recurse" => RECURSE_FUNC_INDEX,
+			"trap_sub" => TRAP_SUB_FUNC_INDEX,
 			_ => {
 				return Err(Error::Instantiation(
 					format!("Export {} not found", field_name),
@@ -226,6 +245,51 @@ fn call_host_func() {
 
 	assert_eq!(
 		instance.invoke_export("test", &[], &mut env).expect(
+			"Failed to invoke 'test' function",
+		),
+		Some(RuntimeValue::I32(-2))
+	);
+}
+
+#[test]
+fn resume_call_host_func() {
+	let module = parse_wat(
+		r#"
+(module
+	(import "env" "trap_sub" (func $trap_sub (param i32 i32) (result i32)))
+
+	(func (export "test") (result i32)
+		(call $trap_sub
+			(i32.const 5)
+			(i32.const 7)
+		)
+	)
+)
+"#,
+	);
+
+	let mut env = TestHost::new();
+
+	let instance = ModuleInstance::new(&module, &ImportsBuilder::new().with_resolver("env", &env))
+		.expect("Failed to instantiate module")
+		.assert_no_start();
+
+	let func_instance = match instance.export_by_name("test").unwrap() {
+		ExternVal::Func(func_instance) => func_instance,
+		_ => panic!(),
+	};
+
+	let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[]).unwrap();
+	let result = invocation.start_execution(&mut env);
+	match result {
+		Err(ResumableError::Trap(_)) => {},
+		_ => panic!(),
+	}
+
+	assert!(invocation.is_resumable());
+	let trap_sub_result = env.trap_sub_result.take();
+	assert_eq!(
+		invocation.resume_execution(trap_sub_result, &mut env).expect(
 			"Failed to invoke 'test' function",
 		),
 		Some(RuntimeValue::I32(-2))
@@ -325,6 +389,8 @@ fn pull_internal_mem_from_module() {
 	let mut env = TestHost {
 		memory: None,
 		instance: None,
+
+		trap_sub_result: None,
 	};
 
 	let instance = ModuleInstance::new(&module, &ImportsBuilder::new().with_resolver("env", &env))


### PR DESCRIPTION
Implements #85. If a trap of kind Host happens, we allow the caller to feed back in another return value for that host function, and then continue the execution.

* For interpreter, the call stack is moved to `Interpreter` struct itself. We drop the interpreter altogether for normal executions anyway. `resume_execution`, which takes the feeded-back return value, will continue the execution with the loop.
* For public interface, `invoke_resumable` is added to `FuncInstance`. This function returns a handle `FuncInvocation`. The caller can then use this to start or resume an execution.