### PR TITLE
Adding lifetime to Externals

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -199,8 +199,8 @@ impl HostError {
 /// ```
 pub trait Externals {
 	/// Perform invoke of a host function by specified `index`.
-	fn invoke_index(
-		&mut self,
+	fn invoke_index<'a>(
+		&'a mut self,
 		index: usize,
 		args: RuntimeArgs,
 	) -> Result<Option<RuntimeValue>, Trap>;


### PR DESCRIPTION
To allow to expose information by reference that exists within externals existence