### PR TITLE
Add feature flag for opt-in thread-safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
 num-rational = "0.2.2"
 num-traits = "0.2.8"
+atomic = { version = "0.4", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
@@ -24,6 +25,7 @@ rand = "0.4.2"
 wabt = "0.6"
 
 [features]
+threadsafe = ["atomic"]
 default = ["std"]
 # Disable for no_std support
 std = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ git clone https://github.com/paritytech/wasmi.git --recursive
 cd wasmi
 cargo build
 cargo test
+cargo test --features threadsafe
 ```
 
 # `no_std` support
@@ -38,6 +39,19 @@ Also, code related to `std::error` is disabled.
 
 Floating point operations in `no_std` use [`libm`](https://crates.io/crates/libm), which sometimes panics in debug mode (https://github.com/japaric/libm/issues/4).
 So make sure to either use release builds or avoid WASM with floating point operations, for example by using [`deny_floating_point`](https://docs.rs/wasmi/0.4.0/wasmi/struct.Module.html#method.deny_floating_point).
+
+# Thread-safe support
+
+This crate supports thread-safe environments.
+Enable the `threadsafe` feature and Rust's thread-safe data structures will be used.
+```toml
+[dependencies]
+parity-wasm = {
+	version = "0.31",
+	default-features = true,
+	features = "threadsafe"
+}
+```
 
 # License
 

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,6 +1,5 @@
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;
-use alloc::rc::{Rc, Weak};
 use core::fmt;
 use host::Externals;
 use isa;
@@ -17,7 +16,7 @@ use {Signature, Trap};
 ///
 /// [`FuncInstance`]: struct.FuncInstance.html
 #[derive(Clone, Debug)]
-pub struct FuncRef(Rc<FuncInstance>);
+pub struct FuncRef(::MyRc<FuncInstance>);
 
 impl ::core::ops::Deref for FuncRef {
     type Target = FuncInstance;
@@ -45,9 +44,9 @@ pub struct FuncInstance(FuncInstanceInternal);
 #[derive(Clone)]
 pub(crate) enum FuncInstanceInternal {
     Internal {
-        signature: Rc<Signature>,
-        module: Weak<ModuleInstance>,
-        body: Rc<FuncBody>,
+        signature: ::MyRc<Signature>,
+        module: ::MyWeak<ModuleInstance>,
+        body: ::MyRc<FuncBody>,
     },
     Host {
         signature: Signature,
@@ -84,7 +83,7 @@ impl FuncInstance {
             signature,
             host_func_index,
         };
-        FuncRef(Rc::new(FuncInstance(func)))
+        FuncRef(::MyRc::new(FuncInstance(func)))
     }
 
     /// Returns [signature] of this function instance.
@@ -104,21 +103,21 @@ impl FuncInstance {
     }
 
     pub(crate) fn alloc_internal(
-        module: Weak<ModuleInstance>,
-        signature: Rc<Signature>,
+        module: ::MyWeak<ModuleInstance>,
+        signature: ::MyRc<Signature>,
         body: FuncBody,
     ) -> FuncRef {
         let func = FuncInstanceInternal::Internal {
             signature,
             module: module,
-            body: Rc::new(body),
+            body: ::MyRc::new(body),
         };
-        FuncRef(Rc::new(FuncInstance(func)))
+        FuncRef(::MyRc::new(FuncInstance(func)))
     }
 
-    pub(crate) fn body(&self) -> Option<Rc<FuncBody>> {
+    pub(crate) fn body(&self) -> Option<::MyRc<FuncBody>> {
         match *self.as_internal() {
-            FuncInstanceInternal::Internal { ref body, .. } => Some(Rc::clone(body)),
+            FuncInstanceInternal::Internal { ref body, .. } => Some(::MyRc::clone(body)),
             FuncInstanceInternal::Host { .. } => None,
         }
     }

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,5 +1,3 @@
-use alloc::rc::Rc;
-use core::cell::Cell;
 use parity_wasm::elements::ValueType as EValueType;
 use types::ValueType;
 use value::RuntimeValue;
@@ -11,7 +9,7 @@ use Error;
 ///
 /// [`GlobalInstance`]: struct.GlobalInstance.html
 #[derive(Clone, Debug)]
-pub struct GlobalRef(Rc<GlobalInstance>);
+pub struct GlobalRef(::MyRc<GlobalInstance>);
 
 impl ::core::ops::Deref for GlobalRef {
     type Target = GlobalInstance;
@@ -33,7 +31,7 @@ impl ::core::ops::Deref for GlobalRef {
 /// [`I64`]: enum.RuntimeValue.html#variant.I64
 #[derive(Debug)]
 pub struct GlobalInstance {
-    val: Cell<RuntimeValue>,
+    val: ::MyCell<RuntimeValue>,
     mutable: bool,
 }
 
@@ -43,8 +41,8 @@ impl GlobalInstance {
     /// Since it is possible to export only immutable globals,
     /// users likely want to set `mutable` to `false`.
     pub fn alloc(val: RuntimeValue, mutable: bool) -> GlobalRef {
-        GlobalRef(Rc::new(GlobalInstance {
-            val: Cell::new(val),
+        GlobalRef(::MyRc::new(GlobalInstance {
+            val: ::MyCell::new(val),
             mutable,
         }))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,12 @@ mod table;
 mod types;
 mod value;
 
+#[cfg(feature = "threadsafe")]
+mod threadsafe;
+
+#[cfg(not(feature = "threadsafe"))]
+mod not_threadsafe;
+
 #[cfg(test)]
 mod tests;
 
@@ -409,6 +415,12 @@ pub use self::runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_ST
 pub use self::table::{TableInstance, TableRef};
 pub use self::types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType};
 pub use self::value::{Error as ValueError, FromRuntimeValue, LittleEndianConvert, RuntimeValue};
+
+#[cfg(feature = "threadsafe")]
+pub use self::threadsafe::*;
+
+#[cfg(not(feature = "threadsafe"))]
+pub use self::not_threadsafe::*;
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,8 +1,6 @@
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;
-use alloc::rc::Rc;
 use core::{
-    cell::{Cell, RefCell},
     cmp, fmt,
     ops::Range,
     u32,
@@ -26,7 +24,7 @@ pub const LINEAR_MEMORY_PAGE_SIZE: Bytes = Bytes(65536);
 /// [`MemoryInstance`]: struct.MemoryInstance.html
 ///
 #[derive(Clone, Debug)]
-pub struct MemoryRef(Rc<MemoryInstance>);
+pub struct MemoryRef(::MyRc<MemoryInstance>);
 
 impl ::core::ops::Deref for MemoryRef {
     type Target = MemoryInstance;
@@ -52,11 +50,11 @@ pub struct MemoryInstance {
     /// Memory limits.
     limits: ResizableLimits,
     /// Linear memory buffer with lazy allocation.
-    buffer: RefCell<Vec<u8>>,
+    buffer: ::MyRefCell<Vec<u8>>,
     initial: Pages,
-    current_size: Cell<usize>,
+    current_size: ::MyCell<usize>,
     maximum: Option<Pages>,
-    lowest_used: Cell<u32>,
+    lowest_used: ::MyCell<u32>,
 }
 
 impl fmt::Debug for MemoryInstance {
@@ -127,7 +125,7 @@ impl MemoryInstance {
         }
 
         let memory = MemoryInstance::new(initial, maximum);
-        Ok(MemoryRef(Rc::new(memory)))
+        Ok(MemoryRef(::MyRc::new(memory)))
     }
 
     /// Create new linear memory instance.
@@ -137,11 +135,11 @@ impl MemoryInstance {
         let initial_size: Bytes = initial.into();
         MemoryInstance {
             limits: limits,
-            buffer: RefCell::new(Vec::with_capacity(4096)),
+            buffer: ::MyRefCell::new(Vec::with_capacity(4096)),
             initial: initial,
-            current_size: Cell::new(initial_size.0),
+            current_size: ::MyCell::new(initial_size.0),
             maximum: maximum,
-            lowest_used: Cell::new(u32::max_value()),
+            lowest_used: ::MyCell::new(u32::max_value()),
         }
     }
 
@@ -558,7 +556,6 @@ mod tests {
 
     use super::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
     use memory_units::Pages;
-    use std::rc::Rc;
     use Error;
 
     #[test]
@@ -660,8 +657,8 @@ mod tests {
 
     #[test]
     fn transfer_works() {
-        let src = MemoryRef(Rc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
-        let dst = MemoryRef(Rc::new(create_memory(&[
+        let src = MemoryRef(::MyRc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
+        let dst = MemoryRef(::MyRc::new(create_memory(&[
             10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         ])));
 
@@ -676,7 +673,7 @@ mod tests {
 
     #[test]
     fn transfer_still_works_with_same_memory() {
-        let src = MemoryRef(Rc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
+        let src = MemoryRef(::MyRc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
 
         MemoryInstance::transfer(&src, 4, &src, 0, 3).unwrap();
 
@@ -685,7 +682,7 @@ mod tests {
 
     #[test]
     fn transfer_oob_with_same_memory_errors() {
-        let src = MemoryRef(Rc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
+        let src = MemoryRef(::MyRc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
         assert!(MemoryInstance::transfer(&src, 65535, &src, 0, 3).is_err());
 
         // Check that memories content left untouched
@@ -694,8 +691,8 @@ mod tests {
 
     #[test]
     fn transfer_oob_errors() {
-        let src = MemoryRef(Rc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
-        let dst = MemoryRef(Rc::new(create_memory(&[
+        let src = MemoryRef(::MyRc::new(create_memory(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])));
+        let dst = MemoryRef(::MyRc::new(create_memory(&[
             10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         ])));
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -742,6 +742,8 @@ mod tests {
         });
     }
 
+    // this test works only in the non-thread-safe variant, it deadlocks otherwise.
+    #[cfg(not(feature = "threadsafe"))]
     #[should_panic]
     #[test]
     fn zero_copy_panics_on_nested_access() {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,10 +1,6 @@
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;
-use core::{
-    cmp, fmt,
-    ops::Range,
-    u32,
-};
+use core::{cmp, fmt, ops::Range, u32};
 use memory_units::{Bytes, Pages, RoundUpTo};
 use parity_wasm::elements::ResizableLimits;
 use value::LittleEndianConvert;
@@ -202,8 +198,7 @@ impl MemoryInstance {
 
     /// Get value from memory at given offset.
     pub fn get_value<T: LittleEndianConvert>(&self, offset: u32) -> Result<T, Error> {
-        let region =
-            self.checked_region(offset as usize, ::core::mem::size_of::<T>())?;
+        let region = self.checked_region(offset as usize, ::core::mem::size_of::<T>())?;
 
         let buffer = self.buffer.borrow();
         Ok(T::from_little_endian(&buffer[region.range()]).expect("Slice size is checked"))
@@ -238,9 +233,7 @@ impl MemoryInstance {
 
     /// Copy data in the memory at given offset.
     pub fn set(&self, offset: u32, value: &[u8]) -> Result<(), Error> {
-        let range = self
-            .checked_region(offset as usize, value.len())?
-            .range();
+        let range = self.checked_region(offset as usize, value.len())?.range();
 
         if offset < self.lowest_used.get() {
             self.lowest_used.set(offset);
@@ -298,11 +291,7 @@ impl MemoryInstance {
         Ok(size_before_grow)
     }
 
-    fn checked_region(
-        &self,
-        offset: usize,
-        size: usize,
-    ) -> Result<CheckedRegion, Error> {
+    fn checked_region(&self, offset: usize, size: usize) -> Result<CheckedRegion, Error> {
         let mut buffer = self.buffer.borrow_mut();
         let end = offset.checked_add(size).ok_or_else(|| {
             Error::Memory(format!(
@@ -472,12 +461,8 @@ impl MemoryInstance {
             return src.copy(src_offset, dst_offset, len);
         }
 
-        let src_range = src
-            .checked_region(src_offset, len)?
-            .range();
-        let dst_range = dst
-            .checked_region(dst_offset, len)?
-            .range();
+        let src_range = src.checked_region(src_offset, len)?.range();
+        let dst_range = dst.checked_region(dst_offset, len)?.range();
 
         if dst_offset < dst.lowest_used.get() as usize {
             dst.lowest_used.set(dst_offset as u32);

--- a/src/module.rs
+++ b/src/module.rs
@@ -213,7 +213,7 @@ impl ModuleInstance {
 
     /// Access all globals. This is a non-standard API so it's unlikely to be
     /// portable to other engines.
-    pub fn globals<'a>(&self) -> ::MyRef<Vec<GlobalRef>> {
+    pub fn globals<'a>(&self) -> ::MyRefRead<Vec<GlobalRef>> {
         self.globals.borrow()
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,13 +1,10 @@
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;
-use alloc::rc::Rc;
-use core::cell::RefCell;
 use core::fmt;
 use Trap;
 
 use alloc::collections::BTreeMap;
 
-use core::cell::Ref;
 use func::{FuncBody, FuncInstance, FuncRef};
 use global::{GlobalInstance, GlobalRef};
 use host::Externals;
@@ -35,7 +32,7 @@ use {Error, MemoryInstance, Module, RuntimeValue, Signature, TableInstance};
 ///
 /// [`ModuleInstance`]: struct.ModuleInstance.html
 #[derive(Clone, Debug)]
-pub struct ModuleRef(pub(crate) Rc<ModuleInstance>);
+pub struct ModuleRef(pub(crate) ::MyRc<ModuleInstance>);
 
 impl ::core::ops::Deref for ModuleRef {
     type Target = ModuleInstance;
@@ -154,23 +151,23 @@ impl ExternVal {
 /// [`invoke_export`]: #method.invoke_export
 #[derive(Debug)]
 pub struct ModuleInstance {
-    signatures: RefCell<Vec<Rc<Signature>>>,
-    tables: RefCell<Vec<TableRef>>,
-    funcs: RefCell<Vec<FuncRef>>,
-    memories: RefCell<Vec<MemoryRef>>,
-    globals: RefCell<Vec<GlobalRef>>,
-    exports: RefCell<BTreeMap<String, ExternVal>>,
+    signatures: ::MyRefCell<Vec<::MyRc<Signature>>>,
+    tables: ::MyRefCell<Vec<TableRef>>,
+    funcs: ::MyRefCell<Vec<FuncRef>>,
+    memories: ::MyRefCell<Vec<MemoryRef>>,
+    globals: ::MyRefCell<Vec<GlobalRef>>,
+    exports: ::MyRefCell<BTreeMap<String, ExternVal>>,
 }
 
 impl ModuleInstance {
     fn default() -> Self {
         ModuleInstance {
-            funcs: RefCell::new(Vec::new()),
-            signatures: RefCell::new(Vec::new()),
-            tables: RefCell::new(Vec::new()),
-            memories: RefCell::new(Vec::new()),
-            globals: RefCell::new(Vec::new()),
-            exports: RefCell::new(BTreeMap::new()),
+            funcs: ::MyRefCell::new(Vec::new()),
+            signatures: ::MyRefCell::new(Vec::new()),
+            tables: ::MyRefCell::new(Vec::new()),
+            memories: ::MyRefCell::new(Vec::new()),
+            globals: ::MyRefCell::new(Vec::new()),
+            exports: ::MyRefCell::new(BTreeMap::new()),
         }
     }
 
@@ -190,7 +187,7 @@ impl ModuleInstance {
         self.funcs.borrow().get(idx as usize).cloned()
     }
 
-    pub(crate) fn signature_by_index(&self, idx: u32) -> Option<Rc<Signature>> {
+    pub(crate) fn signature_by_index(&self, idx: u32) -> Option<::MyRc<Signature>> {
         self.signatures.borrow().get(idx as usize).cloned()
     }
 
@@ -198,7 +195,7 @@ impl ModuleInstance {
         self.funcs.borrow_mut().push(func);
     }
 
-    fn push_signature(&self, signature: Rc<Signature>) {
+    fn push_signature(&self, signature: ::MyRc<Signature>) {
         self.signatures.borrow_mut().push(signature)
     }
 
@@ -216,7 +213,7 @@ impl ModuleInstance {
 
     /// Access all globals. This is a non-standard API so it's unlikely to be
     /// portable to other engines.
-    pub fn globals<'a>(&self) -> Ref<Vec<GlobalRef>> {
+    pub fn globals<'a>(&self) -> ::MyRef<Vec<GlobalRef>> {
         self.globals.borrow()
     }
 
@@ -229,10 +226,10 @@ impl ModuleInstance {
         extern_vals: I,
     ) -> Result<ModuleRef, Error> {
         let module = loaded_module.module();
-        let instance = ModuleRef(Rc::new(ModuleInstance::default()));
+        let instance = ModuleRef(::MyRc::new(ModuleInstance::default()));
 
         for &Type::Function(ref ty) in module.type_section().map(|ts| ts.types()).unwrap_or(&[]) {
-            let signature = Rc::new(Signature::from_elements(ty));
+            let signature = ::MyRc::new(Signature::from_elements(ty));
             instance.push_signature(signature);
         }
 
@@ -327,7 +324,7 @@ impl ModuleInstance {
                     code: code,
                 };
                 let func_instance =
-                    FuncInstance::alloc_internal(Rc::downgrade(&instance.0), signature, func_body);
+                    FuncInstance::alloc_internal(::MyRc::downgrade(&instance.0), signature, func_body);
                 instance.push_func(func_instance);
             }
         }

--- a/src/module.rs
+++ b/src/module.rs
@@ -323,8 +323,11 @@ impl ModuleInstance {
                     locals: body.locals().to_vec(),
                     code: code,
                 };
-                let func_instance =
-                    FuncInstance::alloc_internal(::MyRc::downgrade(&instance.0), signature, func_body);
+                let func_instance = FuncInstance::alloc_internal(
+                    ::MyRc::downgrade(&instance.0),
+                    signature,
+                    func_body,
+                );
                 instance.push_func(func_instance);
             }
         }

--- a/src/not_threadsafe.rs
+++ b/src/not_threadsafe.rs
@@ -1,5 +1,6 @@
 pub use alloc::rc::Rc as MyRc;
 pub use alloc::rc::Weak as MyWeak;
 pub use core::cell::Cell as MyCell;
-pub use core::cell::Ref as MyRef;
+pub use core::cell::Ref as MyRefRead;
+pub use core::cell::Ref as MyRefWrite;
 pub use core::cell::RefCell as MyRefCell;

--- a/src/not_threadsafe.rs
+++ b/src/not_threadsafe.rs
@@ -1,5 +1,5 @@
 pub use alloc::rc::Rc as MyRc;
 pub use alloc::rc::Weak as MyWeak;
 pub use core::cell::Cell as MyCell;
-pub use core::cell::RefCell as MyRefCell;
 pub use core::cell::Ref as MyRef;
+pub use core::cell::RefCell as MyRefCell;

--- a/src/not_threadsafe.rs
+++ b/src/not_threadsafe.rs
@@ -1,0 +1,5 @@
+pub use alloc::rc::Rc as MyRc;
+pub use alloc::rc::Weak as MyWeak;
+pub use core::cell::Cell as MyCell;
+pub use core::cell::RefCell as MyRefCell;
+pub use core::cell::Ref as MyRef;

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,5 @@
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;
-use alloc::rc::Rc;
-use core::cell::RefCell;
 use core::fmt;
 use core::u32;
 use func::FuncRef;
@@ -16,7 +14,7 @@ use Error;
 /// [`TableInstance`]: struct.TableInstance.html
 ///
 #[derive(Clone, Debug)]
-pub struct TableRef(Rc<TableInstance>);
+pub struct TableRef(::MyRc<TableInstance>);
 
 impl ::core::ops::Deref for TableRef {
     type Target = TableInstance;
@@ -42,7 +40,7 @@ pub struct TableInstance {
     /// Table limits.
     limits: ResizableLimits,
     /// Table memory buffer.
-    buffer: RefCell<Vec<Option<FuncRef>>>,
+    buffer: ::MyRefCell<Vec<Option<FuncRef>>>,
 }
 
 impl fmt::Debug for TableInstance {
@@ -67,13 +65,13 @@ impl TableInstance {
     /// Returns `Err` if `initial_size` is greater than `maximum_size`.
     pub fn alloc(initial_size: u32, maximum_size: Option<u32>) -> Result<TableRef, Error> {
         let table = TableInstance::new(ResizableLimits::new(initial_size, maximum_size))?;
-        Ok(TableRef(Rc::new(table)))
+        Ok(TableRef(::MyRc::new(table)))
     }
 
     fn new(limits: ResizableLimits) -> Result<TableInstance, Error> {
         check_limits(&limits)?;
         Ok(TableInstance {
-            buffer: RefCell::new(vec![None; limits.initial() as usize]),
+            buffer: ::MyRefCell::new(vec![None; limits.initial() as usize]),
             limits: limits,
         })
     }

--- a/src/threadsafe.rs
+++ b/src/threadsafe.rs
@@ -1,0 +1,52 @@
+extern crate atomic;
+
+use alloc::sync::{Arc, Mutex};
+
+pub use alloc::sync::{
+    Arc as MyRc, Weak as MyWeak, MutexGuard as MyRef,
+};
+pub use self::atomic::{
+    Atomic, Ordering::Relaxed as Ordering,
+};
+
+/// Thread-safe wrapper which can be used in place of a `RefCell`.
+#[derive(Debug)]
+pub struct MyRefCell<T>(Arc<Mutex<T>>);
+
+impl<T> MyRefCell<T> {
+    /// Create new wrapper object.
+    pub fn new(obj: T) -> MyRefCell<T> {
+        MyRefCell(Arc::new(Mutex::new(obj)))
+    }
+
+    /// Borrow a `MyRef` to the inner value.
+    pub fn borrow(&self) -> ::MyRef<T> {
+        self.0.lock().expect("bar")
+    }
+
+    /// Borrow a mutable `MyRef` to the inner value.
+    pub fn borrow_mut(&self) -> ::MyRef<T> {
+        self.0.lock().expect("bar")
+    }
+}
+
+/// Thread-safe wrapper which can be used in place of a `Cell`.
+#[derive(Debug)]
+pub struct MyCell<T>(Atomic<T>) where T: Copy;
+
+impl<T> MyCell<T> where T: Copy {
+    /// Create new wrapper object.
+    pub fn new(obj: T) -> MyCell<T> {
+        MyCell(Atomic::new(obj))
+    }
+
+    /// Returns the inner value.
+    pub fn get(&self) -> T {
+        self.0.load(::Ordering)
+    }
+
+    /// Sets the inner value.
+    pub fn set(&self, val: T) {
+        self.0.store(val, ::Ordering);
+    }
+}

--- a/src/threadsafe.rs
+++ b/src/threadsafe.rs
@@ -17,12 +17,16 @@ impl<T> MyRefCell<T> {
 
     /// Borrow a `MyRef` to the inner value.
     pub fn borrow(&self) -> ::MyRef<T> {
-        self.0.lock().expect("bar")
+        self.0
+            .lock()
+            .expect("failed to acquire lock while trying to borrow")
     }
 
     /// Borrow a mutable `MyRef` to the inner value.
     pub fn borrow_mut(&self) -> ::MyRef<T> {
-        self.0.lock().expect("bar")
+        self.0
+            .lock()
+            .expect("failed to acquire lock while trying to borrow mutably")
     }
 }
 

--- a/src/threadsafe.rs
+++ b/src/threadsafe.rs
@@ -1,31 +1,33 @@
 extern crate atomic;
 
-use alloc::sync::{Arc, Mutex};
+use alloc::sync::{Arc, RwLock};
 
 pub use self::atomic::{Atomic, Ordering::Relaxed as Ordering};
-pub use alloc::sync::{Arc as MyRc, MutexGuard as MyRef, Weak as MyWeak};
+pub use alloc::sync::{
+    Arc as MyRc, RwLockReadGuard as MyRefRead, RwLockWriteGuard as MyRefWrite, Weak as MyWeak,
+};
 
 /// Thread-safe wrapper which can be used in place of a `RefCell`.
 #[derive(Debug)]
-pub struct MyRefCell<T>(Arc<Mutex<T>>);
+pub struct MyRefCell<T>(Arc<RwLock<T>>);
 
 impl<T> MyRefCell<T> {
     /// Create new wrapper object.
     pub fn new(obj: T) -> MyRefCell<T> {
-        MyRefCell(Arc::new(Mutex::new(obj)))
+        MyRefCell(Arc::new(RwLock::new(obj)))
     }
 
     /// Borrow a `MyRef` to the inner value.
-    pub fn borrow(&self) -> ::MyRef<T> {
+    pub fn borrow(&self) -> ::MyRefRead<T> {
         self.0
-            .lock()
+            .read()
             .expect("failed to acquire lock while trying to borrow")
     }
 
     /// Borrow a mutable `MyRef` to the inner value.
-    pub fn borrow_mut(&self) -> ::MyRef<T> {
+    pub fn borrow_mut(&self) -> ::MyRefWrite<T> {
         self.0
-            .lock()
+            .write()
             .expect("failed to acquire lock while trying to borrow mutably")
     }
 }

--- a/src/threadsafe.rs
+++ b/src/threadsafe.rs
@@ -2,12 +2,8 @@ extern crate atomic;
 
 use alloc::sync::{Arc, Mutex};
 
-pub use alloc::sync::{
-    Arc as MyRc, Weak as MyWeak, MutexGuard as MyRef,
-};
-pub use self::atomic::{
-    Atomic, Ordering::Relaxed as Ordering,
-};
+pub use self::atomic::{Atomic, Ordering::Relaxed as Ordering};
+pub use alloc::sync::{Arc as MyRc, MutexGuard as MyRef, Weak as MyWeak};
 
 /// Thread-safe wrapper which can be used in place of a `RefCell`.
 #[derive(Debug)]
@@ -32,9 +28,14 @@ impl<T> MyRefCell<T> {
 
 /// Thread-safe wrapper which can be used in place of a `Cell`.
 #[derive(Debug)]
-pub struct MyCell<T>(Atomic<T>) where T: Copy;
+pub struct MyCell<T>(Atomic<T>)
+where
+    T: Copy;
 
-impl<T> MyCell<T> where T: Copy {
+impl<T> MyCell<T>
+where
+    T: Copy,
+{
     /// Create new wrapper object.
     pub fn new(obj: T) -> MyCell<T> {
         MyCell(Atomic::new(obj))

--- a/test.sh
+++ b/test.sh
@@ -16,4 +16,6 @@ cd $(dirname $0)
 
 time cargo test --all ${EXTRA_ARGS}
 
+time cargo test --all --features threadsafe
+
 cd -


### PR DESCRIPTION
This PR adds a new feature `threadsafe` which switches the concurrency-relevant types to Rust's thread-safe types (`Arc`, `Mutex`, etc.). These types are computationally more expensive than the types which are used now, hence it is a feature.

If the feature is enabled this package can be used in concurrent code as well (e.g. passing `ModuleRef` or `ModuleInstance` among threads). Without this feature this is not possible, because the inner values of e.g. a `Mutex` need to implement `Send` as well.

Background:
We need this for https://github.com/paritytech/substrate/issues/2051, where we want to try out the idea of using a pool of pre-spawned runtime instances instead of a runtime cache. To achieve this, a background thread will continuously spawn new instances to the pool by cloning `ModuleInstance`. Therefore `ModuleInstance` needs to be sent to the background thread.