### PR TITLE
Hide instruction storage details

### DIFF
--- a/src/isa.rs
+++ b/src/isa.rs
@@ -348,7 +348,7 @@ impl Instructions {
 		}
 	}
 
-	pub fn iterate_from(&self, position: usize) -> InstructionIter {
+	pub fn iterate_from(&self, position: u32) -> InstructionIter {
 		InstructionIter{
 			instructions: &self.vec,
 			position,
@@ -358,12 +358,12 @@ impl Instructions {
 
 pub struct InstructionIter<'a> {
 	instructions: &'a [Instruction],
-	position: usize,
+	position: u32,
 }
 
 impl<'a> InstructionIter<'a> {
 	#[inline]
-	pub fn position(&self) -> usize {
+	pub fn position(&self) -> u32 {
 		self.position
 	}
 }
@@ -373,7 +373,7 @@ impl<'a> Iterator for InstructionIter<'a> {
 
 	#[inline]
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-		self.instructions.get(self.position).map(|instruction| {
+		self.instructions.get(self.position as usize).map(|instruction| {
 			self.position += 1;
 			instruction
 		})

--- a/src/isa.rs
+++ b/src/isa.rs
@@ -299,5 +299,46 @@ pub enum Instruction {
 
 #[derive(Debug, Clone)]
 pub struct Instructions {
-	pub code: Vec<Instruction>,
+	vec: Vec<Instruction>,
+}
+
+impl Instructions {
+	pub fn new<I>(instructions: I) -> Self
+		where I: IntoIterator<Item=Instruction>
+	{
+		Instructions {
+			vec: instructions.into_iter().collect()
+		}
+	}
+
+	pub fn iterate_from(&self, position: usize) -> InstructionIter {
+		InstructionIter{
+			instructions: &self.vec,
+			position,
+		}
+	}
+}
+
+pub struct InstructionIter<'a> {
+	instructions: &'a [Instruction],
+	position: usize,
+}
+
+impl<'a> InstructionIter<'a> {
+	#[inline]
+	pub fn position(&self) -> usize {
+		self.position
+	}
+}
+
+impl<'a> Iterator for InstructionIter<'a> {
+	type Item = &'a Instruction;
+
+	#[inline]
+	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+		self.instructions.get(self.position).map(|instruction| {
+			self.position += 1;
+			instruction
+		})
+	}
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -175,7 +175,7 @@ impl Interpreter {
 			let function_return =
 				self.do_run_function(
 					&mut function_context,
-					&function_body.code.code,
+					&function_body.code,
 				).map_err(Trap::new)?;
 
 			match function_return {
@@ -229,18 +229,24 @@ impl Interpreter {
 		}
 	}
 
-	fn do_run_function(&mut self, function_context: &mut FunctionContext, instructions: &[isa::Instruction]) -> Result<RunResult, TrapKind> {
+	fn do_run_function(&mut self, function_context: &mut FunctionContext, instructions: &isa::Instructions)
+		-> Result<RunResult, TrapKind>
+	{
+		let mut iter = instructions.iterate_from(function_context.position);
 		loop {
-			let instruction = &instructions[function_context.position];
+			let instruction = iter.next().expect("instruction");
 
 			match self.run_instruction(function_context, instruction)? {
-				InstructionOutcome::RunNextInstruction => function_context.position += 1,
+				InstructionOutcome::RunNextInstruction => {
+					function_context.position = iter.position();
+				},
 				InstructionOutcome::Branch(target) => {
 					function_context.position = target.dst_pc as usize;
+					iter = instructions.iterate_from(function_context.position);
 					self.value_stack.drop_keep(target.drop_keep);
 				},
 				InstructionOutcome::ExecuteCall(func_ref) => {
-					function_context.position += 1;
+					function_context.position = iter.position();
 					return Ok(RunResult::NestedCall(func_ref));
 				},
 				InstructionOutcome::Return(drop_keep) => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -241,7 +241,7 @@ impl Interpreter {
 					function_context.position = iter.position();
 				},
 				InstructionOutcome::Branch(target) => {
-					function_context.position = target.dst_pc as usize;
+					function_context.position = target.dst_pc;
 					iter = instructions.iterate_from(function_context.position);
 					self.value_stack.drop_keep(target.drop_keep);
 				},
@@ -1083,7 +1083,7 @@ struct FunctionContext {
 	pub module: ModuleRef,
 	pub memory: Option<MemoryRef>,
 	/// Current instruction position.
-	pub position: usize,
+	pub position: u32,
 }
 
 impl FunctionContext {

--- a/src/validation/func.rs
+++ b/src/validation/func.rs
@@ -1406,9 +1406,7 @@ impl<'a> FunctionValidationContext<'a> {
 	}
 
 	fn into_code(self) -> isa::Instructions {
-		isa::Instructions {
-			code: self.sink.into_inner(),
-		}
+		isa::Instructions::new(self.sink.into_inner())
 	}
 }
 

--- a/src/validation/func.rs
+++ b/src/validation/func.rs
@@ -1406,7 +1406,7 @@ impl<'a> FunctionValidationContext<'a> {
 	}
 
 	fn into_code(self) -> isa::Instructions {
-		isa::Instructions::new(self.sink.into_inner())
+		self.sink.into_inner()
 	}
 }
 
@@ -1626,22 +1626,6 @@ struct Target {
 	drop_keep: isa::DropKeep,
 }
 
-/// A relocation entry that specifies.
-#[derive(Debug)]
-enum Reloc {
-	/// Patch the destination of the branch instruction (br, br_eqz, br_nez)
-	/// at the specified pc.
-	Br {
-		pc: u32,
-	},
-	/// Patch the specified destination index inside of br_table instruction at
-	/// the specified pc.
-	BrTable {
-		pc: u32,
-		idx: usize,
-	},
-}
-
 /// Identifier of a label.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct LabelId(usize);
@@ -1653,23 +1637,23 @@ enum Label {
 }
 
 struct Sink {
-	ins: Vec<isa::Instruction>,
-	labels: Vec<(Label, Vec<Reloc>)>,
+	ins: isa::Instructions,
+	labels: Vec<(Label, Vec<isa::Reloc>)>,
 }
 
 impl Sink {
 	fn with_instruction_capacity(capacity: usize) -> Sink {
 		Sink {
-			ins: Vec::with_capacity(capacity),
+			ins: isa::Instructions::with_capacity(capacity),
 			labels: Vec::new(),
 		}
 	}
 
 	fn cur_pc(&self) -> u32 {
-		self.ins.len() as u32
+		self.ins.current_pc()
 	}
 
-	fn pc_or_placeholder<F: FnOnce() -> Reloc>(&mut self, label: LabelId, reloc_creator: F) -> u32 {
+	fn pc_or_placeholder<F: FnOnce() -> isa::Reloc>(&mut self, label: LabelId, reloc_creator: F) -> u32 {
 		match self.labels[label.0] {
 			(Label::Resolved(dst_pc), _) => dst_pc,
 			(Label::NotResolved, ref mut unresolved) => {
@@ -1690,7 +1674,7 @@ impl Sink {
 			drop_keep,
 		} = target;
 		let pc = self.cur_pc();
-		let dst_pc = self.pc_or_placeholder(label, || Reloc::Br { pc });
+		let dst_pc = self.pc_or_placeholder(label, || isa::Reloc::Br { pc });
 		self.ins.push(isa::Instruction::Br(isa::Target {
 			dst_pc,
 			drop_keep: drop_keep.into(),
@@ -1703,7 +1687,7 @@ impl Sink {
 			drop_keep,
 		} = target;
 		let pc = self.cur_pc();
-		let dst_pc = self.pc_or_placeholder(label, || Reloc::Br { pc });
+		let dst_pc = self.pc_or_placeholder(label, || isa::Reloc::Br { pc });
 		self.ins.push(isa::Instruction::BrIfEqz(isa::Target {
 			dst_pc,
 			drop_keep: drop_keep.into(),
@@ -1716,7 +1700,7 @@ impl Sink {
 			drop_keep,
 		} = target;
 		let pc = self.cur_pc();
-		let dst_pc = self.pc_or_placeholder(label, || Reloc::Br { pc });
+		let dst_pc = self.pc_or_placeholder(label, || isa::Reloc::Br { pc });
 		self.ins.push(isa::Instruction::BrIfNez(isa::Target {
 			dst_pc,
 			drop_keep: drop_keep.into(),
@@ -1729,7 +1713,7 @@ impl Sink {
 		let pc = self.cur_pc();
 		let mut isa_targets = Vec::new();
 		for (idx, &Target { label, drop_keep }) in targets.iter().chain(iter::once(&default)).enumerate() {
-			let dst_pc = self.pc_or_placeholder(label, || Reloc::BrTable { pc, idx });
+			let dst_pc = self.pc_or_placeholder(label, || isa::Reloc::BrTable { pc, idx });
 			isa_targets.push(
 				isa::Target {
 					dst_pc,
@@ -1766,26 +1750,15 @@ impl Sink {
 		// particular label.
 		let unresolved_rels = mem::replace(&mut self.labels[label.0].1, Vec::new());
 		for reloc in unresolved_rels {
-			match reloc {
-				Reloc::Br { pc } => match self.ins[pc as usize] {
-					isa::Instruction::Br(ref mut target)
-					| isa::Instruction::BrIfEqz(ref mut target)
-					| isa::Instruction::BrIfNez(ref mut target) => target.dst_pc = dst_pc,
-					_ => panic!("branch relocation points to a non-branch instruction"),
-				},
-				Reloc::BrTable { pc, idx } => match self.ins[pc as usize] {
-					isa::Instruction::BrTable(ref mut targets) => targets[idx].dst_pc = dst_pc,
-					_ => panic!("brtable relocation points to not brtable instruction"),
-				}
-			}
+			self.ins.patch_relocation(reloc, dst_pc);
 		}
 
 		// Mark this label as resolved.
 		self.labels[label.0] = (Label::Resolved(dst_pc), Vec::new());
 	}
 
-	/// Consume this Sink and returns isa::Instruction.
-	fn into_inner(self) -> Vec<isa::Instruction> {
+	/// Consume this Sink and returns isa::Instructions.
+	fn into_inner(self) -> isa::Instructions {
 		// At this moment all labels should be resolved.
 		assert!({
 			self.labels.iter().all(|(state, unresolved)|

--- a/src/validation/tests.rs
+++ b/src/validation/tests.rs
@@ -313,7 +313,7 @@ fn validate(wat: &str) -> ValidatedModule {
 fn compile(wat: &str) -> Vec<isa::Instruction> {
 	let validated_module = validate(wat);
 	let code = &validated_module.code_map[0];
-	code.code.clone()
+	code.iterate_from(0).map(|i| i.clone()).collect()
 }
 
 #[test]


### PR DESCRIPTION
This PR lays some groundwork for #100.

`isa::Instructions` is now an opaque container. `current_pc(&self) -> u32` indicates the position at which the next instruction would be added, and `push(&mut self, Instruction)` actually does the adding. Currently this happens by pushing into a `Vec<Instruction>`, but this could instead encode the `Instruction` into bytecode.

`isa::Instructions` supports reading back instructions via `iterate_from(&self, pc: u32) -> InstructionIter<'>`. Again, right now that just walks the internal `Vec<Instruction>`, but it could instead sequentially decode `Instruction`s from bytecode.

Since instruction encoding is now internal to `isa::Instructions`, it also gains `patch_relocation(&mut self, Reloc, dst_pc: u32)`, and that enumeration moves to `isa::Reloc`. `func::Sink::resolve_label()` still controls the process as usual, but since the `isa::Instruction` is now hidden inside `isa::Instructions`, `isa::Instructions` needs to perform the required patching.

Finally, I noticed a few places where `usize` is used as a program counter. I changed those to `u32`, since a) that seems like enough and b) `isa::Instruction` is `u32` already.