### PR TITLE
Replaced hashmap_core with hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ default = ["std"]
 # Disable for no_std support
 std = ["parity-wasm/std", "byteorder/std"]
 # Enable for no_std support
-# hashmap_core only works on no_std
-core = ["hashmap_core", "libm"]
+# hashbrown only works on no_std
+core = ["hashbrown", "libm"]
 
 [dependencies]
 parity-wasm = { version = "0.31", default-features = false }
 byteorder = { version = "1.0", default-features = false }
-hashmap_core = { version = "0.1.9", optional = true }
+hashbrown = { version = "0.1.8", optional = true }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -2,7 +2,7 @@
 use alloc::prelude::*;
 
 #[cfg(not(feature = "std"))]
-use hashmap_core::HashMap;
+use hashbrown::HashMap;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ extern crate assert_matches;
 
 extern crate byteorder;
 #[cfg(not(feature = "std"))]
-extern crate hashmap_core;
+extern crate hashbrown;
 extern crate memory_units as memory_units_crate;
 extern crate parity_wasm;
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use Trap;
 
 #[cfg(not(feature = "std"))]
-use hashmap_core::HashMap;
+use hashbrown::HashMap;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use std::error;
 
 #[cfg(not(feature = "std"))]
-use hashmap_core::HashSet;
+use hashbrown::HashSet;
 #[cfg(feature = "std")]
 use std::collections::HashSet;
 


### PR DESCRIPTION
Hey,
So it turns out that `hashmap_core` is deprecated, I replaced it with `hashbrown` according to the maintainers suggestion here: https://github.com/Amanieu/hashmap_core/pull/10

The tests didn't pass for me locally, But I hope this is a configuration thing because I see no reason for any meaningful difference here