### PR TITLE
Correct `no_std` import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ This crate supports `no_std` environments.
 Enable the `core` feature and disable default features:
 ```toml
 [dependencies]
-wasmi = {
-	version = "*",
-	default-features = false,
-	features = "core"
-}
+wasmi = { version = "*", default-features = false, features = ["core"] }
 ```
 
 When the `core` feature is enabled, code related to `std::error` is disabled.


### PR DESCRIPTION
The current example string for defining wasmi in a `Cargo.toml` isn't working. Generally import isn't allowed to span multiple lines and the `features` attribute needs to be a list: `["core"]`.