### PR TITLE
Removed Byteorder now that rust supports it natively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 [features]
 default = ["std"]
 # Disable for no_std support
-std = ["parity-wasm/std", "byteorder/std"]
+std = ["parity-wasm/std"]
 # Enable for no_std support
 # hashbrown only works on no_std
 core = ["hashbrown", "libm"]
 
 [dependencies]
 parity-wasm = { version = "0.31", default-features = false }
-byteorder = { version = "1.0", default-features = false }
 hashbrown = { version = "0.1.8", optional = true }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@ extern crate wabt;
 #[macro_use]
 extern crate assert_matches;
 
-extern crate byteorder;
 #[cfg(not(feature = "std"))]
 extern crate hashbrown;
 extern crate memory_units as memory_units_crate;

--- a/src/value.rs
+++ b/src/value.rs
@@ -607,7 +607,7 @@ impl LittleEndianConvert for i16 {
         let mut res = [0u8; 2];
         buffer
             .get(0..2)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_le_bytes(res)
             })
@@ -624,7 +624,7 @@ impl LittleEndianConvert for u16 {
         let mut res = [0u8; 2];
         buffer
             .get(0..2)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_le_bytes(res)
             })
@@ -641,7 +641,7 @@ impl LittleEndianConvert for i32 {
         let mut res = [0u8; 4];
         buffer
             .get(0..4)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_le_bytes(res)
             })
@@ -658,7 +658,7 @@ impl LittleEndianConvert for u32 {
         let mut res = [0u8; 4];
         buffer
             .get(0..4)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_le_bytes(res)
             })
@@ -675,7 +675,7 @@ impl LittleEndianConvert for i64 {
         let mut res = [0u8; 8];
         buffer
             .get(0..8)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_le_bytes(res)
             })
@@ -692,7 +692,7 @@ impl LittleEndianConvert for f32 {
         let mut res = [0u8; 4];
         buffer
             .get(0..4)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_bits(u32::from_le_bytes(res))
             })
@@ -709,7 +709,7 @@ impl LittleEndianConvert for f64 {
         let mut res = [0u8; 8];
         buffer
             .get(0..8)
-            .map(|s|{
+            .map(|s| {
                 res.copy_from_slice(s);
                 Self::from_bits(u64::from_le_bytes(res))
             })

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,3 @@
-use byteorder::{ByteOrder, LittleEndian};
 use core::{f32, i32, i64, u32, u64};
 use nan_preserving_float::{F32, F64};
 use types::ValueType;
@@ -601,91 +600,119 @@ impl LittleEndianConvert for u8 {
 
 impl LittleEndianConvert for i16 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_i16(buffer, self);
+        buffer.copy_from_slice(&self.to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 2];
         buffer
             .get(0..2)
-            .map(LittleEndian::read_i16)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_le_bytes(res)
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }
 
 impl LittleEndianConvert for u16 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_u16(buffer, self);
+        buffer.copy_from_slice(&self.to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 2];
         buffer
             .get(0..2)
-            .map(LittleEndian::read_u16)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_le_bytes(res)
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }
 
 impl LittleEndianConvert for i32 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_i32(buffer, self);
+        buffer.copy_from_slice(&self.to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 4];
         buffer
             .get(0..4)
-            .map(LittleEndian::read_i32)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_le_bytes(res)
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }
 
 impl LittleEndianConvert for u32 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_u32(buffer, self);
+        buffer.copy_from_slice(&self.to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 4];
         buffer
             .get(0..4)
-            .map(LittleEndian::read_u32)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_le_bytes(res)
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }
 
 impl LittleEndianConvert for i64 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_i64(buffer, self);
+        buffer.copy_from_slice(&self.to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 8];
         buffer
             .get(0..8)
-            .map(LittleEndian::read_i64)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_le_bytes(res)
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }
 
 impl LittleEndianConvert for f32 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_f32(buffer, self);
+        buffer.copy_from_slice(&self.to_bits().to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 4];
         buffer
             .get(0..4)
-            .map(LittleEndian::read_f32)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_bits(u32::from_le_bytes(res))
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }
 
 impl LittleEndianConvert for f64 {
     fn into_little_endian(self, buffer: &mut [u8]) {
-        LittleEndian::write_f64(buffer, self);
+        buffer.copy_from_slice(&self.to_bits().to_le_bytes());
     }
 
     fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
+        let mut res = [0u8; 8];
         buffer
             .get(0..8)
-            .map(LittleEndian::read_f64)
+            .map(|s|{
+                res.copy_from_slice(s);
+                Self::from_bits(u64::from_le_bytes(res))
+            })
             .ok_or_else(|| Error::InvalidLittleEndianBuffer)
     }
 }


### PR DESCRIPTION
Almost all the operations Byteorder supported using IO are now possible natively.
so to not break the API the trait still accepts a mutable buffer but it transmutes the data using the native functions that were stabilized: https://github.com/rust-lang/rust/pull/53697