### PR TITLE
Remove redundent check_function_args

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -1,7 +1,7 @@
 use std::rc::{Rc, Weak};
 use std::fmt;
 use parity_wasm::elements::Local;
-use {Trap, TrapKind, Signature};
+use {Trap, Signature};
 use host::Externals;
 use runner::{check_function_args, Interpreter, InterpreterState};
 use value::RuntimeValue;
@@ -142,7 +142,7 @@ impl FuncInstance {
 		args: &[RuntimeValue],
 		externals: &mut E,
 	) -> Result<Option<RuntimeValue>, Trap> {
-		check_function_args(func.signature(), &args).map_err(|_| TrapKind::UnexpectedSignature)?;
+		check_function_args(func.signature(), &args)?;
 		match *func.as_internal() {
 			FuncInstanceInternal::Internal { .. } => {
 				let mut interpreter = Interpreter::new(func, args)?;
@@ -173,7 +173,7 @@ impl FuncInstance {
 		func: &FuncRef,
 		args: &'args [RuntimeValue],
 	) -> Result<FuncInvocation<'args>, Trap> {
-		check_function_args(func.signature(), &args).map_err(|_| TrapKind::UnexpectedSignature)?;
+		check_function_args(func.signature(), &args)?;
 		match *func.as_internal() {
 			FuncInstanceInternal::Internal { .. } => {
 				let interpreter = Interpreter::new(func, args)?;

--- a/src/module.rs
+++ b/src/module.rs
@@ -623,7 +623,6 @@ impl ModuleInstance {
 			}
 		};
 
-		check_function_args(func_instance.signature(), &args)?;
 		FuncInstance::invoke(&func_instance, args, externals)
 			.map_err(|t| Error::Trap(t))
 	}

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,3 @@
-use runner::check_function_args;
 use Trap;
 use std::rc::Rc;
 use std::cell::RefCell;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3,7 +3,7 @@ use std::{u32, usize};
 use std::fmt;
 use std::iter::repeat;
 use parity_wasm::elements::Local;
-use {Error, Trap, TrapKind, Signature};
+use {Trap, TrapKind, Signature};
 use module::ModuleRef;
 use memory::MemoryRef;
 use func::{FuncRef, FuncInstance, FuncInstanceInternal};
@@ -1158,26 +1158,20 @@ fn prepare_function_args(
 	args
 }
 
-pub fn check_function_args(signature: &Signature, args: &[RuntimeValue]) -> Result<(), Error> {
+pub fn check_function_args(signature: &Signature, args: &[RuntimeValue]) -> Result<(), Trap> {
 	if signature.params().len() != args.len() {
 		return Err(
-			Error::Function(
-				format!(
-					"not enough arguments, given {} but expected: {}",
-					args.len(),
-					signature.params().len(),
-				)
-			)
+			TrapKind::UnexpectedSignature.into()
 		);
 	}
 
 	signature.params().iter().cloned().zip(args).map(|(expected_type, param_value)| {
 		let actual_type = param_value.value_type();
 		if actual_type != expected_type {
-			return Err(Error::Function(format!("invalid parameter type {:?} when expected {:?}", actual_type, expected_type)));
+			return Err(TrapKind::UnexpectedSignature.into());
 		}
 		Ok(())
-	}).collect::<Result<Vec<_>, _>>()?;
+	}).collect::<Result<Vec<_>, Trap>>()?;
 
 	Ok(())
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1167,13 +1167,12 @@ pub fn check_function_args(signature: &Signature, args: &[RuntimeValue]) -> Resu
 		);
 	}
 
-	signature.params().iter().cloned().zip(args).map(|(expected_type, param_value)| {
+	if signature.params().iter().zip(args).any(|(expected_type, param_value)| {
 		let actual_type = param_value.value_type();
-		if actual_type != expected_type {
-			return Err(TrapKind::UnexpectedSignature.into());
-		}
-		Ok(())
-	}).collect::<Result<Vec<_>, Trap>>()?;
+		&actual_type != expected_type
+	}) {
+		return Err(TrapKind::UnexpectedSignature.into());
+	}
 
 	Ok(())
 }


### PR DESCRIPTION
In `FuncInstance::invoke`, `check_function_args` is immediately called again.