### PR TITLE
Common bounded stack

### DIFF
--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -1,3 +1,2 @@
-/target
+target
 *.trace
-

--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -1,2 +1,3 @@
-target
+/target
 *.trace
+

--- a/benches/src/reuse.rs
+++ b/benches/src/reuse.rs
@@ -1,7 +1,7 @@
 use std::error;
 use std::fs::File;
 use test::Bencher;
-use wasmi::{FuncInstance, ImportsBuilder, Interpreter, Module, ModuleInstance, NopExternals, RuntimeValue};
+use wasmi::{ImportsBuilder, Interpreter, Module, ModuleInstance, NopExternals, RuntimeValue};
 
 // Load a module from a file.
 fn load_from_file(filename: &str) -> Result<Module, Box<error::Error>> {
@@ -39,7 +39,7 @@ fn bench_tiny_keccak(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		FuncInstance::invoke_configurable(&func, &[test_data_ptr], &mut NopExternals, &mut interpreter).unwrap()
+		interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap()
 	});
 }
 
@@ -85,7 +85,7 @@ fn bench_rev_comp(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		FuncInstance::invoke_configurable(&func, &[test_data_ptr], &mut NopExternals, &mut interpreter).unwrap()
+		interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap()
 	});
 
 	// Verify the result.
@@ -142,7 +142,7 @@ fn bench_regex_redux(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		FuncInstance::invoke_configurable(&func, &[test_data_ptr], &mut NopExternals, &mut interpreter).unwrap()
+		interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap()
 	});
 }
 
@@ -174,9 +174,9 @@ fn fac_recursive(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		let value =
-			FuncInstance::invoke_configurable(&func, &[RuntimeValue::I64(25)], &mut NopExternals, &mut interpreter)
-				.unwrap();
+		let value = interpreter
+			.invoke(&func, &[RuntimeValue::I64(25)], &mut NopExternals)
+			.unwrap();
 		assert_matches!(value, Some(RuntimeValue::I64(7034535277573963776)));
 	});
 }
@@ -214,9 +214,9 @@ fn fac_opt(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		let value =
-			FuncInstance::invoke_configurable(&func, &[RuntimeValue::I64(25)], &mut NopExternals, &mut interpreter)
-				.unwrap();
+		let value = interpreter
+			.invoke(&func, &[RuntimeValue::I64(25)], &mut NopExternals)
+			.unwrap();
 		assert_matches!(value, Some(RuntimeValue::I64(7034535277573963776)));
 	});
 }
@@ -255,9 +255,9 @@ fn recursive_ok(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		let value =
-			FuncInstance::invoke_configurable(&func, &[RuntimeValue::I32(8000)], &mut NopExternals, &mut interpreter)
-				.unwrap();
+		let value = interpreter
+			.invoke(&func, &[RuntimeValue::I32(8000)], &mut NopExternals)
+			.unwrap();
 		assert_matches!(value, Some(RuntimeValue::I32(0)));
 	});
 }
@@ -295,7 +295,8 @@ fn recursive_trap(b: &mut Bencher) {
 
 	b.iter(|| {
 		interpreter.reset();
-		FuncInstance::invoke_configurable(&func, &[RuntimeValue::I32(1000)], &mut NopExternals, &mut interpreter)
+		interpreter
+			.invoke(&func, &[RuntimeValue::I32(1000)], &mut NopExternals)
 			.unwrap_err();
 	});
 }

--- a/benches/src/reuse.rs
+++ b/benches/src/reuse.rs
@@ -1,10 +1,7 @@
 use std::error;
 use std::fs::File;
 use test::Bencher;
