### PR TITLE
Update parity-wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
 wasmi-validation = { version = "0.1", path = "validation", default-features = false }
-parity-wasm = { version = "0.39", default-features = false }
+parity-wasm = { version = "0.40.1", default-features = false }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
 num-rational = "0.2.2"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/paritytech/wasmi"
 description = "Wasm code validator"
 
 [dependencies]
-parity-wasm = { version = "0.39", default-features = false }
+parity-wasm = { version = "0.40.1", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.1"


### PR DESCRIPTION
This is necessary so that the same can be done in Substrate itself.