### PR TITLE
Bump versions for wasmi and wasmi-validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
-wasmi-validation = { version = "0.2", path = "validation", default-features = false }
+wasmi-validation = { version = "0.3", path = "validation", default-features = false }
 parity-wasm = { version = "0.41.0", default-features = false }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi-validation"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Bump versions for wasmi and wasmi-validation in preparation for cargo publish.

Publishing a new cargo version will allow downstream crates to build in no_std
mode on rust stable (a recent change).

If someone with write access to https://crates.io/crates/wasmi could run cargo publish to update `wasmi` and `wasmi-validation` it would be appreciated. (you'll need to `cargo publish` `wasmi-validation` first because `wasmi` depends on it)