### PR TITLE
doc(host) Fix the `Externals` example

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -189,10 +189,16 @@ impl HostError {
 ///                 ))
 ///             }
 ///         };
-///
+/// 
+///         if self.check_signature(index, signature) {
+///             return Err(Error::Instantiation(
+///                 format!("Export {} has a bad signature", field_name)
+///             ));
+///         }
+/// 
 ///         Ok(FuncInstance::alloc_host(
 ///             Signature::new(&[ValueType::I32, ValueType::I32][..], Some(ValueType::I32)),
-///             ADD_FUNC_INDEX,
+///             index,
 ///         ))
 ///     }
 /// }

--- a/src/host.rs
+++ b/src/host.rs
@@ -190,7 +190,7 @@ impl HostError {
 ///             }
 ///         };
 /// 
-///         if self.check_signature(index, signature) {
+///         if !self.check_signature(index, signature) {
 ///             return Err(Error::Instantiation(
 ///                 format!("Export {} has a bad signature", field_name)
 ///             ));


### PR DESCRIPTION
The example is missing two things:

  * `index` is computed but not used,
  * `check_signature` is never used.

This patch tries to fix that.