-use wasmi::{
-	FuncInstance, ImportsBuilder, Interpreter, Module, ModuleInstance, NopExternals, RuntimeValue, StackSize,
-	StackWithLimit,
-};
+use wasmi::{FuncInstance, ImportsBuilder, Interpreter, Module, ModuleInstance, NopExternals, RuntimeValue};
 
 // Load a module from a file.
 fn load_from_file(filename: &str) -> Result<Module, Box<error::Error>> {
@@ -23,12 +20,6 @@ fn load_kernel() -> Module {
 const REVCOMP_INPUT: &'static [u8] = include_bytes!("./revcomp-input.txt");
 const REVCOMP_OUTPUT: &'static [u8] = include_bytes!("./revcomp-output.txt");
 
-fn new_interpreter() -> Interpreter {
-	let value_stack = StackWithLimit::with_size(StackSize::from_element_count(1024 * 1024));
-	let call_stack = StackWithLimit::with_size(StackSize::from_element_count(1024 * 1024));
-	Interpreter::new(value_stack, call_stack)
-}
-
 #[bench]
 fn bench_tiny_keccak(b: &mut Bencher) {
 	let wasm_kernel = load_kernel();
@@ -44,7 +35,7 @@ fn bench_tiny_keccak(b: &mut Bencher) {
 
 	let func = instance.export_by_name("bench_tiny_keccak").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();
@@ -90,7 +81,7 @@ fn bench_rev_comp(b: &mut Bencher) {
 
 	let func = instance.export_by_name("bench_rev_complement").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();
@@ -147,7 +138,7 @@ fn bench_regex_redux(b: &mut Bencher) {
 
 	let func = instance.export_by_name("bench_regex_redux").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();
@@ -179,7 +170,7 @@ fn fac_recursive(b: &mut Bencher) {
 
 	let func = instance.export_by_name("fac-rec").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();
@@ -219,7 +210,7 @@ fn fac_opt(b: &mut Bencher) {
 
 	let func = instance.export_by_name("fac-opt").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();
@@ -260,7 +251,7 @@ fn recursive_ok(b: &mut Bencher) {
 
 	let func = instance.export_by_name("call").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();
@@ -300,7 +291,7 @@ fn recursive_trap(b: &mut Bencher) {
 
 	let func = instance.export_by_name("call").unwrap();
 	let func = func.as_func().unwrap();
-	let mut interpreter = new_interpreter();
+	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
 		interpreter.reset();

--- a/benches/src/reuse.rs
+++ b/benches/src/reuse.rs
@@ -37,10 +37,7 @@ fn bench_tiny_keccak(b: &mut Bencher) {
 	let func = func.as_func().unwrap();
 	let mut interpreter = Interpreter::new();
 
-	b.iter(|| {
-		interpreter.reset();
-		interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap()
-	});
+	b.iter(|| interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap());
 }
 
 #[bench]
@@ -83,10 +80,7 @@ fn bench_rev_comp(b: &mut Bencher) {
 	let func = func.as_func().unwrap();
 	let mut interpreter = Interpreter::new();
 
-	b.iter(|| {
-		interpreter.reset();
-		interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap()
-	});
+	b.iter(|| interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap());
 
 	// Verify the result.
 	let output_data_mem_offset = assert_matches!(
@@ -140,10 +134,7 @@ fn bench_regex_redux(b: &mut Bencher) {
 	let func = func.as_func().unwrap();
 	let mut interpreter = Interpreter::new();
 
-	b.iter(|| {
-		interpreter.reset();
-		interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap()
-	});
+	b.iter(|| interpreter.invoke(&func, &[test_data_ptr], &mut NopExternals).unwrap());
 }
 
 #[bench]
@@ -173,7 +164,6 @@ fn fac_recursive(b: &mut Bencher) {
 	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
-		interpreter.reset();
 		let value = interpreter
 			.invoke(&func, &[RuntimeValue::I64(25)], &mut NopExternals)
 			.unwrap();
@@ -213,7 +203,6 @@ fn fac_opt(b: &mut Bencher) {
 	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
-		interpreter.reset();
 		let value = interpreter
 			.invoke(&func, &[RuntimeValue::I64(25)], &mut NopExternals)
 			.unwrap();
@@ -254,7 +243,6 @@ fn recursive_ok(b: &mut Bencher) {
 	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
-		interpreter.reset();
 		let value = interpreter
 			.invoke(&func, &[RuntimeValue::I32(8000)], &mut NopExternals)
 			.unwrap();
@@ -294,7 +282,6 @@ fn recursive_trap(b: &mut Bencher) {
 	let mut interpreter = Interpreter::new();
 
 	b.iter(|| {
-		interpreter.reset();
 		interpreter
 			.invoke(&func, &[RuntimeValue::I32(1000)], &mut NopExternals)
 			.unwrap_err();

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -1,126 +1,11 @@
-mod ol {
-	#[allow(unused_imports)]
-	use alloc::prelude::*;
+use core::marker::PhantomData;
+use core::usize;
 
-	use core::fmt;
-	#[cfg(feature = "std")]
-	use std::error;
-
-	#[derive(Debug)]
-	pub struct Error(String);
-
-	impl fmt::Display for Error {
-		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-			write!(f, "{}", self.0)
-		}
-	}
-
-	#[cfg(feature = "std")]
-	impl error::Error for Error {
-		fn description(&self) -> &str {
-			&self.0
-		}
-	}
-
-	/// Stack with limit.
-	#[derive(Debug)]
-	pub struct StackWithLimit<T>
-	where
-		T: Clone,
-	{
-		/// Stack values.
-		values: Vec<T>,
-		/// Stack limit (maximal stack len).
-		limit: usize,
-	}
-
-	impl<T> StackWithLimit<T>
-	where
-		T: Clone,
-	{
-		pub fn with_limit(limit: usize) -> Self {
-			StackWithLimit {
-				values: Vec::new(),
-				limit: limit,
-			}
-		}
-
-		pub fn is_empty(&self) -> bool {
-			self.values.is_empty()
-		}
-
-		pub fn len(&self) -> usize {
-			self.values.len()
-		}
-
-		pub fn top(&self) -> Result<&T, Error> {
-			self.values
-				.last()
-				.ok_or_else(|| Error("non-empty stack expected".into()))
-		}
-
-		pub fn top_mut(&mut self) -> Result<&mut T, Error> {
-			self.values
-				.last_mut()
-				.ok_or_else(|| Error("non-empty stack expected".into()))
-		}
-
-		// Not the same as vector.get
-		pub fn get(&self, index: usize) -> Result<&T, Error> {
-			if index >= self.values.len() {
-				return Err(Error(format!(
-					"trying to get value at position {} on stack of size {}",
-					index,
-					self.values.len()
-				)));
-			}
-
-			Ok(self
-				.values
-				.get(self.values.len() - 1 - index)
-				.expect("checked couple of lines above"))
-		}
-
-		pub fn push(&mut self, value: T) -> Result<(), Error> {
-			if self.values.len() >= self.limit {
-				return Err(Error(format!("exceeded stack limit {}", self.limit)));
-			}
-
-			self.values.push(value);
-			Ok(())
-		}
-
-		pub fn pop(&mut self) -> Result<T, Error> {
-			self.values
-				.pop()
-				.ok_or_else(|| Error("non-empty stack expected".into()))
-		}
-
-		pub fn resize(&mut self, new_size: usize, dummy: T) {
-			debug_assert!(new_size <= self.values.len());
-			self.values.resize(new_size, dummy);
-		}
-	}
-}
+#[allow(unused_imports)]
+use alloc::prelude::*;
 
 #[derive(Copy, Clone, Debug)]
 pub struct StackOverflow;
-
-// impl From<StackOverflow> for TrapKind {
-// 	fn from(_: StackOverflow) -> TrapKind {
-// 		TrapKind::StackOverflow
-// 	}
-// }
-
-// impl From<StackOverflow> for Trap {
-// 	fn from(_: StackOverflow) -> Trap {
-// 		Trap::new(TrapKind::StackOverflow)
-// 	}
-// }
-
-// TODO: impl constructors
-struct Limit(usize);
-struct InitialSize(usize);
 
 /// Pre-allocated, growable stack with upper bound on size.
 ///
@@ -128,8 +13,8 @@ struct InitialSize(usize);
 /// When limit is reached attempting to push to the stack will return
 /// `Err(StackOverflow)`.
 ///
-/// In addition to the limit. Initial stack size is configurable.
-/// `StackWithLimit` will start out with initial size, but grow if necessary.
+/// Both limit and initial stack size are configurable.
+/// `StackWithLimit` will start out with initial size, but grow when necessary.
 #[derive(Debug)]
 pub struct StackWithLimit<T> {
 	stack: Vec<T>,
@@ -137,26 +22,54 @@ pub struct StackWithLimit<T> {
 }
 
 impl<T> StackWithLimit<T> {
-	/// Create an new StackWithLimit with `limit` max size and `initial_size` elements pre-allocated
-	/// `initial_size` should not be larger than `limit`
-	pub fn new(initial_size: usize, limit: usize) -> StackWithLimit<T> {
+	/// Create a StackWithLimit with `limit` max size and `initial_size` of pre-allocated
+	/// memory.
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// # use wasmi::{StackWithLimit, StackSize, FuncRef};
+	/// StackWithLimit::<FuncRef>::new(
+	/// 	StackSize::from_element_count(1024).into_initial(),
+	/// 	StackSize::from_element_count(2048).into_limit(),
+	/// );
+	/// ```
+	///
+	/// Unlimited
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// # use wasmi::{StackWithLimit, StackSize, RuntimeValue};
+	/// StackWithLimit::<RuntimeValue>::new(
+	/// 	StackSize::from_element_count(1024).into_initial(),
+	/// 	StackSize::unlimited(),
+	/// );
+	/// ```
+	///
+	/// # Errors
+	///
+	/// In debug mode, panics if `initial_size` is larger than `limit`.
+	pub fn new(initial_size: StackSizeInitial<T>, limit: StackSizeLimit<T>) -> StackWithLimit<T> {
+		let initial_size_elements = initial_size.0.element_count();
+		let limit_elements = limit.0.element_count();
 		debug_assert!(
-			limit >= initial_size,
+			limit_elements >= initial_size_elements,
 			"initial_size should not be larger than StackWithLimit limit"
 		);
-		use std::cmp::min;
 		StackWithLimit {
-			stack: Vec::with_capacity(initial_size),
-			limit: min(initial_size, limit),
+			stack: Vec::with_capacity(initial_size_elements.min(limit_elements)),
+			limit: limit_elements,
 		}
 	}
 
 	/// Create an new StackWithLimit with `limit` max size and `limit` elements pre-allocated
-	pub fn with_limit(limit: usize) -> StackWithLimit<T> {
-		StackWithLimit {
-			stack: Vec::with_capacity(limit),
-			limit: limit,
-		}
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// # use wasmi::{StackWithLimit, StackSize};
+	/// let bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+	/// ```
+	pub fn with_size(size: StackSize<T>) -> StackWithLimit<T> {
+		StackWithLimit::new(StackSizeInitial(size), StackSizeLimit(size))
 	}
 
 	/// Attempt to push value onto stack.
@@ -165,16 +78,18 @@ impl<T> StackWithLimit<T> {
 	///
 	/// Returns Err(StackOverflow) if stack is already full.
 	pub(crate) fn push(&mut self, value: T) -> Result<(), StackOverflow> {
-		debug_assert!(
-			self.stack.len() <= self.limit,
-			"Stack length should never be larger than stack limit."
-		);
-		if self.stack.len() < self.limit {
+		println!("limit {}", self.limit);
+		let ret = if self.stack.len() < self.limit {
 			self.stack.push(value);
 			Ok(())
 		} else {
 			Err(StackOverflow)
-		}
+		};
+		debug_assert!(
+			self.stack.len() <= self.limit,
+			"Stack length should never be larger than stack limit."
+		);
+		ret
 	}
 
 	pub(crate) fn pop(&mut self) -> Option<T> {
@@ -190,18 +105,15 @@ impl<T> StackWithLimit<T> {
 	/// `bstack.get_relative_to_top(0)` gets the top of the stack
 	///
 	/// `bstack.get_relative_to_top(1)` gets the item just below the stack
-	///
-
 	pub(crate) fn get_relative_to_top(&self, depth: usize) -> Option<&T> {
-		let offset = depth + 1;
-		if self.stack.len() < offset {
-			None
-		} else {
-			// We should be cognizant of integer underflow here.
-			// If offset > len(), (len() - offset) will underflow.
-			// In debug builds, underflow panics, but in release mode, underflow is not checked.
-			self.stack.get(self.stack.len() - offset)
-		}
+		// Be cognizant of integer underflow and overflow here. Both are possible in this situation.
+		// len() is unsigned, so if len() == 0, subtraction is a problem
+		// depth can legally be 2^32. On a 32 bit system, adding may overflow
+		// overflow isn't an issue unless T is zero size
+		// In debug builds, underflow panics, but in release mode, underflow is not checked.
+
+		let index = self.stack.len().checked_sub(1)?.checked_sub(depth)?;
+		self.stack.get(index)
 	}
 
 	pub(crate) fn top(&self) -> Option<&T> {
@@ -212,6 +124,7 @@ impl<T> StackWithLimit<T> {
 		self.stack.last_mut()
 	}
 
+	// Same as Vec::[truncate](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.truncate)
 	pub(crate) fn truncate(&mut self, new_size: usize) {
 		self.stack.truncate(new_size)
 	}
@@ -223,26 +136,203 @@ impl<T> StackWithLimit<T> {
 	pub(crate) fn is_empty(&self) -> bool {
 		self.stack.is_empty()
 	}
-
-	// /// return a new empty StackWithLimit with limit equal to the amount of room
-	// /// this stack has available
-	// pub fn spare(&self) -> StackWithLimit<T> {
-	//     // This will be used to allocate new stacks when calling into other wasm modules
-	//     StackWithLimit::new(0, self.limit - self.len())
-	// }
 }
+
+// Why introduce the extra complexity of StackSizeLimit, StackSizeInitial, and StackSize?
+// We want to make the user to do the correct thing using the type checker.
+// Check out the excellent Rust API Guidelines (linked below) for suggestions
+// about type safety in rust.
+//
+// By introducing the new typed arguments, we turn:
+//
+// ```
+// pub fn new(initial_size: usize, limit: usize) -> StackWithLimit<T> { ... }
+// ```
+//
+// into:
+//
+// ```
+// pub fn new(initial_size: StackSizeInitial<T>, limit: StackSizeLimit<T>) -> StackWithLimit<T> { ... }
+// ```
+//
+// https://rust-lang-nursery.github.io/api-guidelines/type-safety.html#c-custom-type
+
+/// Type for communicating the size of some contigous container.
+/// Used for constructing both [`StackSizeLimit`] and [`StackSizeInitial`].
+#[derive(Eq, PartialEq, Hash, Debug)]
+pub struct StackSize<T> {
+	num_elements: usize,
+	// PhantomData is a zero-sized type for keeping track of T without rustc complaining.
+	phantom: PhantomData<*const T>,
+}
+
+impl<T> Clone for StackSize<T> {
+	fn clone(&self) -> Self {
+		StackSize {
+			num_elements: self.num_elements,
+			phantom: PhantomData,
+		}
+	}
+}
+
+impl<T> Copy for StackSize<T> {}
+
+impl<T> StackSize<T> {
+	/// Create StackSize based on number of elements.
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// # use wasmi::StackSize;
+	/// let ss = StackSize::<(u8, u8)>::from_element_count(10);
+	/// assert_eq!(ss.element_count(), 10);
+	/// ```
+	pub fn from_element_count(num_elements: usize) -> StackSize<T> {
+		StackSize {
+			num_elements,
+			phantom: PhantomData,
+		}
+	}
+
+	/// Compute StackSize based on allowable memory.
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// # use wasmi::StackSize;
+	/// let ss = StackSize::<(u8, u8)>::from_byte_count(10);
+	/// assert_eq!(ss.element_count(), 10 / 2);
+	/// ```
+	///
+	/// # Errors
+	///
+	/// In debug mode, panics if size of `T` is 0.
+	pub fn from_byte_count(num_bytes: usize) -> StackSize<T> {
+		// This debug_assert should catch logical errors.
+		debug_assert!(::core::mem::size_of::<T>() != 0, "That doesn't make sense.");
+
+		// In case a zero sized T still makes it into prod. We assume unlimited stack
+		// size instead of panicking.
+		let element_count = if ::core::mem::size_of::<T>() != 0 {
+			num_bytes / ::core::mem::size_of::<T>()
+		} else {
+			usize::MAX // Semi-relevant fun fact: Vec::<()>::new().capacity() == usize::MAX
+		};
+
+		StackSize::from_element_count(element_count)
+	}
+
+	/// Return number the of elements this StackSize indicates.
+	///
+	/// ```
+	/// # use wasmi::StackSize;
+	/// let ss = StackSize::<(u8, u8)>::from_element_count(10);
+	/// assert_eq!(ss.element_count(), 10);
+	/// ```
+	///
+	pub fn element_count(&self) -> usize {
+		self.num_elements
+	}
+
+	/// Create StackSizeLimit out of self
+	///
+	/// ```
+	/// # use wasmi::{StackSize, StackSizeLimit, RuntimeValue};
+	/// let values_limit: StackSizeLimit<RuntimeValue> = StackSize::from_element_count(1024).into_limit();
+	/// ```
+	pub fn into_limit(self) -> StackSizeLimit<T> {
+		StackSizeLimit(self)
+	}
+
+	/// Create StackSizeLimit out of self
+	pub fn into_initial(self) -> StackSizeInitial<T> {
+		StackSizeInitial(self)
+	}
+
+	/// Create StackSizeLimit with no upper bound.
+	pub fn unlimited() -> StackSizeLimit<T> {
+		StackSize::from_element_count(usize::MAX).into_limit()
+	}
+}
+
+/// Max size a stack may become.
+///
+/// Constructed by [`StackSize::into_limit`](into_limit) or [`StackSize::unlimited`](unlimited)
+///
+/// [into_limit]: type.StackSize.into_limit.html
+/// [unlimited]: type.StackSize.unlimited.html
+pub struct StackSizeLimit<T>(StackSize<T>);
+
+/// Number of pre-allocated elements.
+///
+/// Constructed by [`StackSize::into_initial`]
+///
+/// [into_initial]: type.StackSize.into_initial.html
+pub struct StackSizeInitial<T>(StackSize<T>);
 
 #[cfg(test)]
 mod test {
-	use super::StackWithLimit;
+	use super::{StackSize, StackSizeInitial, StackSizeLimit, StackWithLimit};
+	use core::usize;
 
+	#[test]
 	fn get_relative_to_top() {
-		let mut bstack = StackWithLimit::<i32>::with_limit(2);
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		assert_eq!(bstack.get_relative_to_top(0), None);
 		bstack.push(1).unwrap();
 		bstack.push(2).unwrap();
 		bstack.push(3).unwrap_err();
 		assert_eq!(bstack.get_relative_to_top(0), Some(&2));
 		assert_eq!(bstack.get_relative_to_top(1), Some(&1));
 		assert_eq!(bstack.get_relative_to_top(2), None);
+		assert_eq!(bstack.get_relative_to_top(3), None);
+	}
+
+	fn exersize(mut bstack: StackWithLimit<i32>) {
+		assert!(bstack.is_empty());
+		assert_eq!(bstack.len(), 0);
+		assert_eq!(bstack.top(), None);
+		assert_eq!(bstack.top_mut(), None);
+		assert_eq!(bstack.pop(), None);
+		bstack.push(0).unwrap();
+		assert!(!bstack.is_empty());
+		assert_eq!(bstack.len(), 1);
+		assert_eq!(bstack.top(), Some(&0));
+		assert_eq!(bstack.top_mut(), Some(&mut 0));
+		assert_eq!(bstack.pop(), Some(0));
+
+		bstack.push(0).unwrap();
+		bstack.push(0).unwrap();
+		bstack.push(0).unwrap();
+		bstack.push(0).unwrap();
+		assert_eq!(bstack.len(), 4);
+		bstack.truncate(8);
+		assert_eq!(bstack.len(), 4);
+		bstack.truncate(4);
+		assert_eq!(bstack.len(), 4);
+		bstack.truncate(2);
+		assert_eq!(bstack.len(), 2);
+		bstack.truncate(0);
+		assert_eq!(bstack.len(), 0);
+	}
+
+	#[test]
+	fn stack_with_limit() {
+		let bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(20));
+		exersize(bstack);
+	}
+
+	// Check for integer overflow bugs
+	#[test]
+	fn practically_unlimited_stack() {
+		let bstack = StackWithLimit::<i32>::new(
+			StackSizeInitial(StackSize::from_element_count(0)),
+			StackSizeLimit(StackSize::from_element_count(usize::MAX)),
+		);
+		println!(
+			"{}",
+			StackSizeLimit(StackSize::<i32>::from_element_count(usize::MAX))
+				.0
+				.element_count()
+		);
+		exersize(bstack);
 	}
 }

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -130,10 +130,10 @@ impl<T> StackWithLimit<T> {
 	/// ```
 	/// # extern crate wasmi;
 	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
 	/// bstack.push(4);
-	/// assert_eq!(bstack.nth_from_top(0, Some(&4));
-	/// assert_eq!(bstack.nth_from_top(1, None);
+	/// assert_eq!(bstack.nth_from_top(0), Some(&4));
+	/// assert_eq!(bstack.nth_from_top(1), None);
 	/// ```
 	pub fn nth_from_top(&self, depth: usize) -> Option<&T> {
 		// Be cognizant of integer underflow and overflow here. Both are possible in this situation.

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -123,10 +123,10 @@ impl<T> StackWithLimit<T> {
 
 	/// Return optional reference to item `depth` distance away from top
 	///
-	/// `bstack.get_relative_to_top(0)` gets the top of the stack
+	/// `bstack.nth_from_top(0)` gets the top of the stack
 	///
-	/// `bstack.get_relative_to_top(1)` gets the item just below the stack
-	pub(crate) fn get_relative_to_top(&self, depth: usize) -> Option<&T> {
+	/// `bstack.nth_from_top(1)` gets the item just below the stack
+	pub(crate) fn nth_from_top(&self, depth: usize) -> Option<&T> {
 		// Be cognizant of integer underflow and overflow here. Both are possible in this situation.
 		// len() is unsigned, so if len() == 0, subtraction is a problem
 		// depth can legally be 2^32. On a 32 bit system, adding may overflow
@@ -141,7 +141,7 @@ impl<T> StackWithLimit<T> {
 	/// Return mutable reference to item `depth` distance away from top
 	///
 	/// Does not check whether depth is in range.
-	pub(crate) fn get_relative_to_top_mut_unchecked(&mut self, depth: usize) -> &mut T {
+	pub(crate) fn nth_from_top_mut_unchecked(&mut self, depth: usize) -> &mut T {
 		let offset = self.stack.len() - 1 - depth;
 		&mut self.stack[offset]
 	}
@@ -333,16 +333,16 @@ mod test {
 	use core::usize;
 
 	#[test]
-	fn get_relative_to_top() {
+	fn nth_from_top() {
 		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-		assert_eq!(bstack.get_relative_to_top(0), None);
+		assert_eq!(bstack.nth_from_top(0), None);
 		bstack.push(1).unwrap();
 		bstack.push(2).unwrap();
 		bstack.push(3).unwrap_err();
-		assert_eq!(bstack.get_relative_to_top(0), Some(&2));
-		assert_eq!(bstack.get_relative_to_top(1), Some(&1));
-		assert_eq!(bstack.get_relative_to_top(2), None);
-		assert_eq!(bstack.get_relative_to_top(3), None);
+		assert_eq!(bstack.nth_from_top(0), Some(&2));
+		assert_eq!(bstack.nth_from_top(1), Some(&1));
+		assert_eq!(bstack.nth_from_top(2), None);
+		assert_eq!(bstack.nth_from_top(3), None);
 	}
 
 	fn exersize(mut bstack: StackWithLimit<i32>) {

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -46,7 +46,7 @@ impl<T> StackWithLimit<T> {
 	/// );
 	/// ```
 	///
-	/// # Errors
+	/// # Panics
 	///
 	/// In debug mode, panics if `initial_size` is larger than `limit`.
 	pub fn new(initial_size: StackSizeInitial<T>, limit: StackSizeLimit<T>) -> StackWithLimit<T> {

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -79,7 +79,7 @@ impl<T> StackWithLimit<T> {
 	///
 	/// Returns Err(StackOverflow) if stack is already full.
 	#[inline]
-	pub(crate) fn push(&mut self, value: T) -> Result<(), StackOverflow> {
+	pub fn push(&mut self, value: T) -> Result<(), StackOverflow> {
 		if self.stack.len() == self.stack.capacity() {
 			if self.stack.len() == self.limit {
 				return Err(StackOverflow);
@@ -106,7 +106,7 @@ impl<T> StackWithLimit<T> {
 		Ok(())
 	}
 
-	pub(crate) fn pop(&mut self) -> Option<T> {
+	pub fn pop(&mut self) -> Option<T> {
 		self.stack.pop()
 	}
 
@@ -114,7 +114,7 @@ impl<T> StackWithLimit<T> {
 	/// If this is called on a zero length stack, bad things will happen.
 	/// Do not call this method unless you can prove the stack has length.
 	#[inline]
-	pub(crate) unsafe fn pop_unchecked(&mut self) -> T {
+	pub unsafe fn pop_unchecked(&mut self) -> T {
 		debug_assert!(self.stack.len() > 0);
 		let len = self.stack.len();
 		self.stack.set_len(len - 1);
@@ -126,7 +126,16 @@ impl<T> StackWithLimit<T> {
 	/// `bstack.nth_from_top(0)` gets the top of the stack
 	///
 	/// `bstack.nth_from_top(1)` gets the item just below the stack
-	pub(crate) fn nth_from_top(&self, depth: usize) -> Option<&T> {
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// # use wasmi::{StackWithLimit, StackSize};
+	/// let bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+	/// bstack.push(4);
+	/// assert_eq!(bstack.nth_from_top(0, Some(&4));
+	/// assert_eq!(bstack.nth_from_top(1, None);
+	/// ```
+	pub fn nth_from_top(&self, depth: usize) -> Option<&T> {
 		// Be cognizant of integer underflow and overflow here. Both are possible in this situation.
 		// len() is unsigned, so if len() == 0, subtraction is a problem
 		// depth can legally be 2^32. On a 32 bit system, adding may overflow
@@ -141,7 +150,7 @@ impl<T> StackWithLimit<T> {
 	/// Return mutable reference to item `depth` distance away from top
 	///
 	/// Does not check whether depth is in range.
-	pub(crate) fn nth_from_top_mut_unchecked(&mut self, depth: usize) -> &mut T {
+	pub fn nth_from_top_mut_unchecked(&mut self, depth: usize) -> &mut T {
 		let offset = self.stack.len() - 1 - depth;
 		&mut self.stack[offset]
 	}
@@ -157,7 +166,7 @@ impl<T> StackWithLimit<T> {
 	///
 	/// Panics if `a` or `b` are out of bound.
 	#[inline]
-	pub(crate) fn swap(&mut self, a: usize, b: usize) {
+	pub fn swap(&mut self, a: usize, b: usize) {
 		self.stack.swap(a, b)
 	}
 
@@ -174,25 +183,25 @@ impl<T> StackWithLimit<T> {
 		self.stack.swap_remove(index)
 	}
 
-	pub(crate) fn top(&self) -> Option<&T> {
+	pub fn top(&self) -> Option<&T> {
 		self.stack.last()
 	}
 
-	pub(crate) fn top_mut(&mut self) -> Option<&mut T> {
+	pub fn top_mut(&mut self) -> Option<&mut T> {
 		self.stack.last_mut()
 	}
 
 	// Same as Vec::[truncate](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.truncate)
-	pub(crate) fn truncate(&mut self, new_size: usize) {
+	pub fn truncate(&mut self, new_size: usize) {
 		self.stack.truncate(new_size)
 	}
 
 	#[inline]
-	pub(crate) fn len(&self) -> usize {
+	pub fn len(&self) -> usize {
 		self.stack.len()
 	}
 
-	pub(crate) fn is_empty(&self) -> bool {
+	pub fn is_empty(&self) -> bool {
 		self.stack.is_empty()
 	}
 }

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -26,26 +26,6 @@ impl<T> StackWithLimit<T> {
 	/// Create a StackWithLimit with `limit` max size and `initial_size` of pre-allocated
 	/// memory.
 	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize, FuncRef};
-	/// StackWithLimit::<FuncRef>::new(
-	/// 	StackSize::from_element_count(1024).into_initial(),
-	/// 	StackSize::from_element_count(2048).into_limit(),
-	/// );
-	/// ```
-	///
-	/// Unlimited
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize, RuntimeValue};
-	/// StackWithLimit::<RuntimeValue>::new(
-	/// 	StackSize::from_element_count(1024).into_initial(),
-	/// 	StackSize::unlimited(),
-	/// );
-	/// ```
-	///
 	/// # Panics
 	///
 	/// In debug mode, panics if `initial_size` is larger than `limit`.
@@ -63,12 +43,6 @@ impl<T> StackWithLimit<T> {
 	}
 
 	/// Create an new StackWithLimit with `limit` max size and `limit` elements pre-allocated
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// ```
 	pub fn with_size(size: StackSize<T>) -> StackWithLimit<T> {
 		StackWithLimit::new(StackSizeInitial(size), StackSizeLimit(size))
 	}
@@ -102,21 +76,11 @@ impl<T> StackWithLimit<T> {
 	}
 
 	/// Remove item from the top of a stack and return it, or `None` if the stack is empty.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// bstack.push(2);
-	/// assert_eq!(bstack.pop(), Some(2));
-	/// assert_eq!(bstack.len(), 0);
-	/// assert_eq!(bstack.pop(), None);
-	/// ```
 	pub fn pop(&mut self) -> Option<T> {
 		self.stack.pop()
 	}
 
-	/// Remove and Return top element. Does not check for emptyness.
+	/// Remove and return top element. Does not check for emptiness.
 	/// If this is called on a zero length stack, bad things will happen.
 	/// Do not call this method unless you can prove the stack has length.
 	#[inline]
@@ -132,15 +96,6 @@ impl<T> StackWithLimit<T> {
 	/// `bstack.nth_from_top(0)` gets the top of the stack
 	///
 	/// `bstack.nth_from_top(1)` gets the item just below the stack
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// bstack.push(4);
-	/// assert_eq!(bstack.nth_from_top(0), Some(&4));
-	/// assert_eq!(bstack.nth_from_top(1), None);
-	/// ```
 	pub fn nth_from_top(&self, depth: usize) -> Option<&T> {
 		// Be cognizant of integer underflow and overflow here. Both are possible in this situation.
 		// len() is unsigned, so if len() == 0, subtraction is a problem
@@ -176,54 +131,12 @@ impl<T> StackWithLimit<T> {
 	/// # Panics
 	///
 	/// Panics if `a` or `b` are out of bound.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// bstack.push(1);
-	/// bstack.push(2);
-	/// assert_eq!(bstack.top(), Some(&2));
-	/// bstack.swap(0, 1);
-	/// assert_eq!(bstack.top(), Some(&1));
-	/// ```
 	#[inline]
 	pub fn swap(&mut self, a: usize, b: usize) {
 		self.stack.swap(a, b)
 	}
 
-	/// Removes an element from the stack and returns it.
-	///
-	/// The removed element is replaced by the element at the top of the stack.
-	///
-	/// # Panics
-	///
-	/// Panics if `index` is out of bounds.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// bstack.push(1);
-	/// bstack.push(2);
-	/// assert_eq!(bstack.top(), Some(&2));
-	/// assert_eq!(bstack.swap_remove(0), 1);
-	/// assert_eq!(bstack.top(), Some(&2));
-	/// ```
-	pub fn swap_remove(&mut self, index: usize) -> T {
-		self.stack.swap_remove(index)
-	}
-
 	/// Get a reference to the top of the stack, or `None` if the stack is empty.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// assert_eq!(bstack.top(), None);
-	/// bstack.push(2);
-	/// assert_eq!(bstack.top(), Some(&2));
-	/// ```
 	pub fn top(&self) -> Option<&T> {
 		self.stack.last()
 	}
@@ -241,54 +154,16 @@ impl<T> StackWithLimit<T> {
 	}
 
 	/// Get number of items in a stack.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// assert_eq!(bstack.len(), 0);
-	/// bstack.push(1);
-	/// bstack.push(2);
-	/// assert_eq!(bstack.len(), 2);
-	/// ```
 	#[inline]
 	pub fn len(&self) -> usize {
 		self.stack.len()
 	}
 
 	/// Check whether the stack is empty.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::{StackWithLimit, StackSize};
-	/// let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
-	/// assert_eq!(bstack.is_empty(), true);
-	/// bstack.push(1);
-	/// assert_eq!(bstack.is_empty(), false);
-	/// ```
 	pub fn is_empty(&self) -> bool {
 		self.stack.is_empty()
 	}
 }
-
-// Why introduce the extra complexity of StackSizeLimit, StackSizeInitial, and StackSize?
-// We want to make the user to do the correct thing using the type checker.
-// Check out the excellent Rust API Guidelines (linked below) for suggestions
-// about type safety in rust.
-//
-// By introducing the new typed arguments, we turn:
-//
-// ```
-// pub fn new(initial_size: usize, limit: usize) -> StackWithLimit<T> { ... }
-// ```
-//
-// into:
-//
-// ```
-// pub fn new(initial_size: StackSizeInitial<T>, limit: StackSizeLimit<T>) -> StackWithLimit<T> { ... }
-// ```
-//
-// https://rust-lang-nursery.github.io/api-guidelines/type-safety.html#c-custom-type
 
 /// Type for communicating the size of some contigous container.
 /// Used for constructing both [`StackSizeLimit`] and [`StackSizeInitial`].
@@ -314,13 +189,6 @@ impl<T> Copy for StackSize<T> {}
 
 impl<T> StackSize<T> {
 	/// Create StackSize based on number of elements.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::StackSize;
-	/// let ss = StackSize::<(u8, u8)>::from_element_count(10);
-	/// assert_eq!(ss.element_count(), 10);
-	/// ```
 	pub fn from_element_count(num_elements: usize) -> StackSize<T> {
 		StackSize {
 			num_elements,
@@ -328,51 +196,12 @@ impl<T> StackSize<T> {
 		}
 	}
 
-	/// Compute StackSize based on allowable memory.
-	///
-	/// ```
-	/// # extern crate wasmi;
-	/// # use wasmi::StackSize;
-	/// let ss = StackSize::<(u8, u8)>::from_byte_count(10);
-	/// assert_eq!(ss.element_count(), 10 / 2);
-	/// ```
-	///
-	/// # Errors
-	///
-	/// In debug mode, panics if size of `T` is 0.
-	pub fn from_byte_count(num_bytes: usize) -> StackSize<T> {
-		// This debug_assert should catch logical errors.
-		debug_assert!(::core::mem::size_of::<T>() != 0, "That doesn't make sense.");
-
-		// In case a zero sized T still makes it into prod. We assume unlimited stack
-		// size instead of panicking.
-		let element_count = if ::core::mem::size_of::<T>() != 0 {
-			num_bytes / ::core::mem::size_of::<T>()
-		} else {
-			usize::MAX // Semi-relevant fun fact: Vec::<()>::new().capacity() == usize::MAX
-		};
-
-		StackSize::from_element_count(element_count)
-	}
-
 	/// Return number the of elements this StackSize indicates.
-	///
-	/// ```
-	/// # use wasmi::StackSize;
-	/// let ss = StackSize::<(u8, u8)>::from_element_count(10);
-	/// assert_eq!(ss.element_count(), 10);
-	/// ```
-	///
 	pub fn element_count(&self) -> usize {
 		self.num_elements
 	}
 
 	/// Create StackSizeLimit out of self
-	///
-	/// ```
-	/// # use wasmi::{StackSize, StackSizeLimit, RuntimeValue};
-	/// let values_limit: StackSizeLimit<RuntimeValue> = StackSize::from_element_count(1024).into_limit();
-	/// ```
 	pub fn into_limit(self) -> StackSizeLimit<T> {
 		StackSizeLimit(self)
 	}
@@ -380,11 +209,6 @@ impl<T> StackSize<T> {
 	/// Create StackSizeLimit out of self
 	pub fn into_initial(self) -> StackSizeInitial<T> {
 		StackSizeInitial(self)
-	}
-
-	/// Create StackSizeLimit with no upper bound.
-	pub fn unlimited() -> StackSizeLimit<T> {
-		StackSize::from_element_count(usize::MAX).into_limit()
 	}
 }
 
@@ -491,5 +315,62 @@ mod test {
 		bstack.push(0).unwrap();
 		assert_eq!(unsafe { bstack.pop_unchecked() }, 0);
 		assert_eq!(unsafe { bstack.pop_unchecked() }, 8);
+	}
+
+	#[test]
+	fn misc() {
+		// These used to be doctests. They were moved here because StackWithLimit no longer
+		// public. Doctests can't test internal APIs.
+
+		StackWithLimit::<usize>::new(
+			StackSize::from_element_count(1024).into_initial(),
+			StackSize::from_element_count(2048).into_limit(),
+		);
+
+		let bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		bstack.push(2).unwrap();
+		assert_eq!(bstack.pop(), Some(2));
+		assert_eq!(bstack.len(), 0);
+		assert_eq!(bstack.pop(), None);
+
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		bstack.push(4).unwrap();
+		assert_eq!(bstack.nth_from_top(0), Some(&4));
+		assert_eq!(bstack.nth_from_top(1), None);
+
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		bstack.push(1).unwrap();
+		bstack.push(2).unwrap();
+		assert_eq!(bstack.top(), Some(&2));
+		bstack.swap(0, 1);
+		assert_eq!(bstack.top(), Some(&1));
+
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		bstack.push(1).unwrap();
+		bstack.push(2).unwrap();
+		assert_eq!(bstack.top(), Some(&2));
+		bstack.swap(0, 1);
+		assert_eq!(bstack.top(), Some(&1));
+
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		assert_eq!(bstack.len(), 0);
+		bstack.push(1).unwrap();
+		bstack.push(2).unwrap();
+		assert_eq!(bstack.len(), 2);
+
+		let mut bstack = StackWithLimit::<i32>::with_size(StackSize::from_element_count(2));
+		assert_eq!(bstack.is_empty(), true);
+		bstack.push(1).unwrap();
+		assert_eq!(bstack.is_empty(), false);
+
+		let ss = StackSize::<(u8, u8)>::from_element_count(10);
+		assert_eq!(ss.element_count(), 10);
+
+		let ss = StackSize::<(u8, u8)>::from_element_count(10);
+		assert_eq!(ss.element_count(), 10);
+
+		let values_limit: StackSizeLimit<usize> = StackSize::from_element_count(1024).into_limit();
 	}
 }

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -91,7 +91,6 @@ impl<T> StackWithLimit<T> {
 		ret
 	}
 
-	#[inline]
 	pub(crate) fn pop(&mut self) -> Option<T> {
 		debug_assert!(
 			self.stack.len() <= self.limit,

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -116,6 +116,16 @@ impl<T> StackWithLimit<T> {
 		self.stack.get(index)
 	}
 
+	/// mutable version of get_relative_to_top
+	///
+	/// `bstack.get_relative_to_top(0)` gets the top of the stack
+	///
+	/// `bstack.get_relative_to_top(1)` gets the item just below the stack
+	pub(crate) fn get_relative_to_top_mut(&mut self, depth: usize) -> Option<&mut T> {
+		let index = self.stack.len().checked_sub(1)?.checked_sub(depth)?;
+		self.stack.get_mut(index)
+	}
+
 	pub(crate) fn top(&self) -> Option<&T> {
 		self.stack.last()
 	}

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -86,13 +86,7 @@ impl<T> StackWithLimit<T> {
 			}
 			// grows exponentially, just like Vec normally does
 			// https://doc.rust-lang.org/1.26.0/src/alloc/raw_vec.rs.html#462
-			let desired_len = self
-				.stack
-				.len()
-				.checked_mul(2)
-				.unwrap_or(usize::MAX)
-				.min(self.limit)
-				.max(1);
+			let desired_len = self.stack.len().saturating_mul(2).min(self.limit).max(1);
 			let additional_len = desired_len - self.stack.len();
 			self.stack.reserve_exact(additional_len);
 		}
@@ -231,6 +225,8 @@ impl<T> StackWithLimit<T> {
 pub struct StackSize<T> {
 	num_elements: usize,
 	// PhantomData is a zero-sized type for keeping track of T without rustc complaining.
+	// *const T or &'a T is recommended when T is not actually owned.
+	// https://doc.rust-lang.org/std/marker/struct.PhantomData.html#ownership-and-the-drop-check
 	phantom: PhantomData<*const T>,
 }
 

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -78,7 +78,6 @@ impl<T> StackWithLimit<T> {
 	///
 	/// Returns Err(StackOverflow) if stack is already full.
 	pub(crate) fn push(&mut self, value: T) -> Result<(), StackOverflow> {
-		println!("limit {}", self.limit);
 		let ret = if self.stack.len() < self.limit {
 			self.stack.push(value);
 			Ok(())
@@ -92,6 +91,7 @@ impl<T> StackWithLimit<T> {
 		ret
 	}
 
+	#[inline]
 	pub(crate) fn pop(&mut self) -> Option<T> {
 		debug_assert!(
 			self.stack.len() <= self.limit,

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -1,88 +1,248 @@
-#[allow(unused_imports)]
-use alloc::prelude::*;
+mod ol {
+	#[allow(unused_imports)]
+	use alloc::prelude::*;
 
-#[cfg(feature = "std")]
-use std::error;
-use core::fmt;
+	use core::fmt;
+	#[cfg(feature = "std")]
+	use std::error;
 
-#[derive(Debug)]
-pub struct Error(String);
+	#[derive(Debug)]
+	pub struct Error(String);
 
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{}", self.0)
+	impl fmt::Display for Error {
+		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+			write!(f, "{}", self.0)
+		}
+	}
+
+	#[cfg(feature = "std")]
+	impl error::Error for Error {
+		fn description(&self) -> &str {
+			&self.0
+		}
+	}
+
+	/// Stack with limit.
+	#[derive(Debug)]
+	pub struct StackWithLimit<T>
+	where
+		T: Clone,
+	{
+		/// Stack values.
+		values: Vec<T>,
+		/// Stack limit (maximal stack len).
+		limit: usize,
+	}
+
+	impl<T> StackWithLimit<T>
+	where
+		T: Clone,
+	{
+		pub fn with_limit(limit: usize) -> Self {
+			StackWithLimit {
+				values: Vec::new(),
+				limit: limit,
+			}
+		}
+
+		pub fn is_empty(&self) -> bool {
+			self.values.is_empty()
+		}
+
+		pub fn len(&self) -> usize {
+			self.values.len()
+		}
+
+		pub fn top(&self) -> Result<&T, Error> {
+			self.values
+				.last()
+				.ok_or_else(|| Error("non-empty stack expected".into()))
+		}
+
+		pub fn top_mut(&mut self) -> Result<&mut T, Error> {
+			self.values
+				.last_mut()
+				.ok_or_else(|| Error("non-empty stack expected".into()))
+		}
+
+		// Not the same as vector.get
+		pub fn get(&self, index: usize) -> Result<&T, Error> {
+			if index >= self.values.len() {
+				return Err(Error(format!(
+					"trying to get value at position {} on stack of size {}",
+					index,
+					self.values.len()
+				)));
+			}
+
+			Ok(self
+				.values
+				.get(self.values.len() - 1 - index)
+				.expect("checked couple of lines above"))
+		}
+
+		pub fn push(&mut self, value: T) -> Result<(), Error> {
+			if self.values.len() >= self.limit {
+				return Err(Error(format!("exceeded stack limit {}", self.limit)));
+			}
+
+			self.values.push(value);
+			Ok(())
+		}
+
+		pub fn pop(&mut self) -> Result<T, Error> {
+			self.values
+				.pop()
+				.ok_or_else(|| Error("non-empty stack expected".into()))
+		}
+
+		pub fn resize(&mut self, new_size: usize, dummy: T) {
+			debug_assert!(new_size <= self.values.len());
+			self.values.resize(new_size, dummy);
+		}
 	}
 }
 
-#[cfg(feature = "std")]
-impl error::Error for Error {
-	fn description(&self) -> &str {
-		&self.0
-	}
-}
+#[derive(Copy, Clone, Debug)]
+pub struct StackOverflow;
 
-/// Stack with limit.
+// impl From<StackOverflow> for TrapKind {
+// 	fn from(_: StackOverflow) -> TrapKind {
+// 		TrapKind::StackOverflow
+// 	}
+// }
+
+// impl From<StackOverflow> for Trap {
+// 	fn from(_: StackOverflow) -> Trap {
+// 		Trap::new(TrapKind::StackOverflow)
+// 	}
+// }
+
+// TODO: impl constructors
+struct Limit(usize);
+struct InitialSize(usize);
+
+/// Pre-allocated, growable stack with upper bound on size.
+///
+/// StackWithLimit is guaranteed never to grow larger than a set limit.
+/// When limit is reached attempting to push to the stack will return
+/// `Err(StackOverflow)`.
+///
+/// In addition to the limit. Initial stack size is configurable.
+/// `StackWithLimit` will start out with initial size, but grow if necessary.
 #[derive(Debug)]
-pub struct StackWithLimit<T> where T: Clone {
-	/// Stack values.
-	values: Vec<T>,
-	/// Stack limit (maximal stack len).
+pub struct StackWithLimit<T> {
+	stack: Vec<T>,
 	limit: usize,
 }
 
-impl<T> StackWithLimit<T> where T: Clone {
-	pub fn with_limit(limit: usize) -> Self {
+impl<T> StackWithLimit<T> {
+	/// Create an new StackWithLimit with `limit` max size and `initial_size` elements pre-allocated
+	/// `initial_size` should not be larger than `limit`
+	pub fn new(initial_size: usize, limit: usize) -> StackWithLimit<T> {
+		debug_assert!(
+			limit >= initial_size,
+			"initial_size should not be larger than StackWithLimit limit"
+		);
+		use std::cmp::min;
 		StackWithLimit {
-			values: Vec::new(),
-			limit: limit
+			stack: Vec::with_capacity(initial_size),
+			limit: min(initial_size, limit),
 		}
 	}
 
-	pub fn is_empty(&self) -> bool {
-		self.values.is_empty()
-	}
-
-	pub fn len(&self) -> usize {
-		self.values.len()
-	}
-
-	pub fn top(&self) -> Result<&T, Error> {
-		self.values
-			.last()
-			.ok_or_else(|| Error("non-empty stack expected".into()))
-	}
-
-	pub fn top_mut(&mut self) -> Result<&mut T, Error> {
-		self.values
-			.last_mut()
-			.ok_or_else(|| Error("non-empty stack expected".into()))
-	}
-
-	pub fn get(&self, index: usize) -> Result<&T, Error> {
-		if index >= self.values.len() {
-			return Err(Error(format!("trying to get value at position {} on stack of size {}", index, self.values.len())));
+	/// Create an new StackWithLimit with `limit` max size and `limit` elements pre-allocated
+	pub fn with_limit(limit: usize) -> StackWithLimit<T> {
+		StackWithLimit {
+			stack: Vec::with_capacity(limit),
+			limit: limit,
 		}
-
-		Ok(self.values.get(self.values.len() - 1 - index).expect("checked couple of lines above"))
 	}
 
-	pub fn push(&mut self, value: T) -> Result<(), Error> {
-		if self.values.len() >= self.limit {
-			return Err(Error(format!("exceeded stack limit {}", self.limit)));
+	/// Attempt to push value onto stack.
+	///
+	/// # Errors
+	///
+	/// Returns Err(StackOverflow) if stack is already full.
+	pub(crate) fn push(&mut self, value: T) -> Result<(), StackOverflow> {
+		debug_assert!(
+			self.stack.len() <= self.limit,
+			"Stack length should never be larger than stack limit."
+		);
+		if self.stack.len() < self.limit {
+			self.stack.push(value);
+			Ok(())
+		} else {
+			Err(StackOverflow)
 		}
-
-		self.values.push(value);
-		Ok(())
 	}
 
-	pub fn pop(&mut self) -> Result<T, Error> {
-		self.values
-			.pop()
-			.ok_or_else(|| Error("non-empty stack expected".into()))
+	pub(crate) fn pop(&mut self) -> Option<T> {
+		debug_assert!(
+			self.stack.len() <= self.limit,
+			"Stack length should never be larger than stack limit."
+		);
+		self.stack.pop()
 	}
 
-	pub fn resize(&mut self, new_size: usize, dummy: T) {
-		debug_assert!(new_size <= self.values.len());
-		self.values.resize(new_size, dummy);
+	/// Return optional reference to item in stack
+	///
+	/// `bstack.get_relative_to_top(0)` gets the top of the stack
+	///
+	/// `bstack.get_relative_to_top(1)` gets the item just below the stack
+	///
+
+	pub(crate) fn get_relative_to_top(&self, depth: usize) -> Option<&T> {
+		let offset = depth + 1;
+		if self.stack.len() < offset {
+			None
+		} else {
+			// We should be cognizant of integer underflow here.
+			// If offset > len(), (len() - offset) will underflow.
+			// In debug builds, underflow panics, but in release mode, underflow is not checked.
+			self.stack.get(self.stack.len() - offset)
+		}
+	}
+
+	pub(crate) fn top(&self) -> Option<&T> {
+		self.stack.last()
+	}
+
+	pub(crate) fn top_mut(&mut self) -> Option<&mut T> {
+		self.stack.last_mut()
+	}
+
+	pub(crate) fn truncate(&mut self, new_size: usize) {
+		self.stack.truncate(new_size)
+	}
+
+	pub(crate) fn len(&self) -> usize {
+		self.stack.len()
+	}
+
+	pub(crate) fn is_empty(&self) -> bool {
+		self.stack.is_empty()
+	}
+
+	// /// return a new empty StackWithLimit with limit equal to the amount of room
+	// /// this stack has available
+	// pub fn spare(&self) -> StackWithLimit<T> {
+	//     // This will be used to allocate new stacks when calling into other wasm modules
+	//     StackWithLimit::new(0, self.limit - self.len())
+	// }
+}
+
+#[cfg(test)]
+mod test {
+	use super::StackWithLimit;
+
+	fn get_relative_to_top() {
+		let mut bstack = StackWithLimit::<i32>::with_limit(2);
+		bstack.push(1).unwrap();
+		bstack.push(2).unwrap();
+		bstack.push(3).unwrap_err();
+		assert_eq!(bstack.get_relative_to_top(0), Some(&2));
+		assert_eq!(bstack.get_relative_to_top(1), Some(&1));
+		assert_eq!(bstack.get_relative_to_top(2), None);
 	}
 }

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -156,9 +156,14 @@ impl<T> StackWithLimit<T> {
 	/// Return mutable reference to item `depth` distance away from top
 	///
 	/// Does not check whether depth is in range.
-	pub fn nth_from_top_mut_unchecked(&mut self, depth: usize) -> &mut T {
-		let offset = self.stack.len() - 1 - depth;
-		&mut self.stack[offset]
+	///
+	/// # Panics
+	///
+	/// Panics if depth is out of range.
+	pub fn nth_from_top_mut(&mut self, depth: usize) -> &mut T {
+		assert!(depth + 1 <= self.stack.len());
+		let index = self.stack.len() - 1 - depth;
+		unsafe { self.stack.get_unchecked_mut(index) }
 	}
 
 	/// Swaps two elements in the stack.
@@ -179,7 +184,7 @@ impl<T> StackWithLimit<T> {
 	/// bstack.push(1);
 	/// bstack.push(2);
 	/// assert_eq!(bstack.top(), Some(&2));
-	/// stack.swap(0, 1);
+	/// bstack.swap(0, 1);
 	/// assert_eq!(bstack.top(), Some(&1));
 	/// ```
 	#[inline]
@@ -202,7 +207,7 @@ impl<T> StackWithLimit<T> {
 	/// bstack.push(1);
 	/// bstack.push(2);
 	/// assert_eq!(bstack.top(), Some(&2));
-	/// assert_eq!(stack.swap_remove(0), 1);
+	/// assert_eq!(bstack.swap_remove(0), 1);
 	/// assert_eq!(bstack.top(), Some(&2));
 	/// ```
 	pub fn swap_remove(&mut self, index: usize) -> T {

--- a/src/func.rs
+++ b/src/func.rs
@@ -138,7 +138,7 @@ impl FuncInstance {
 		check_function_args(func.signature(), &args)?;
 		match *func.as_internal() {
 			FuncInstanceInternal::Internal { .. } => {
-				interpreter.start_execution(externals, func, args, func.signature().return_type())
+				interpreter.start_execution(externals, func, args)
 			}
 			FuncInstanceInternal::Host {
 				ref host_func_index, ..
@@ -268,14 +268,13 @@ impl FuncInvocation {
 		externals: &'externals mut E,
 		func: &FuncRef,
 		args: &[RuntimeValue],
-		return_type: Option<ValueType>,
 	) -> Result<Option<RuntimeValue>, ResumableError> {
 		match self.kind {
 			FuncInvocationKind::Internal(ref mut interpreter) => {
 				if interpreter.state() != &InterpreterState::Initialized {
 					return Err(ResumableError::AlreadyStarted);
 				}
-				Ok(interpreter.start_execution(externals, func, args, return_type)?)
+				Ok(interpreter.start_execution(externals, func, args)?)
 			}
 			FuncInvocationKind::Host {
 				ref mut finished,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,8 +404,7 @@ pub use self::module::{ModuleInstance, ModuleRef, ExternVal, NotStartedModuleRef
 pub use self::global::{GlobalInstance, GlobalRef};
 pub use self::func::{FuncInstance, FuncRef, FuncInvocation, ResumableError};
 pub use self::types::{Signature, ValueType, GlobalDescriptor, TableDescriptor, MemoryDescriptor};
-pub use self::common::stack::{StackWithLimit, StackSize, StackSizeLimit, StackSizeInitial};
-pub use self::runner::Interpreter;
+pub use self::runner::{Interpreter, InterpreterStackConfig};
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,6 +405,7 @@ pub use self::global::{GlobalInstance, GlobalRef};
 pub use self::func::{FuncInstance, FuncRef, FuncInvocation, ResumableError};
 pub use self::types::{Signature, ValueType, GlobalDescriptor, TableDescriptor, MemoryDescriptor};
 pub use self::common::stack::{StackWithLimit, StackSize, StackSizeLimit, StackSizeInitial};
+pub use self::runner::Interpreter;
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,7 @@ pub use self::module::{ModuleInstance, ModuleRef, ExternVal, NotStartedModuleRef
 pub use self::global::{GlobalInstance, GlobalRef};
 pub use self::func::{FuncInstance, FuncRef, FuncInvocation, ResumableError};
 pub use self::types::{Signature, ValueType, GlobalDescriptor, TableDescriptor, MemoryDescriptor};
+pub use self::common::stack::{StackWithLimit, StackSize, StackSizeLimit, StackSizeInitial};
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/module.rs
+++ b/src/module.rs
@@ -21,6 +21,7 @@ use host::Externals;
 use common::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 use types::{GlobalDescriptor, TableDescriptor, MemoryDescriptor};
 use memory_units::Pages;
+use runner::Interpreter;
 
 /// Reference to a [`ModuleInstance`].
 ///
@@ -629,7 +630,7 @@ impl ModuleInstance {
 			}
 		};
 
-		FuncInstance::invoke(&func_instance, args, externals)
+		Interpreter::new().invoke(&func_instance, args, externals)
 			.map_err(|t| Error::Trap(t))
 	}
 
@@ -688,7 +689,7 @@ impl<'a> NotStartedModuleRef<'a> {
 			let start_func = self.instance.func_by_index(start_fn_idx).expect(
 				"Due to validation start function should exists",
 			);
-			FuncInstance::invoke(&start_func, &[], state)?;
+			Interpreter::new().invoke(&start_func, &[], state)?;
 		}
 		Ok(self.instance)
 	}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1360,7 +1360,9 @@ impl ValueStack {
 
 	#[inline]
 	fn top(&self) -> &RuntimeValueInternal {
-		self.0.top().expect("pre-validated")
+		self.0
+			.top()
+			.expect("The stack is empty, this should never be possible due to the validation step")
 	}
 
 	#[inline]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1321,7 +1321,7 @@ impl ValueStack {
 
 	#[inline]
 	fn pop(&mut self) -> RuntimeValueInternal {
-		self.0.pop().expect("pre-validated")
+		unsafe { self.0.pop_unchecked() }
 	}
 
 	#[inline]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -216,6 +216,7 @@ impl Interpreter {
 		self.state = InterpreterState::Initialized;
 	}
 
+	/// Get current state of interpreter.
 	pub fn state(&self) -> &InterpreterState {
 		&self.state
 	}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -204,10 +204,7 @@ impl Interpreter {
 		externals: &mut E,
 		func: &FuncRef,
 		args: &[RuntimeValue],
-		return_type: Option<ValueType>,
 	) -> Result<Option<RuntimeValue>, Trap> {
-		debug_assert_eq!(func.signature().return_type(), return_type);
-
 		// Ensure that the VM has not been executed. This is checked in `FuncInvocation::start_execution`.
 		assert!(self.state == InterpreterState::Initialized);
 
@@ -224,7 +221,10 @@ impl Interpreter {
 		self.state = InterpreterState::Started;
 		self.run_interpreter_loop(externals)?;
 
-		let opt_return_value = return_type.map(|vt| self.value_stack.pop().with_type(vt));
+		let opt_return_value = func
+			.signature()
+			.return_type()
+			.map(|vt| self.value_stack.pop().with_type(vt));
 
 		// Ensure that stack is empty after the execution. This is guaranteed by the validation properties.
 		assert!(self.value_stack.len() == 0);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -216,7 +216,7 @@ impl Interpreter {
 		self.state = InterpreterState::Initialized;
 	}
 
-	pub(crate) fn state(&self) -> &InterpreterState {
+	pub fn state(&self) -> &InterpreterState {
 		&self.state
 	}
 
@@ -1228,7 +1228,7 @@ pub struct FunctionContext {
 }
 
 impl FunctionContext {
-	pub(crate) fn new(function: FuncRef) -> Self {
+	pub fn new(function: FuncRef) -> Self {
 		let module = match function.as_internal() {
 			FuncInstanceInternal::Internal { module, .. } => module.upgrade().expect("module deallocated"),
 			FuncInstanceInternal::Host { .. } => panic!("Host functions can't be called as internally defined functions; Thus FunctionContext can be created only with internally defined functions; qed"),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,6 @@
 #[allow(unused_imports)]
 use alloc::prelude::*;
-use common::stack::{StackOverflow, StackWithLimit};
+use common::stack::{StackOverflow, StackSize, StackWithLimit};
 use common::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 use core::fmt;
 use core::ops;
@@ -172,10 +172,18 @@ pub struct Interpreter {
 }
 
 impl Interpreter {
+	/// Initialize an interpreter with defaults stack sizes.
+	pub fn new() -> Interpreter {
+		Interpreter::with_stacks(
+			StackWithLimit::with_size(StackSize::from_element_count(DEFAULT_VALUE_STACK_LIMIT)),
+			StackWithLimit::with_size(StackSize::from_element_count(DEFAULT_CALL_STACK_LIMIT)),
+		)
+	}
+
 	/// Initialize an interpreter that will use `value_stack` and `call_stack`.
 	///
 	/// `value_stack` `call_stack` determine the allowed stack size during later executions.
-	pub fn new(
+	pub fn with_stacks(
 		value_stack: StackWithLimit<RuntimeValueInternal>,
 		call_stack: StackWithLimit<FunctionContext>,
 	) -> Interpreter {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -209,10 +209,8 @@ impl Interpreter {
 		}
 	}
 
-	// Todo, use types to prevent user from calling start_execution on an interpreter not in Initialized
-	// state.
-	/// Wipe all data in this interpreter, so it can be safely reused.
-	pub fn reset(&mut self) {
+	/// Wipe all data in this interpreter so it can be safely reused.
+	fn reset(&mut self) {
 		self.value_stack.truncate(0);
 		self.call_stack.truncate(0);
 		self.state = InterpreterState::Initialized;
@@ -252,8 +250,7 @@ impl Interpreter {
 		args: &[RuntimeValue],
 		externals: &mut E,
 	) -> Result<Option<RuntimeValue>, Trap> {
-		// Ensure that the VM has not been executed. This is checked in `FuncInvocation::start_execution`.
-		assert!(self.state == InterpreterState::Initialized);
+		self.reset();
 
 		// Add initial args to value stack
 		for arg in args {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -209,7 +209,7 @@ impl Interpreter {
 		}
 	}
 
-	// Todo, use types to prevent user from calling start_execution on an inretpreter not in Initialized
+	// Todo, use types to prevent user from calling start_execution on an interpreter not in Initialized
 	// state.
 	/// Wipe all data in this interpreter, so it can be safely reused.
 	pub fn reset(&mut self) {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -183,6 +183,21 @@ impl Interpreter {
 	/// Initialize an interpreter that will use `value_stack` and `call_stack`.
 	///
 	/// `value_stack` `call_stack` determine the allowed stack size during later executions.
+	///
+	/// ```
+	/// # extern crate wasmi;
+	/// use wasmi::{Interpreter, StackWithLimit, StackSize};
+	/// let interpreter = Interpreter::with_stacks(
+	///     StackWithLimit::with_size(StackSize::from_byte_count(8192)),
+	///     StackWithLimit::with_size(StackSize::from_element_count(2048)),
+	/// );
+	/// # let value_stack_size = StackSize::from_byte_count(8192);
+	/// # let value_stack = StackWithLimit::with_size(value_stack_size);
+	/// # let interpreter = Interpreter::with_stacks(
+	/// #     value_stack,
+	/// #     StackWithLimit::with_size(StackSize::from_element_count(2048)),
+	/// # );
+	/// ```
 	pub fn with_stacks(
 		value_stack: StackWithLimit<RuntimeValueInternal>,
 		call_stack: StackWithLimit<FunctionContext>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1368,7 +1368,7 @@ impl ValueStack {
 
 	#[inline]
 	fn pick_mut(&mut self, depth: usize) -> &mut RuntimeValueInternal {
-		self.0.nth_from_top_mut_unchecked(depth - 1)
+		self.0.nth_from_top_mut(depth - 1)
 	}
 
 	#[inline]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1365,7 +1365,7 @@ impl ValueStack {
 
 	#[inline]
 	fn pick_mut(&mut self, depth: usize) -> &mut RuntimeValueInternal {
-		self.0.get_relative_to_top_mut_unchecked(depth - 1)
+		self.0.nth_from_top_mut_unchecked(depth - 1)
 	}
 
 	#[inline]

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -266,7 +266,7 @@ fn resume_call_host_func() {
 	let func_instance = export.as_func().unwrap();
 	let return_type = func_instance.signature().return_type();
 
-	let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[]).unwrap();
+	let mut invocation = FuncInstance::invoke_resumable(&func_instance);
 	let result = invocation.start_execution(&mut env, func_instance, &[], return_type);
 	match result {
 		Err(ResumableError::Trap(_)) => {}

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -267,7 +267,7 @@ fn resume_call_host_func() {
 	let return_type = func_instance.signature().return_type();
 
 	let mut invocation = FuncInstance::invoke_resumable(&func_instance);
-	let result = invocation.start_execution(&mut env, func_instance, &[], return_type);
+	let result = invocation.start_execution(&mut env, func_instance, &[]);
 	match result {
 		Err(ResumableError::Trap(_)) => {}
 		_ => panic!(),

--- a/src/validation/func.rs
+++ b/src/validation/func.rs
@@ -1487,7 +1487,7 @@ fn top_label(frame_stack: &StackWithLimit<BlockFrame>) -> &BlockFrame {
 
 fn require_label(depth: u32, frame_stack: &StackWithLimit<BlockFrame>) -> Result<&BlockFrame, Error> {
 	frame_stack
-		.get_relative_to_top(depth as usize)
+		.nth_from_top(depth as usize)
 		.ok_or_else(|| Error("non-empty stack expected".into()))
 }
 

--- a/src/validation/func.rs
+++ b/src/validation/func.rs
@@ -1377,7 +1377,9 @@ fn make_top_frame_polymorphic(
 	debug_assert!(frame.value_stack_len <= value_stack.len());
 	while value_stack.len() > frame.value_stack_len {
 		value_stack.pop().expect(
-			"frame.value_stack_len >= 0, value_stack.len() > frame.value_stack_len :. value_stack.len() > 0; qed",
+			"The value stack is empty, this should never happen since \
+			 frame.value_stack_len >= 0 and value_stack.len() > frame.value_stack_len, \
+			 so therefore value_stack.len() must be more than 0",
 		);
 	}
 
@@ -1402,7 +1404,7 @@ fn pop_value(
 	let actual_value = if stack_is_empty && is_stack_polymorphic {
 		StackValueType::Any
 	} else {
-		let value_stack_min = frame_stack.top().expect("at least 1 topmost block").value_stack_len;
+		let value_stack_min = frame_stack.top().expect("Expected a non-empty frame stack.").value_stack_len;
 		if value_stack.len() <= value_stack_min {
 			return Err(Error("Trying to access parent frame stack values.".into()));
 		}

--- a/src/validation/func.rs
+++ b/src/validation/func.rs
@@ -8,7 +8,7 @@ use validation::context::ModuleContext;
 use validation::util::Locals;
 use validation::Error;
 
-use common::stack::{StackOverflow, StackWithLimit};
+use common::stack::{StackSize, StackWithLimit};
 use isa;
 
 /// Maximum number of entries in value stack per function.
@@ -1348,8 +1348,8 @@ impl<'a> FunctionValidationContext<'a> {
 			module: module,
 			position: 0,
 			locals: locals,
-			value_stack: StackWithLimit::with_limit(value_stack_limit),
-			frame_stack: StackWithLimit::with_limit(frame_stack_limit),
+			value_stack: StackWithLimit::with_size(StackSize::from_element_count(value_stack_limit)),
+			frame_stack: StackWithLimit::with_size(StackSize::from_element_count(frame_stack_limit)),
 			return_type: return_type,
 			sink: Sink::with_instruction_capacity(size_estimate),
 		}

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,23 +1,23 @@
 #[allow(unused_imports)]
 use alloc::prelude::*;
+use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
-use core::fmt;
 
-#[cfg(feature = "std")]
-use std::collections::HashSet;
 #[cfg(not(feature = "std"))]
 use hashmap_core::HashSet;
+#[cfg(feature = "std")]
+use std::collections::HashSet;
 
-use parity_wasm::elements::{
-	BlockType, External, GlobalEntry, GlobalType, Internal, MemoryType, Module, Instruction,
-	ResizableLimits, TableType, ValueType, InitExpr, Type,
-};
-use common::stack;
 use self::context::ModuleContextBuilder;
 use self::func::FunctionReader;
-use memory_units::Pages;
+use common::stack;
 use isa;
+use memory_units::Pages;
+use parity_wasm::elements::{
+	BlockType, External, GlobalEntry, GlobalType, InitExpr, Instruction, Internal, MemoryType, Module, ResizableLimits,
+	TableType, Type, ValueType,
+};
 
 mod context;
 mod func;
@@ -42,9 +42,9 @@ impl error::Error for Error {
 	}
 }
 
-impl From<stack::Error> for Error {
-	fn from(e: stack::Error) -> Error {
-		Error(format!("Stack: {}", e))
+impl From<stack::StackOverflow> for Error {
+	fn from(_: stack::StackOverflow) -> Error {
+		Error("Stack: exeeded stack limit".into())
 	}
 }
 
@@ -158,7 +158,8 @@ pub fn deny_floating_point(module: &Module) -> Result<(), Error> {
 			if let Some(typ) = types.get(sig.type_ref() as usize) {
 				match *typ {
 					Type::Function(ref func) => {
-						if func.params()
+						if func
+							.params()
 							.iter()
 							.chain(func.return_type().as_ref())
 							.any(|&typ| typ == ValueType::F32 || typ == ValueType::F64)
@@ -189,16 +190,11 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 					.map(|&Type::Function(ref ty)| ty)
 					.cloned()
 					.collect()
-			})
-			.unwrap_or_default(),
+			}).unwrap_or_default(),
 	);
 
 	// Fill elements with imported values.
-	for import_entry in module
-		.import_section()
-		.map(|i| i.entries())
-		.unwrap_or_default()
-	{
+	for import_entry in module.import_section().map(|i| i.entries()).unwrap_or_default() {
 		match *import_entry.external() {
 			External::Function(idx) => context_builder.push_func_type_index(idx),
 			External::Table(ref table) => context_builder.push_table(table.clone()),
@@ -237,41 +233,32 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 
 	let context = context_builder.build();
 
-	let function_section_len = module
-		.function_section()
-		.map(|s| s.entries().len())
-		.unwrap_or(0);
+	let function_section_len = module.function_section().map(|s| s.entries().len()).unwrap_or(0);
 	let code_section_len = module.code_section().map(|s| s.bodies().len()).unwrap_or(0);
 	if function_section_len != code_section_len {
 		return Err(Error(format!(
 			"length of function section is {}, while len of code section is {}",
-			function_section_len,
-			code_section_len
+			function_section_len, code_section_len
 		)));
 	}
 
 	// validate every function body in user modules
 	if function_section_len != 0 {
 		// tests use invalid code
-		let function_section = module.function_section().expect(
-			"function_section_len != 0; qed",
-		);
-		let code_section = module.code_section().expect(
-			"function_section_len != 0; function_section_len == code_section_len; qed",
-		);
+		let function_section = module.function_section().expect("function_section_len != 0; qed");
+		let code_section = module
+			.code_section()
+			.expect("function_section_len != 0; function_section_len == code_section_len; qed");
 		// check every function body
 		for (index, function) in function_section.entries().iter().enumerate() {
-			let function_body = code_section.bodies().get(index as usize).ok_or(
-				Error(format!(
-					"Missing body for function {}",
-					index
-				)),
-			)?;
-			let code = FunctionReader::read_function(&context, function, function_body)
-				.map_err(|e| {
-					let Error(ref msg) = e;
-					Error(format!("Function #{} reading/validation error: {}", index, msg))
-				})?;
+			let function_body = code_section
+				.bodies()
+				.get(index as usize)
+				.ok_or(Error(format!("Missing body for function {}", index)))?;
+			let code = FunctionReader::read_function(&context, function, function_body).map_err(|e| {
+				let Error(ref msg) = e;
+				Error(format!("Function #{} reading/validation error: {}", index, msg))
+			})?;
 			code_map.push(code);
 		}
 	}
@@ -280,9 +267,7 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 	if let Some(start_fn_idx) = module.start_section() {
 		let (params, return_ty) = context.require_function(start_fn_idx)?;
 		if return_ty != BlockType::NoResult || params.len() != 0 {
-			return Err(Error(
-				"start function expected to have type [] -> []".into(),
-			));
+			return Err(Error("start function expected to have type [] -> []".into()));
 		}
 	}
 
@@ -293,9 +278,7 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 			// HashSet::insert returns false if item already in set.
 			let duplicate = export_names.insert(export.field()) == false;
 			if duplicate {
-				return Err(Error(
-					format!("duplicate export {}", export.field()),
-				));
+				return Err(Error(format!("duplicate export {}", export.field())));
 			}
 			match *export.internal() {
 				Internal::Function(function_index) => {
@@ -323,10 +306,7 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 				}
 				External::Global(ref global_type) => {
 					if global_type.is_mutable() {
-						return Err(Error(format!(
-							"trying to import mutable global {}",
-							import.field()
-						)));
+						return Err(Error(format!("trying to import mutable global {}", import.field())));
 					}
 				}
 				External::Memory(ref memory_type) => {
@@ -382,10 +362,7 @@ pub fn validate_module(module: Module) -> Result<ValidatedModule, Error> {
 		}
 	}
 
-	Ok(ValidatedModule {
-		module,
-		code_map,
-	})
+	Ok(ValidatedModule { module, code_map })
 }
 
 fn validate_limits(limits: &ResizableLimits) -> Result<(), Error> {
@@ -413,45 +390,37 @@ fn validate_table_type(table_type: &TableType) -> Result<(), Error> {
 
 fn validate_global_entry(global_entry: &GlobalEntry, globals: &[GlobalType]) -> Result<(), Error> {
 	let init = global_entry.init_expr();
-		let init_expr_ty = expr_const_type(init, globals)?;
-		if init_expr_ty != global_entry.global_type().content_type() {
-			return Err(Error(format!(
-				"Trying to initialize variable of type {:?} with value of type {:?}",
-				global_entry.global_type().content_type(),
-				init_expr_ty
-			)));
-		}
-		Ok(())
+	let init_expr_ty = expr_const_type(init, globals)?;
+	if init_expr_ty != global_entry.global_type().content_type() {
+		return Err(Error(format!(
+			"Trying to initialize variable of type {:?} with value of type {:?}",
+			global_entry.global_type().content_type(),
+			init_expr_ty
+		)));
+	}
+	Ok(())
 }
 
 /// Returns type of this constant expression.
 fn expr_const_type(init_expr: &InitExpr, globals: &[GlobalType]) -> Result<ValueType, Error> {
 	let code = init_expr.code();
 	if code.len() != 2 {
-		return Err(Error(
-			"Init expression should always be with length 2".into(),
-		));
+		return Err(Error("Init expression should always be with length 2".into()));
 	}
 	let expr_ty: ValueType = match code[0] {
 		Instruction::I32Const(_) => ValueType::I32,
 		Instruction::I64Const(_) => ValueType::I64,
 		Instruction::F32Const(_) => ValueType::F32,
 		Instruction::F64Const(_) => ValueType::F64,
-		Instruction::GetGlobal(idx) => {
-			match globals.get(idx as usize) {
-				Some(target_global) => {
-					if target_global.is_mutable() {
-						return Err(Error(format!("Global {} is mutable", idx)));
-					}
-					target_global.content_type()
+		Instruction::GetGlobal(idx) => match globals.get(idx as usize) {
+			Some(target_global) => {
+				if target_global.is_mutable() {
+					return Err(Error(format!("Global {} is mutable", idx)));
 				}
-				None => {
-					return Err(Error(
-						format!("Global {} doesn't exists or not yet defined", idx),
-					))
-				}
+				target_global.content_type()
 			}
-		}
+			None => return Err(Error(format!("Global {} doesn't exists or not yet defined", idx))),
+		},
 		_ => return Err(Error("Non constant opcode in init expr".into())),
 	};
 	if code[1] != Instruction::End {


### PR DESCRIPTION
This pr addresses #51. The goal of this pr is to make stack limits configurable without sacrificing performance.
A useful side effect of these changes is that value and frame stacks become reuseable.

Benches:

| name              | control.trace ns/iter | variable.trace ns/iter | diff ns/iter | diff %  | speedup |
| -                 | -                     | -                      | -            | -       | -       |
| bench_regex_redux | 2,791,066             | 2,812,252              | 21,186       | 0.76%   | x 0.99  |
| bench_rev_comp    | 6,600,544             | 6,651,448              | 50,904       | 0.77%   | x 0.99  |
| bench_tiny_keccak | 3,512,802             | 3,434,810              | -77,992      | -2.22%  | x 1.02  |
| fac_opt           | 19,906                | 11,045                 | -8,861       | -44.51% | x 1.80  |
| fac_recursive     | 22,074                | 13,603                 | -8,471       | -38.38% | x 1.62  |
| recursive_ok      | 1,018,325             | 1,173,291              | 154,966      | 15.22%  | x 0.87  |
| recursive_trap    | 114,942               | 125,829                | 10,887       | 9.47%   | x 0.91  |

I changed `Interpreter` to hold a value and call stack. It no longer remembers the function it is running or the arguments it was passed.

This makes it possible to reuse an interpreter object, (with value and call stack) for subseqeunt function invocations. These are the results of a benchmark with interperters being recycled:

| name              | reuse-control.trace ns/iter | variable.trace ns/iter | diff ns/iter | diff %  | speedup |
| -                 | -                           | -                      | -            | -       | -       |
| bench_regex_redux | 2,791,066                   | 2,781,772              | -9,294       | -0.33%  | x 1.00  |
| bench_rev_comp    | 6,600,544                   | 6,584,948              | -15,596      | -0.24%  | x 1.00  |
| bench_tiny_keccak | 3,512,802                   | 3,432,738              | -80,064      | -2.28%  | x 1.02  |
| fac_opt           | 19,906                      | 1,860                  | -18,046      | -90.66% | x 10.70 |
| fac_recursive     | 22,074                      | 4,194                  | -17,880      | -81.00% | x 5.26  |
| recursive_ok      | 1,018,325                   | 1,129,373              | 111,048      | 10.90%  | x 0.90  |
| recursive_trap    | 114,942                     | 111,131                | -3,811       | -3.32%  | x 1.03  |

Other changes:

- public typesafe api for configuring frame and value stacks (see `StackSize` common/stack.rs)
- made `StackWithLimit` pre-allocate and dynamically resize when appropriate
- optimized `StackWithLimit` implementation (push and pop_unchecked are speedy now). As @pepykin found, Vec::push and Vec::pop were the main bottleneck.
- added `invoke_configurable` function which borrows an interpreter and uses it to run a wasm function
- made copies of benchmarks that recycle interpreters. There were 7, now there are 14. I think its best we get rid of the old ones.

There is still one todo, namely:

- Interpreter::start_execution does not need return type passed as an argument.
