### PR TITLE
Added the nightly feature to hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["std"]
 std = ["parity-wasm/std"]
 # Enable for no_std support
 # hashbrown only works on no_std
-core = ["hashbrown", "libm"]
+core = ["hashbrown/nightly", "libm"]
 
 [dependencies]
 parity-wasm = { version = "0.31", default-features = false }


### PR DESCRIPTION
So, when I replaced `hashmap_core` with `hashbrown` I didn't add the nightly feature to it.
This means that it uses `std`.

source: https://github.com/Amanieu/hashbrown/blob/master/src/lib.rs#L46