### PR TITLE
added Error::try_into_host_error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,25 @@ impl Error {
             _ => None,
         }
     }
+
+    /// Returns [`HostError`] if this `Error` represents some host error, otherwise returns the original error.
+    ///
+    /// I.e. if this error have variant [`Host`] or [`Trap`][`Trap`] with [host][`TrapKind::Host`] error.
+    ///
+    /// [`HostError`]: trait.HostError.html
+    /// [`Host`]: enum.Error.html#variant.Host
+    /// [`Trap`]: enum.Error.html#variant.Trap
+    /// [`TrapKind::Host`]: enum.TrapKind.html#variant.Host
+    pub fn try_into_host_error(self) -> Result<Box<dyn host::HostError>, Self> {
+        match self {
+            Error::Host(host_err) => Ok(host_err),
+            Error::Trap(trap) => match trap.into_kind() {
+                TrapKind::Host(host_err) => Ok(host_err),
+                other => Err(Error::Trap(Trap::new(other))),
+            },
+            other => Err(other),
+        }
+    }
 }
 
 impl Into<String> for Error {


### PR DESCRIPTION
PR #234 was just merged, and i realized that i'd also need access to the original error if it was not a host error.
I'm adding a `try_into_host_error` method for the `Error` type which will either unwrap the host error, or return the original error unmodified.

I'll use this space to also thank you for merging my previous PR :)