### PR TITLE
Obviate need for a nightly compiler when building for no_std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
 wasmi-validation = { version = "0.2", path = "validation", default-features = false }
-parity-wasm = { version = "0.40.1", default-features = false }
+parity-wasm = { version = "0.41.0", default-features = false }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
 num-rational = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ wasmi = {
 }
 ```
 
-The `core` feature requires the `core` and `alloc` libraries and a nightly compiler.
-Also, code related to `std::error` is disabled.
+When the `core` feature is enabled, code related to `std::error` is disabled.
 
 Floating point operations in `no_std` use [`libm`](https://crates.io/crates/libm), which sometimes panics in debug mode (https://github.com/japaric/libm/issues/4).
 So make sure to either use release builds or avoid WASM with floating point operations, for example by using [`deny_floating_point`](https://docs.rs/wasmi/0.4.0/wasmi/struct.Module.html#method.deny_floating_point).

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/paritytech/wasmi"
 description = "Wasm code validator"
 
 [dependencies]
-parity-wasm = { version = "0.40.1", default-features = false }
+parity-wasm = { version = "0.41.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.1"


### PR DESCRIPTION
Changes:

- Bump parity-wasm version to "0.41"; parity-wasm "0.41" no longer requires
  nightly for no_std
- Edit clause in readme to show nightly is no longer needed.