### PR TITLE
Render constrained system friendly

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -730,6 +730,26 @@ impl<'a> NotStartedModuleRef<'a> {
         Ok(self.instance)
     }
 
+    /// Executes `start` function (if any) and returns fully instantiated module.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if start function traps.
+    pub fn run_start_with_stack<E: Externals>(
+        self,
+        state: &mut E,
+        stack_recycler: &mut StackRecycler,
+    ) -> Result<ModuleRef, Trap> {
+        if let Some(start_fn_idx) = self.loaded_module.module().start_section() {
+            let start_func = self
+                .instance
+                .func_by_index(start_fn_idx)
+                .expect("Due to validation start function should exists");
+            FuncInstance::invoke_with_stack(&start_func, &[], state, stack_recycler)?;
+        }
+        Ok(self.instance)
+    }
+
     /// Returns fully instantiated module without running `start` function.
     ///
     /// # Panics


### PR DESCRIPTION
This is to allow building and running wasmi on constrained target such as microcontroller.
This requires the ability to build without std.
