### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
We need to bump the major version number because `parity-wasm` was bumped and it is used in a public interface.