### PR TITLE
RFC: Recycle value stacks to avoid allocation costs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,7 @@ pub use self::host::{Externals, HostError, NopExternals, RuntimeArgs};
 pub use self::imports::{ImportResolver, ImportsBuilder, ModuleImportResolver};
 pub use self::memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
 pub use self::module::{ExternVal, ModuleInstance, ModuleRef, NotStartedModuleRef};
+pub use self::runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT};
 pub use self::table::{TableInstance, TableRef};
 pub use self::types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType};
 pub use self::value::{Error as ValueError, FromRuntimeValue, LittleEndianConvert, RuntimeValue};


### PR DESCRIPTION
We hope to use `wasmi` to implement a policy engine for low-volume packet inspection in an embedded setting. Initial CPU profiles using toy policies showed almost 40% CPU time spent in `Vec::extend_with` to allocate and initialize a new value stack for each function call.

This MR tries to address this by adding API to allow applications to reuse stack allocations (for both value and call stacks).

As a side effect, it also provides API for applications to configure the stack size limits (which is rather useful for us as we only need a few kB of value stack in our particular application).

A micro benchmark executing a minimal policy for single packet optimized for size showed the following changes:
* Originally, an iteration took 205 µs.
* With this MR, but _without_ doing any recycling, an iteration took 295 µs.
* With this MR, and using the recycling, an iteration took 165 µs. (Also variance dropped from 1.7% to 0.6%.)
* With this MR, using the recycling as well as keeping the stack "dirty", an iteration took 75 µs.
* With this MR, using the recycling as well as a "clean" but much smaller stack of 32 kB, an iteration took 77 µs.

At least the following questions remain open from my point of view:
* [ ] The performance dropped significantly without recycling and I am not certain where this is coming from. I currently suspect that making the limits configurable prevents some micro optimizations that add up to the observed slow down.
* [ ] Zeroing out the stack before reuse does not seem to be necessary to pass the test suite and not doing it significantly improves performance. However, I am unsure if this would mean that programs could observe "dirty" values on the stack or whether the spec requires the stack to be zeroed before invoking an exported function.