### PR TITLE
Fix wasmi no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
 
 install:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then rustup target add wasm32-unknown-unknown; fi
+- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo install cargo-no-std-check; fi
 - if [ -n "$TARGET" ]; then rustup target add "$TARGET" && sudo apt-get install --yes qemu-user-static; fi
 - if [ "$TARGET" == "armv7-unknown-linux-gnueabihf" ]; then sudo apt-get install --yes crossbuild-essential-armhf && export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf; fi
 - rustup component add rustfmt
@@ -25,7 +26,7 @@ script:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo check --tests --manifest-path=fuzz/Cargo.toml; fi
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo check --benches --manifest-path=benches/Cargo.toml; fi
 # Make sure `no_std` version checks.
-- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo +nightly check --no-default-features --features core; fi
+- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo no-std-check --no-default-features --features core; fi
 # Check that `vec_memory` feature works.
 - cargo check --features vec_memory
 - travis_wait 60 ./test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ wasmi-validation = { version = "0.3", path = "validation", default-features = fa
 parity-wasm = { version = "0.41.0", default-features = false }
 memory_units = "0.3.0"
 libm = { version = "0.1.2", optional = true }
-num-rational = "0.2.2"
-num-traits = "0.2.8"
+num-rational = { version = "0.2.2", default-features = false }
+num-traits = { version = "0.2.8", default-features = false }
 libc = "0.2.58"
 errno = { version = "0.2.4", optional = true }
 
@@ -32,6 +32,7 @@ std = [
     "parity-wasm/std",
     "wasmi-validation/std",
     "num-rational/std",
+    "num-rational/bigint-std",
     "num-traits/std"
 ]
 # Enable for no_std support

--- a/src/nan_preserving_float.rs
+++ b/src/nan_preserving_float.rs
@@ -2,6 +2,7 @@
 
 use core::cmp::{Ordering, PartialEq, PartialOrd};
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use num_traits::float::FloatCore;
 
 macro_rules! impl_binop {
     ($for:ident, $is:ident, $op:ident, $func_name:ident) => {
@@ -63,7 +64,7 @@ macro_rules! float {
             }
 
             pub fn fract(self) -> Self {
-                self.to_float().fract().into()
+                FloatCore::fract(self.to_float()).into()
             }
 
             pub fn min(self, other: Self) -> Self {


### PR DESCRIPTION
Two issues are fixed:
 1. `num-bigint 0.2` requires `std`, and is used to perform float to int conversions since #186. This patch disables this change in no_std environments. This change can be reverted once `num-bigint 0.3` is released, which will support no_std.
 2. The `f{32,64}::fract` method is currently not implemented by `core`. This patch uses the no_std supporting implementation from `num-trait`'s `FloatCore` trait.

Travis tests were also updated to check the crate with `cargo no-std-check` which should fail the build if new std dependencies are added in the future. 