### PR TITLE
Add ARMv7 as CI test target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,24 @@
-dist: trusty
-sudo: required
+dist: xenial
+
 language:
 - rust
 - cpp
-rust:
-  - nightly
-  - stable
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-8
-    - g++-8
-    - cmake
-env:
-- CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
+
+matrix:
+  fast_finish: true
+  include:
+  - rust: nightly
+  - rust: stable
+  - rust: stable
+    env: TARGET=armv7-unknown-linux-gnueabihf
 
 install:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then rustup target add wasm32-unknown-unknown; fi
+- if [ -n "$TARGET" ]; then rustup target add "$TARGET" && sudo apt-get install --yes qemu-user-static; fi
+- if [ "$TARGET" == "armv7-unknown-linux-gnueabihf" ]; then sudo apt-get install --yes crossbuild-essential-armhf && export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf; fi
 - rustup component add rustfmt
+- sudo apt-get install --yes cmake
+
 script:
 - cargo fmt --all -- --check
 # Make sure nightly targets are not broken.
@@ -27,8 +26,9 @@ script:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo check --benches --manifest-path=benches/Cargo.toml; fi
 # Make sure `no_std` version checks.
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo +nightly check --no-default-features --features core; fi
-- ./test.sh
+- travis_wait 60 ./test.sh
 - ./doc.sh
+
 after_success: |
   # Build documentation and deploy it to github pages.
   [ $TRAVIS_BRANCH = master ] &&
@@ -37,6 +37,7 @@ after_success: |
   sudo pip install ghp-import &&
   ghp-import -n target/doc &&
   git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+
 cache: cargo
 before_cache:
   # Travis can't cache files that are not readable by "others"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ wasmi-validation = { version = "0.1", path = "validation", default-features = fa
 parity-wasm = { version = "0.31", default-features = false }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
+num-rational = "0.2.2"
+num-traits = "0.2.8"
 
 [dev-dependencies]
 assert_matches = "1.1"
@@ -27,6 +29,8 @@ default = ["std"]
 std = [
     "parity-wasm/std",
     "wasmi-validation/std",
+    "num-rational/std",
+    "num-traits/std"
 ]
 # Enable for no_std support
 core = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,9 @@ use std::error;
 #[cfg(not(feature = "std"))]
 extern crate libm;
 
+extern crate num_rational;
+extern crate num_traits;
+
 /// Error type which can be thrown by wasm code or by host environment.
 ///
 /// Under some conditions, wasm execution may produce a `Trap`, which immediately aborts execution.

--- a/test.sh
+++ b/test.sh
@@ -2,8 +2,14 @@
 
 set -eux
 
+EXTRA_ARGS=""
+
+if [ -n "${TARGET-}" ]; then
+    EXTRA_ARGS="--target=${TARGET} -- --test-threads=1"
+fi
+
 cd $(dirname $0)
 
-time cargo test --all
+time cargo test --all ${EXTRA_ARGS}
 
 cd -

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,11 @@ set -eux
 EXTRA_ARGS=""
 
 if [ -n "${TARGET-}" ]; then
-    EXTRA_ARGS="--target=${TARGET} -- --test-threads=1"
+    # Tests build in debug mode are prohibitively
+    # slow when ran under emulation so that
+    # e.g. Travis CI will hit timeouts.
+    EXTRA_ARGS="--release --target=${TARGET}"
+    export RUSTFLAGS="--cfg debug_assertions"
 fi
 
 cd $(dirname $0)


### PR DESCRIPTION
This adds ARMv7 as test target for Travis CI so that issues on this 32-bit platform can be spotted immediately which should also resolve #43.

To do so, I opted to bump the CI to Xenial to avoid needing third-party repositories as everything just works using `crossbuild-essential-armhf` and `qemu-user-static` on this platform.

I also to install packages using `sudo apt-get` instead of the APT `addon` as the latter does not support conditional installs based on the build matrix, but I did not want to use a different installation method of the conditional and the unconditional dependencies.

**Note that the spec tests currently fail due to failures in `wasm_conversions`. I would be glad if someone could help me with fixing those.**