### PR TITLE
Expose the `validate_module` function and `ValidatedModule` to crate users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,7 @@ pub use self::module::{ModuleInstance, ModuleRef, ExternVal, NotStartedModuleRef
 pub use self::global::{GlobalInstance, GlobalRef};
 pub use self::func::{FuncInstance, FuncRef, FuncInvocation, ResumableError};
 pub use self::types::{Signature, ValueType, GlobalDescriptor, TableDescriptor, MemoryDescriptor};
+pub use self::validation::{ValidatedModule, validate_module};
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -40,8 +40,11 @@ impl From<stack::Error> for Error {
 }
 
 #[derive(Clone)]
+/// A deserialized and validated module
 pub struct ValidatedModule {
+	/// The instructions in each Function, represented using isa::Instructions
 	pub code_map: Vec<isa::Instructions>,
+	/// The deserialized module
 	pub module: Module,
 }
 
@@ -165,6 +168,7 @@ pub fn deny_floating_point(module: &Module) -> Result<(), Error> {
 	Ok(())
 }
 
+/// Validate a module. This checks all of the invariants given by the WebAssembly spec.
 pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 	let mut context_builder = ModuleContextBuilder::new();
 	let mut imported_globals = Vec::new();


### PR DESCRIPTION
This just makes the function and struct public in `lib.rs`, so that they can be used outside of the crate.