### PR TITLE
Implement Send & Sync for ModuleInstance and ModuleRef to enable sharing across threads

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -39,6 +39,9 @@ use {Error, MemoryInstance, Module, RuntimeValue, Signature, TableInstance};
 #[derive(Clone, Debug)]
 pub struct ModuleRef(pub(crate) Rc<ModuleInstance>);
 
+unsafe impl Sync for ModuleRef {}
+unsafe impl Send for ModuleRef {}
+
 impl ::core::ops::Deref for ModuleRef {
     type Target = ModuleInstance;
     fn deref(&self) -> &ModuleInstance {
@@ -163,6 +166,9 @@ pub struct ModuleInstance {
     globals: RefCell<Vec<GlobalRef>>,
     exports: RefCell<HashMap<String, ExternVal>>,
 }
+
+unsafe impl Sync for ModuleInstance {}
+unsafe impl Send for ModuleInstance {}
 
 impl ModuleInstance {
     fn default() -> Self {


### PR DESCRIPTION
I have a project that wishes to execute loaded Web Assembly modules in multiple threads.

To be able to do so, I need to have ModuleRef and ModuleInstance implement the marker traits "Send" and "Sync".

These are added to the modules.rs file as markers, with no code changes required.

I have run and passed tests and hope these changes seem reasonable to you.