### PR TITLE
Bump validation version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
-validation = { package = "wasmi-validation", version = "0.3", path = "validation", default-features = false }
+validation = { package = "wasmi-validation", version = "0.4", path = "validation", default-features = false }
 parity-wasm = { version = "0.42.0", default-features = false }
 memory_units = "0.3.0"
 libm = { version = "0.2.1", optional = true }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi-validation"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
The major bump is necessary because it exposes parity-wasm in it's public interface and that got a major bump.

CI is already failing in master. Unrelated to this PR.