### PR TITLE
Use hashbrown for std in addition to no_std builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 [dependencies]
 wasmi-validation = { version = "0.1", path = "validation", default-features = false }
 parity-wasm = { version = "0.31", default-features = false }
-hashbrown = { version = "0.1.8", optional = true }
+hashbrown = "0.4.0"
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
 
@@ -30,7 +30,6 @@ std = [
     "wasmi-validation/std",
 ]
 # Enable for no_std support
-# hashbrown only works on no_std
 core = [
     "wasmi-validation/core",
     "hashbrown/nightly",

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,10 +1,7 @@
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;
 
-#[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 
 use func::FuncRef;
 use global::GlobalRef;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,6 @@ extern crate assert_matches;
 #[cfg(test)]
 extern crate wabt;
 
-#[cfg(not(feature = "std"))]
 extern crate hashbrown;
 extern crate memory_units as memory_units_crate;
 extern crate parity_wasm;

--- a/src/module.rs
+++ b/src/module.rs
@@ -5,10 +5,7 @@ use core::cell::RefCell;
 use core::fmt;
 use Trap;
 
-#[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 
 use core::cell::Ref;
 use func::{FuncBody, FuncInstance, FuncRef};

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -9,7 +9,7 @@ description = "Wasm code validator"
 
 [dependencies]
 parity-wasm = { version = "0.31", default-features = false }
-hashbrown = { version = "0.1.8", optional = true }
+hashbrown = "0.4.0"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -27,10 +27,7 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
 
-#[cfg(not(feature = "std"))]
 use hashbrown::HashSet;
-#[cfg(feature = "std")]
-use std::collections::HashSet;
 
 use self::context::ModuleContextBuilder;
 use parity_wasm::elements::{


### PR DESCRIPTION
This simplifies dependency management a little bit and might also yield minimal performance improvements for large modules even though the included benchmarks do not have enough exports to make this measurable.