### PR TITLE
Travis maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
 - CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
 
 install:
-# Install `cargo-deadlinks` unless it is currently installed.
-- command -v cargo-deadlinks &> /dev/null || cargo install --git https://github.com/deadlinks/cargo-deadlinks/
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then rustup target add wasm32-unknown-unknown; fi
 script:
 # Make sure nightly targets are not broken.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-6
-    - g++-6
+    - gcc-8
+    - g++-8
     - cmake
 env:
-- CC=/usr/bin/gcc-6 CXX=/usr/bin/g++-6
+- CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
 
 install:
 # Install `cargo-deadlinks` unless it is currently installed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ nan-preserving-float = "0.1.0"
 
 [dev-dependencies]
 assert_matches = "1.1"
-wabt = "0.4"
+wabt = "0.6"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 [dependencies]
 wasmi = { path = ".." }
 assert_matches = "1.2"
-wabt = "0.3"
+wabt = "0.6"
 
 [profile.bench]
 debug = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 wasmi = { path = ".." }
-wabt = "0.2.0"
+wabt = "0.6.0"
 wasmparser = "0.14.1"
 tempdir = "0.3.6"
 

--- a/hfuzz/Cargo.toml
+++ b/hfuzz/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 honggfuzz = "=0.5.9" # Strict equal since hfuzz requires dep and cmd versions to match.
 wasmi = { path = ".." }
 tempdir = "0.3.6"
-wabt = "0.2.0"
+wabt = "0.6.0"


### PR DESCRIPTION
- use gcc-8
- update wabt to 0.6.
- don't run cargo-deadlinks in CI. It keeps getting us problems, e.g. [this](https://travis-ci.org/paritytech/wasmi/jobs/444458704#L1311-L1313). It's time to get rid of it.