### PR TITLE
Expose globals to host

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -183,7 +183,10 @@ impl ModuleInstance {
         self.tables.borrow_mut().get(idx as usize).cloned()
     }
 
-    pub(crate) fn global_by_index(&self, idx: u32) -> Option<GlobalRef> {
+    /// Get global by index. Index can be obtained by calling [globals].
+    ///
+    /// [globals]: [#method.globals]
+    pub fn global_by_index(&self, idx: u32) -> Option<GlobalRef> {
         self.globals.borrow_mut().get(idx as usize).cloned()
     }
 
@@ -213,6 +216,17 @@ impl ModuleInstance {
 
     fn push_global(&self, global: GlobalRef) {
         self.globals.borrow_mut().push(global)
+    }
+
+    /// Enumerates over globals, index can be used as an argument to [global_by_index].
+    ///
+    /// [global_by_index]: #method.global_by_index
+    pub fn globals(&self) -> impl Iterator<Item = (u32, GlobalRef)> {
+        let globals = self.globals.borrow().clone();
+        globals
+            .into_iter()
+            .enumerate()
+            .map(|(idx, global)| (idx as u32, global))
     }
 
     fn insert_export<N: Into<String>>(&self, name: N, extern_val: ExternVal) {


### PR DESCRIPTION
The use case is so that they may be reset to their starting value, to get stateless repeated execution of a module. This is done by making `global_by_index` pub and adding `globals` getter. I'm totally open to better ways of doing this.