### PR TITLE
Don't update PC on every instruction

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -237,12 +237,9 @@ impl Interpreter {
 			let instruction = iter.next().expect("instruction");
 
 			match self.run_instruction(function_context, instruction)? {
-				InstructionOutcome::RunNextInstruction => {
-					function_context.position = iter.position();
-				},
+				InstructionOutcome::RunNextInstruction => {},
 				InstructionOutcome::Branch(target) => {
-					function_context.position = target.dst_pc;
-					iter = instructions.iterate_from(function_context.position);
+					iter = instructions.iterate_from(target.dst_pc);
 					self.value_stack.drop_keep(target.drop_keep);
 				},
 				InstructionOutcome::ExecuteCall(func_ref) => {


### PR DESCRIPTION
We don't have to update frame's PC on every instruction, since the iterator already keeps track of the current PC. We still need update frame's PC before leaving the current frame.

Here is benchmark results:
```
 bench_regex_redux  6,678,107                       5,954,159               -723,948  -10.84%   x 1.12
 bench_rev_comp     8,367,998                       7,778,885               -589,113   -7.04%   x 1.08
 bench_tiny_keccak  4,247,514                       4,091,930               -155,584   -3.66%   x 1.04
 fac_opt            54,793                          52,716                    -2,077   -3.79%   x 1.04
 fac_recursive      57,335                          55,447                    -1,888   -3.29%   x 1.03
 recursive_ok       1,352,769                       1,270,486                -82,283   -6.08%   x 1.06
 recursive_trap     171,129                         168,653                   -2,476   -1.45%   x 1.01
```

cc @willglynn 