### PR TITLE
Avoid temporary allocations during function context initialization

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1289,13 +1289,9 @@ impl FunctionContext {
         debug_assert!(!self.is_initialized);
 
         let num_locals = locals.iter().map(|l| l.count() as usize).sum();
-        let locals = vec![Default::default(); num_locals];
 
-        // TODO: Replace with extend.
-        for local in locals {
-            value_stack
-                .push(local)
-                .map_err(|_| TrapKind::StackOverflow)?;
+        for _ in 0..num_locals {
+            value_stack.push(Default::default())?;
         }
 
         self.is_initialized = true;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1290,9 +1290,7 @@ impl FunctionContext {
 
         let num_locals = locals.iter().map(|l| l.count() as usize).sum();
 
-        for _ in 0..num_locals {
-            value_stack.push(Default::default())?;
-        }
+        value_stack.extend(num_locals)?;
 
         self.is_initialized = true;
         Ok(())
@@ -1435,6 +1433,18 @@ impl ValueStack {
             .ok_or_else(|| TrapKind::StackOverflow)?;
         *cell = value;
         self.sp += 1;
+        Ok(())
+    }
+
+    fn extend(&mut self, len: usize) -> Result<(), TrapKind> {
+        let cells = self
+            .buf
+            .get_mut(self.sp..self.sp + len)
+            .ok_or_else(|| TrapKind::StackOverflow)?;
+        for cell in cells {
+            *cell = Default::default();
+        }
+        self.sp += len;
         Ok(())
     }
 


### PR DESCRIPTION
When heap profiling an application of ours, we noticed `FunctionContext::initialize` being responsible for most allocations¹ by count and size. As the `locals` vector is consumed immediately, it seems reasonable to not allocate it at all and push the default values onto the value stack directly. A follow-up commit then removes the repeated bounds checking by extending the value stack in a single operation as suggested by the TODO comment.

¹ Meaning two orders of magnitude more than the second hottest allocation site so that this change removes 1% CPU usage on an ARM Cortex A9 target.