### PR TITLE
Fix Cargo.toml no_std example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,10 @@ cargo test
 This crate supports `no_std` environments.
 Enable the `core` feature and disable default features:
 ```toml
-[dependencies]
-wasmi = {
-	version = "*",
-	default-features = false,
-	features = "core"
-}
+[dependencies.wasmi]
+version = "*"
+default-features = false
+features = ["core"]
 ```
 
 When the `core` feature is enabled, code related to `std::error` is disabled.


### PR DESCRIPTION
Same changes as https://github.com/paritytech/wasmi/pull/258, just on current master to give CI a chance.