### PR TITLE
added downcast functionality to Box<dyn HostError>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num-rational = { version = "0.2.2", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.58", optional = true}
 errno = { version = "0.2.4", optional = true }
+downcast-rs = { version = "1.2.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.1"
@@ -35,7 +36,8 @@ std = [
     "num-rational/std",
     "num-rational/bigint-std",
     "num-traits/std",
-    "libc"
+    "libc",
+    "downcast-rs/std"
 ]
 # Enable for no_std support
 core = [

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,7 +1,7 @@
 use crate::value::{FromRuntimeValue, RuntimeValue};
 use crate::{Trap, TrapKind};
 
-use downcast_rs::{DowncastSync, impl_downcast};
+use downcast_rs::{impl_downcast, DowncastSync};
 
 /// Wrapper around slice of [`RuntimeValue`] for using it
 /// as an argument list conveniently.

--- a/src/host.rs
+++ b/src/host.rs
@@ -76,6 +76,10 @@ impl<'a> RuntimeArgs<'a> {
 /// It should be useful for representing custom traps,
 /// troubles at instantiation time or other host specific conditions.
 ///
+/// Types that implement this trait can automatically be converted to `wasmi::Error` and `wasmi::Trap`
+/// and will be represented as a boxed `HostError`. You can then use the various methods on `wasmi::Error`
+/// to get your custom error type back
+///
 /// # Examples
 ///
 /// ```rust
@@ -97,7 +101,8 @@ impl<'a> RuntimeArgs<'a> {
 ///
 /// fn failable_fn() -> Result<(), Error> {
 ///     let my_error = MyError { code: 1312 };
-///     Err(Error::Host(Box::new(my_error)))
+///     // Note how you can just convert your errors to `wasmi::Error`
+///     Err(my_error.into())
 /// }
 ///
 /// // Get a reference to the concrete error

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,7 @@
 use crate::value::{FromRuntimeValue, RuntimeValue};
 use crate::{Trap, TrapKind};
-use core::any::TypeId;
+
+use downcast_rs::{DowncastSync, impl_downcast};
 
 /// Wrapper around slice of [`RuntimeValue`] for using it
 /// as an argument list conveniently.
@@ -99,41 +100,27 @@ impl<'a> RuntimeArgs<'a> {
 ///     Err(Error::Host(Box::new(my_error)))
 /// }
 ///
+/// // Get a reference to the concrete error
 /// match failable_fn() {
 ///     Err(Error::Host(host_error)) => {
-///         let my_error = host_error.downcast_ref::<MyError>().unwrap();
+///         let my_error: &MyError = host_error.downcast_ref::<MyError>().unwrap();
 ///         assert_eq!(my_error.code, 1312);
 ///     }
 ///     _ => panic!(),
 /// }
+///
+/// // get the concrete error itself
+/// match failable_fn() {
+///     Err(err) => {
+///         let my_error: Box<MyError> = err.try_into_host_error().unwrap().downcast::<MyError>().unwrap();
+///         assert_eq!(my_error.code, 1312);
+///     }
+///     _ => panic!(),
+/// }
+///
 /// ```
-pub trait HostError: 'static + ::core::fmt::Display + ::core::fmt::Debug + Send + Sync {
-    #[doc(hidden)]
-    fn __private_get_type_id__(&self) -> TypeId {
-        TypeId::of::<Self>()
-    }
-}
-
-impl dyn HostError {
-    /// Attempt to downcast this `HostError` to a concrete type by reference.
-    pub fn downcast_ref<T: HostError>(&self) -> Option<&T> {
-        if self.__private_get_type_id__() == TypeId::of::<T>() {
-            unsafe { Some(&*(self as *const dyn HostError as *const T)) }
-        } else {
-            None
-        }
-    }
-
-    /// Attempt to downcast this `HostError` to a concrete type by mutable
-    /// reference.
-    pub fn downcast_mut<T: HostError>(&mut self) -> Option<&mut T> {
-        if self.__private_get_type_id__() == TypeId::of::<T>() {
-            unsafe { Some(&mut *(self as *mut dyn HostError as *mut T)) }
-        } else {
-            None
-        }
-    }
-}
+pub trait HostError: 'static + ::core::fmt::Display + ::core::fmt::Debug + DowncastSync {}
+impl_downcast!(HostError);
 
 /// Trait that allows to implement host functions.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,10 +289,7 @@ impl Error {
     pub fn as_host_error(&self) -> Option<&dyn host::HostError> {
         match self {
             Error::Host(host_err) => Some(&**host_err),
-            Error::Trap(trap) => match trap.kind() {
-                TrapKind::Host(host_err) => Some(&**host_err),
-                _ => None,
-            },
+            Error::Trap(Trap { kind: TrapKind::Host(host_err) }) => Some(&**host_err),
             _ => None,
         }
     }
@@ -308,10 +305,7 @@ impl Error {
     pub fn into_host_error(self) -> Option<Box<dyn host::HostError>> {
         match self {
             Error::Host(host_err) => Some(host_err),
-            Error::Trap(trap) => match trap.into_kind() {
-                TrapKind::Host(host_err) => Some(host_err),
-                _ => None,
-            },
+            Error::Trap(Trap { kind: TrapKind::Host(host_err) }) => Some(host_err),
             _ => None,
         }
     }
@@ -327,10 +321,7 @@ impl Error {
     pub fn try_into_host_error(self) -> Result<Box<dyn host::HostError>, Self> {
         match self {
             Error::Host(host_err) => Ok(host_err),
-            Error::Trap(trap) => match trap.into_kind() {
-                TrapKind::Host(host_err) => Ok(host_err),
-                other => Err(Error::Trap(Trap::new(other))),
-            },
+            Error::Trap(Trap { kind: TrapKind::Host(host_err) }) => Ok(host_err),
             other => Err(other),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,9 @@ impl Error {
     pub fn as_host_error(&self) -> Option<&dyn host::HostError> {
         match self {
             Error::Host(host_err) => Some(&**host_err),
-            Error::Trap(Trap { kind: TrapKind::Host(host_err) }) => Some(&**host_err),
+            Error::Trap(Trap {
+                kind: TrapKind::Host(host_err),
+            }) => Some(&**host_err),
             _ => None,
         }
     }
@@ -305,7 +307,9 @@ impl Error {
     pub fn into_host_error(self) -> Option<Box<dyn host::HostError>> {
         match self {
             Error::Host(host_err) => Some(host_err),
-            Error::Trap(Trap { kind: TrapKind::Host(host_err) }) => Some(host_err),
+            Error::Trap(Trap {
+                kind: TrapKind::Host(host_err),
+            }) => Some(host_err),
             _ => None,
         }
     }
@@ -321,7 +325,9 @@ impl Error {
     pub fn try_into_host_error(self) -> Result<Box<dyn host::HostError>, Self> {
         match self {
             Error::Host(host_err) => Ok(host_err),
-            Error::Trap(Trap { kind: TrapKind::Host(host_err) }) => Ok(host_err),
+            Error::Trap(Trap {
+                kind: TrapKind::Host(host_err),
+            }) => Ok(host_err),
             other => Err(other),
         }
     }


### PR DESCRIPTION
@pepyakin Sorry for so many small PRs one after the other, this time I made sure the code does what i need it to, and added a documentation test.
The last missing piece was adding by-value downcasting functionality (as opposed to the by-reference downcast). I use the [`downcast-rs`](https://crates.io/crates/downcast-rs) crate here which provides a handy shortcut to implementing this but there's no magic happening there, as you can see in its docs. It also supports no_std as you can see.
Now I can write code like this:
```rust
let wasmi_error = /* Something that returns an instance of wasmi::Error */;
match wasmi_error.try_into_host_error() {
  // host_error: Box<dyn HostError>
  Ok(host_error) => match host_error.downcast::<MyError>() {
    Ok(my_error) => /* my_error is a Box<MyError>. I can get my error object by unboxing it */,
    Err(host_error) => /* I got the host error back */,
}
  Err(wasmi_error) => /* I got the original error object back */,
}
```