### PR TITLE
Loadable functions support

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -401,13 +401,6 @@ pub struct FuncBody {
 
     /// The actual code of the function.
     ///
-    /// Can be empty. See [`crate::runner::Loader`] for details.
+    /// Can be loaded on-demand. See [`crate::runner::Loader`] for details.
     pub code: RefCell<isa::Instructions>,
 }
-
-impl FuncBody {
-    pub(crate) fn patch(&self, chunk: InstructionChunk) {
-        self.code.borrow_mut().patch_region(chunk.start_offset as usize, &chunk.instructions);
-    }
-}
-

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,7 +1,7 @@
 use crate::host::Externals;
 use crate::isa;
 use crate::module::ModuleInstance;
-use crate::runner::{Interpreter, InterpreterState, Loader, StackRecycler, check_function_args};
+use crate::runner::{check_function_args, Interpreter, InterpreterState, Loader, StackRecycler};
 use crate::types::ValueType;
 use crate::value::RuntimeValue;
 use crate::{Signature, Trap};
@@ -10,8 +10,8 @@ use alloc::{
     rc::{Rc, Weak},
     vec::Vec,
 };
-use core::fmt;
 use core::cell::RefCell;
+use core::fmt;
 use parity_wasm::elements::Local;
 
 /// Reference to a function (See [`FuncInstance`] for details).
