### PR TITLE
Bump wabt up to 0.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2.58"
 [dev-dependencies]
 assert_matches = "1.1"
 rand = "0.4.2"
-wabt = "0.6"
+wabt = "0.9"
 
 [features]
 default = ["std"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 [dependencies]
 wasmi = { path = ".." }
 assert_matches = "1.2"
-wabt = "0.6"
+wabt = "0.9"
 
 [profile.bench]
 debug = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 wasmi = { path = ".." }
-wabt = "0.6.0"
+wabt = "0.9"
 wasmparser = "0.14.1"
 tempdir = "0.3.6"
 

--- a/hfuzz/Cargo.toml
+++ b/hfuzz/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
 honggfuzz = "=0.5.9" # Strict equal since hfuzz requires dep and cmd versions to match.
 wasmi = { path = ".." }
 tempdir = "0.3.6"
-wabt = "0.6.0"
+wabt = "0.9"

--- a/tests/spec/run.rs
+++ b/tests/spec/run.rs
@@ -18,6 +18,7 @@ fn spec_to_runtime_value(val: Value<u32, u64>) -> RuntimeValue {
         Value::I64(v) => RuntimeValue::I64(v),
         Value::F32(v) => RuntimeValue::F32(v.into()),
         Value::F64(v) => RuntimeValue::F64(v.into()),
+        Value::V128(_) => panic!("v128 is not supported"),
     }
 }
 


### PR DESCRIPTION
This fixes compilation that users can get with newer GCC versions.