### PR TITLE
Use a Cow for the resumable parameters

### DIFF
--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -285,7 +285,7 @@ fn resume_call_host_func() {
     let export = instance.export_by_name("test").unwrap();
     let func_instance = export.as_func().unwrap();
 
-    let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[]).unwrap();
+    let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[][..]).unwrap();
     let result = invocation.start_execution(&mut env);
     match result {
         Err(ResumableError::Trap(_)) => {}
@@ -330,7 +330,7 @@ fn resume_call_host_func_type_mismatch() {
         let export = instance.export_by_name("test").unwrap();
         let func_instance = export.as_func().unwrap();
 
-        let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[]).unwrap();
+        let mut invocation = FuncInstance::invoke_resumable(&func_instance, &[][..]).unwrap();
         let result = invocation.start_execution(&mut env);
         match result {
             Err(ResumableError::Trap(_)) => {}


### PR DESCRIPTION
Right now, if you call `invoke_resumable`, the function arguments are borrowed by the `FuncInstance`. This is very impractical, as you can't really store the `FuncInstance` in a struct for later.

This PR replaces the `&'args [RuntimeValue]` with a `Cow<'a, [RuntimeValue]>`.
This is technically a breaking change, because unfortunately the type `[RuntimeValue; N]` doesn't implement `Into<Cow<[RuntimeValue]>>`.
For example if someone was calling `invoke_resumable(&[a, b])`, it will stop compiling and they need to do `invoke_resumable(&[a, b][..])` instead.

(fwiw, this PR is for a personal project, not a paritytech thing)