@@ -124,20 +124,22 @@ impl FuncInstance {
 
     pub(crate) fn get_body_or_load(&self, loader: &impl Loader) -> Option<Rc<FuncBody>> {
         match *self.as_internal() {
-            FuncInstanceInternal::Internal { ref body, function_index, .. } => {
+            FuncInstanceInternal::Internal {
+                ref body,
+                function_index,
+                ..
+            } => {
                 let slot = &mut *body.borrow_mut();
 
                 match slot {
                     Some(body) => Some(body.clone()),
 
                     None => {
-                        let body = loader
-                            .load_function_body(function_index)
-                            .map(Rc::new)?;
+                        let body = loader.load_function_body(function_index).map(Rc::new)?;
 
                         *slot = Some(body.clone());
                         Some(body)
-                    },
+                    }
                 }
             }
 

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,7 +1,7 @@
 use crate::host::Externals;
 use crate::isa;
 use crate::module::ModuleInstance;
-use crate::runner::{InstructionChunk, Interpreter, InterpreterState, Loader, StackRecycler, check_function_args};
+use crate::runner::{Interpreter, InterpreterState, Loader, StackRecycler, check_function_args};
 use crate::types::ValueType;
 use crate::value::RuntimeValue;
 use crate::{Signature, Trap};
@@ -11,7 +11,7 @@ use alloc::{
     vec::Vec,
 };
 use core::fmt;
-use std::cell::RefCell;
+use core::cell::RefCell;
 use parity_wasm::elements::Local;
 
 /// Reference to a function (See [`FuncInstance`] for details).

--- a/src/func.rs
+++ b/src/func.rs
@@ -11,7 +11,6 @@ use alloc::{
     vec::Vec,
 };
 use core::fmt;
-use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use parity_wasm::elements::Local;
 
@@ -394,9 +393,15 @@ impl<'args> FuncInvocation<'args> {
     }
 }
 
+/// Function body containing compiled instructions suitable for immediate interpretation
 #[derive(Clone, Debug)]
 pub struct FuncBody {
+    /// Definition of locals that should be allocated during function execution
     pub locals: Vec<Local>,
+
+    /// The actual code of the function.
+    ///
+    /// Can be empty. See [`crate::runner::Loader`] for details.
     pub code: RefCell<isa::Instructions>,
 }
 

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,7 +1,7 @@
 use crate::host::Externals;
 use crate::isa;
 use crate::module::ModuleInstance;
-use crate::runner::{check_function_args, Interpreter, InterpreterState, StackRecycler, Loader};
+use crate::runner::{InstructionChunk, Interpreter, InterpreterState, Loader, StackRecycler, check_function_args};
 use crate::types::ValueType;
 use crate::value::RuntimeValue;
 use crate::{Signature, Trap};
@@ -11,7 +11,7 @@ use alloc::{
     vec::Vec,
 };
 use core::fmt;
-use std::borrow::Borrow;
+use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use parity_wasm::elements::Local;
 
@@ -397,5 +397,12 @@ impl<'args> FuncInvocation<'args> {
 #[derive(Clone, Debug)]
 pub struct FuncBody {
     pub locals: Vec<Local>,
-    pub code: isa::Instructions,
+    pub code: RefCell<isa::Instructions>,
 }
+
+impl FuncBody {
+    pub(crate) fn patch(&self, chunk: InstructionChunk) {
+        self.code.borrow_mut().patch_region(chunk.start_offset as usize, &chunk.instructions);
+    }
+}
+

--- a/src/isa.rs
+++ b/src/isa.rs
@@ -354,8 +354,8 @@ pub enum Instruction<'a> {
 /// When returning instructions we convert to `Instruction`, whose `BrTable` variant internally
 /// borrows the list of instructions and returns targets by reading it.
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::upper_case_acronyms)]
-pub(crate) enum InstructionInternal {
+#[allow(clippy::upper_case_acronyms, missing_docs)]
+pub enum InstructionInternal {
     /// Bogus instruction that marks the not-yet-loaded instruction region within the function body.
     /// Should not appear inside the loaded section.
     NotLoaded,
@@ -551,6 +551,10 @@ pub struct Instructions {
 }
 
 impl Instructions {
+    pub fn instructions(&self) -> &[InstructionInternal] {
+        &self.vec
+    }
+
     pub fn with_capacity(capacity: usize) -> Self {
         Instructions {
             vec: Vec::with_capacity(capacity),

--- a/src/isa.rs
+++ b/src/isa.rs
@@ -366,7 +366,9 @@ pub enum InstructionInternal {
     Br(Target),
     BrIfEqz(Target),
     BrIfNez(Target),
-    BrTable { count: u32 },
+    BrTable {
+        count: u32,
+    },
     BrTableTarget(Target),
 
     Unreachable,
@@ -585,7 +587,7 @@ impl Instructions {
     }
 
     pub fn patch_region(&mut self, offset: usize, patch: &Instructions) {
-        self.vec[offset .. offset + patch.vec.len()].copy_from_slice(&patch.vec);
+        self.vec[offset..offset + patch.vec.len()].copy_from_slice(&patch.vec);
     }
 
     pub fn iterate_from(&self, position: u32) -> InstructionIter {
@@ -617,7 +619,7 @@ impl<'a> Iterator for InstructionIter<'a> {
 
         let out = match *internal {
             InstructionInternal::NotLoaded => Instruction::NotLoaded,
-            
+
             InstructionInternal::GetLocal(x) => Instruction::GetLocal(x),
             InstructionInternal::SetLocal(x) => Instruction::SetLocal(x),
             InstructionInternal::TeeLocal(x) => Instruction::TeeLocal(x),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,17 +435,19 @@ mod value;
 #[cfg(test)]
 mod tests;
 
-pub use self::func::{FuncInstance, FuncInvocation, FuncRef, ResumableError, FuncBody};
+pub use self::func::{FuncBody, FuncInstance, FuncInvocation, FuncRef, ResumableError};
 pub use self::global::{GlobalInstance, GlobalRef};
 pub use self::host::{Externals, HostError, NopExternals, RuntimeArgs};
 pub use self::imports::{ImportResolver, ImportsBuilder, ModuleImportResolver};
+pub use self::isa::InstructionInternal;
 pub use self::memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
 pub use self::module::{ExternVal, ModuleInstance, ModuleRef, NotStartedModuleRef};
-pub use self::runner::{StackRecycler, Loader, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT};
+pub use self::runner::{
+    Loader, StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT,
+};
 pub use self::table::{TableInstance, TableRef};
 pub use self::types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType};
 pub use self::value::{Error as ValueError, FromRuntimeValue, LittleEndianConvert, RuntimeValue};
-pub use self::isa::InstructionInternal;
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,16 +435,17 @@ mod value;
 #[cfg(test)]
 mod tests;
 
-pub use self::func::{FuncInstance, FuncInvocation, FuncRef, ResumableError};
+pub use self::func::{FuncInstance, FuncInvocation, FuncRef, ResumableError, FuncBody};
 pub use self::global::{GlobalInstance, GlobalRef};
 pub use self::host::{Externals, HostError, NopExternals, RuntimeArgs};
 pub use self::imports::{ImportResolver, ImportsBuilder, ModuleImportResolver};
 pub use self::memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
 pub use self::module::{ExternVal, ModuleInstance, ModuleRef, NotStartedModuleRef};
-pub use self::runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT};
+pub use self::runner::{StackRecycler, Loader, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT};
 pub use self::table::{TableInstance, TableRef};
 pub use self::types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType};
 pub use self::value::{Error as ValueError, FromRuntimeValue, LittleEndianConvert, RuntimeValue};
+pub use self::isa::InstructionInternal;
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/module.rs
+++ b/src/module.rs
@@ -324,7 +324,7 @@ impl ModuleInstance {
                             .get(index)
                             .map(|code| FuncBody {
                                 locals,
-                                code: code.clone(),
+                                code: RefCell::new(code.clone()),
                             })
                     });
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -318,18 +318,19 @@ impl ModuleInstance {
                     .expect("Due to validation type should exists");
 
                 let locals = bodies.get(index).map(|b| b.locals().to_vec());
-                let body =
-                    locals.and_then(|locals| {
-                        code
-                            .get(index)
-                            .map(|code| FuncBody {
-                                locals,
-                                code: RefCell::new(code.clone()),
-                            })
-                    });
+                let body = locals.and_then(|locals| {
+                    code.get(index).map(|code| FuncBody {
+                        locals,
+                        code: RefCell::new(code.clone()),
+                    })
+                });
 
-                let func_instance =
-                    FuncInstance::alloc_internal(Rc::downgrade(&instance.0), signature, body, index);
+                let func_instance = FuncInstance::alloc_internal(
+                    Rc::downgrade(&instance.0),
+                    signature,
+                    body,
+                    index,
+                );
                 instance.push_func(func_instance);
             }
         }
@@ -648,7 +649,8 @@ impl ModuleInstance {
     ) -> Result<Option<RuntimeValue>, Error> {
         let func_instance = self.func_by_name(func_name)?;
 
-        FuncInstance::invoke_with_loader(&func_instance, args, externals, loader).map_err(Error::Trap)
+        FuncInstance::invoke_with_loader(&func_instance, args, externals, loader)
+            .map_err(Error::Trap)
     }
 
     /// Invoke exported function by a name using recycled stacks.

--- a/src/module.rs
+++ b/src/module.rs
@@ -324,7 +324,7 @@ impl ModuleInstance {
                     code,
                 };
                 let func_instance =
-                    FuncInstance::alloc_internal(Rc::downgrade(&instance.0), signature, func_body);
+                    FuncInstance::alloc_internal(Rc::downgrade(&instance.0), signature, None, index);
                 instance.push_func(func_instance);
             }
         }

--- a/src/module.rs
+++ b/src/module.rs
@@ -4,7 +4,7 @@ use crate::host::Externals;
 use crate::imports::ImportResolver;
 use crate::memory::MemoryRef;
 use crate::memory_units::Pages;
-use crate::runner::StackRecycler;
+use crate::runner::{Loader, StackRecycler};
 use crate::table::TableRef;
 use crate::types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor};
 use crate::{Error, MemoryInstance, Module, RuntimeValue, Signature, TableInstance, Trap};
@@ -631,6 +631,19 @@ impl ModuleInstance {
         let func_instance = self.func_by_name(func_name)?;
 
         FuncInstance::invoke(&func_instance, args, externals).map_err(Error::Trap)
+    }
+
+    /// Invoke export function with loader
+    pub fn invoke_export_with_loader<E: Externals, L: Loader>(
+        &self,
+        func_name: &str,
+        args: &[RuntimeValue],
+        externals: &mut E,
+        loader: &L,
+    ) -> Result<Option<RuntimeValue>, Error> {
+        let func_instance = self.func_by_name(func_name)?;
+
+        FuncInstance::invoke_with_loader(&func_instance, args, externals, loader).map_err(Error::Trap)
     }
 
     /// Invoke exported function by a name using recycled stacks.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -404,8 +404,8 @@ impl Interpreter {
                     break;
                 }
                 InstructionOutcome::LoadInstruction => {
-                    let (index, _body) = match function_context.function.as_internal() {
-                        FuncInstanceInternal::Internal { function_index, body, .. } => (*function_index, body),
+                    let index = match function_context.function.as_internal() {
+                        FuncInstanceInternal::Internal { function_index, .. } => *function_index,
                         FuncInstanceInternal::Host { .. } => unreachable!("must be internal"),
                     };
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -183,7 +183,11 @@ pub trait Loader {
     /// Loader does not put any restrictions on the size of the loaded
     /// chunk or its starting offset. The only requirement is that the
     /// chunk must contain an instruction that maps to the specified offset.
-    fn load_instruction_chunk(&self, function_index: usize, offset: u32) -> Option<InstructionChunk>;
+    fn load_instruction_chunk(
+        &self,
+        function_index: usize,
+        offset: u32,
+    ) -> Option<InstructionChunk>;
 }
 
 // Dummy loader that always fails
@@ -192,7 +196,11 @@ impl Loader for () {
         None
     }
 
-    fn load_instruction_chunk(&self, _function_index: usize, _offset: u32) -> Option<InstructionChunk> {
+    fn load_instruction_chunk(
+        &self,
+        _function_index: usize,
+        _offset: u32,
+    ) -> Option<InstructionChunk> {
         None
     }
 }
@@ -260,7 +268,7 @@ impl Interpreter {
         Ok(opt_return_value)
     }
 
-    pub fn resume_execution<'a, E: Externals + 'a, >(
+    pub fn resume_execution<'a, E: Externals + 'a>(
         &mut self,
         return_val: Option<RuntimeValue>,
         externals: &'a mut E,
@@ -412,7 +420,9 @@ impl Interpreter {
                     // Store current position to reset the execution later
                     function_context.position = iter.position() - 1;
 
-                    let chunk = loader.load_instruction_chunk(index, function_context.position).ok_or(TrapKind::Unreachable)?;
+                    let chunk = loader
+                        .load_instruction_chunk(index, function_context.position)
+                        .ok_or(TrapKind::Unreachable)?;
                     instructions.patch_region(chunk.start_offset as usize, &chunk.instructions);
 
                     // dbg!(function_context.position, &chunk.instructions);

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -119,6 +119,7 @@ fn loader_on_inc_i32() {
         fn load_function_body(&self, index: usize) -> Option<crate::func::FuncBody> {
             println!("Loading function body index {}", index);
 
+            // In a real setup these should be loaded from an external resource
             let locals = self.bodies.get(index)?.locals().to_vec();
             let code = self.code_map.get(index)?.clone();
 

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -128,6 +128,10 @@ fn loader_on_inc_i32() {
                 code,
             })
         }
+
+        fn load_instruction_region(&self, function_index: usize, offset: u32) -> Option<runner::InstructionRegion> {
+            None
+        }
     }
 
     let retval = instance

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -3,7 +3,11 @@ extern crate std;
 
 use crate::isa::Instructions;
 use crate::memory_units::Pages;
-use crate::{Error, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef, ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver, ModuleInstance, NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef, runner};
+use crate::{
+    runner, Error, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef, ImportsBuilder,
+    MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver, ModuleInstance,
+    NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef,
+};
 use alloc::vec::Vec;
 use std::fs::File;
 
@@ -126,7 +130,7 @@ fn loader_on_inc_i32() {
             // Allocating body filled with placeholder instructions to be patched later
             let len = code.instructions().len();
             let mut stub = Instructions::with_capacity(len);
-            for _ in 0 .. len {
+            for _ in 0..len {
                 stub.push(crate::InstructionInternal::NotLoaded);
             }
 
@@ -136,8 +140,15 @@ fn loader_on_inc_i32() {
             })
         }
 
-        fn load_instruction_chunk(&self, function_index: usize, offset: u32) -> Option<runner::InstructionChunk> {
-            println!("Loading instruction chunk for function index {} at offset {}", function_index, offset);
+        fn load_instruction_chunk(
+            &self,
+            function_index: usize,
+            offset: u32,
+        ) -> Option<runner::InstructionChunk> {
+            println!(
+                "Loading instruction chunk for function index {} at offset {}",
+                function_index, offset
+            );
 
             // In a real setup these should be loaded from an external resource
             let code = self.code_map.get(function_index)?;
@@ -155,10 +166,15 @@ fn loader_on_inc_i32() {
     }
 
     let retval = instance
-        .invoke_export_with_loader(FUNCTION_NAME, args, &mut NopExternals, &Loader {
-            bodies: module.module.code_section().unwrap().bodies(),
-            code_map,
-        })
+        .invoke_export_with_loader(
+            FUNCTION_NAME,
+            args,
+            &mut NopExternals,
+            &Loader {
+                bodies: module.module.code_section().unwrap().bodies(),
+                code_map,
+            },
+        )
         .expect("");
     assert_eq!(exp_retval, retval);
 }

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -121,9 +121,14 @@ fn loader_on_inc_i32() {
 
             // In a real setup these should be loaded from an external resource
             let locals = self.bodies.get(index)?.locals().to_vec();
+            let code = self.code_map.get(index)?;
 
-            let mut stub = Instructions::with_capacity(1);
-            stub.push(crate::InstructionInternal::NotLoaded);
+            // Allocating body filled with placeholder instructions to be patched later
+            let len = code.instructions().len();
+            let mut stub = Instructions::with_capacity(len);
+            for _ in 0 .. len {
+                stub.push(crate::InstructionInternal::NotLoaded);
+            }
 
             Some(crate::func::FuncBody {
                 locals,
@@ -137,6 +142,8 @@ fn loader_on_inc_i32() {
             // In a real setup these should be loaded from an external resource
             let code = self.code_map.get(function_index)?;
 
+            // Here we load instructions one at a time, just for fun.
+            // More practical approach would be to load several instructions at once.
             let mut chunk = Instructions::with_capacity(1);
             chunk.push(code.instructions()[offset as usize]);
 

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -121,16 +121,29 @@ fn loader_on_inc_i32() {
 
             // In a real setup these should be loaded from an external resource
             let locals = self.bodies.get(index)?.locals().to_vec();
-            let code = self.code_map.get(index)?.clone();
+
+            let mut stub = Instructions::with_capacity(1);
+            stub.push(crate::InstructionInternal::NotLoaded);
 
             Some(crate::func::FuncBody {
                 locals,
-                code,
+                code: std::cell::RefCell::new(stub),
             })
         }
 
-        fn load_instruction_region(&self, function_index: usize, offset: u32) -> Option<runner::InstructionRegion> {
-            None
+        fn load_instruction_chunk(&self, function_index: usize, offset: u32) -> Option<runner::InstructionChunk> {
+            println!("Loading instruction chunk for function index {} at offset {}", function_index, offset);
+
+            // In a real setup these should be loaded from an external resource
+            let code = self.code_map.get(function_index)?;
+
+            let mut chunk = Instructions::with_capacity(1);
+            chunk.push(code.instructions()[offset as usize]);
+
+            Some(runner::InstructionChunk {
+                start_offset: offset,
+                instructions: chunk,
+            })
         }
     }
 


### PR DESCRIPTION
This PR is a proof-of-concept implementation of loadable functions. It is designed specifically with https://github.com/paritytech/substrate/issues/9354 in mind.

The main idea is to allow to instantiate a module where some (or all) of function bodies are absent. When VM hits such a function, it calls back to a provided implementation of a `Loader` trait to load the function body, and then resumes the execution of a function as if the function body was always there.

That way it would be possible to pass only the functions that are actually needed to dispatch a particular call, effectively reducing the size of PoV.

Further work may include a support for chunked function execution, where function body is loaded chunk by chunk depending on the offsets that were actually hit during the function execution.