### PR TITLE
Fix tiny_keccak

### DIFF
--- a/benches/wasm-kernel/src/lib.rs
+++ b/benches/wasm-kernel/src/lib.rs
@@ -33,7 +33,7 @@ pub extern "C" fn prepare_tiny_keccak() -> *const TinyKeccakTestData {
 }
 
 #[no_mangle]
-pub extern "C" fn bench_tiny_keccak(test_data: *const TinyKeccakTestData) {
+pub extern "C" fn bench_tiny_keccak(test_data: *mut TinyKeccakTestData) {
 	unsafe {
 		let mut keccak = Keccak::new_keccak256();
 		keccak.update((*test_data).data);


### PR DESCRIPTION
Nightly builds reported:

```
error[E0596]: cannot borrow `*test_data.result` as mutable, as it is behind a `*const` pointer
  --> src/lib.rs:40:19
   |
36 | pub extern "C" fn bench_tiny_keccak(test_data: *const TinyKeccakTestData) {
   |                                                ------------------------- help: consider changing this to be a mutable pointer: `*mut TinyKeccakTestData`
...
40 |         keccak.finalize((*test_data).result);
   |                         ^^^^^^^^^^^^^^^^^^^ `test_data` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
```