### PR TITLE
Remove core crate feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --no-default-features --features core
+          args: --no-default-features --features vec_memory
 
   test:
     name: Test
@@ -54,6 +54,12 @@ jobs:
         with:
           command: test
           args: --release
+      - uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: '--cfg debug_assertions'
+        with:
+          command: test
+          args: --release --features vec_memory
 
   fmt:
     name: Formatting
@@ -101,4 +107,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features core -- -D warnings
+          args: --no-default-features --features vec_memory -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: check --features virtual_memory
+          command: check
+          args: --features virtual_memory
 
   check_no_std:
     name: Check (no_std)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: check --features virtual_memory
 
   check_no_std:
     name: Check (no_std)
@@ -33,8 +33,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --no-default-features --features vec_memory
+          command: check
+          args: --no-default-features
 
   test:
     name: Test
@@ -59,7 +59,7 @@ jobs:
           RUSTFLAGS: '--cfg debug_assertions'
         with:
           command: test
-          args: --release --features vec_memory
+          args: --release --features virtual_memory
 
   fmt:
     name: Formatting
@@ -92,6 +92,10 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features virtual_memory -- -D warnings
 
   clippy_no_std:
     name: Clippy (no_std)
@@ -107,4 +111,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features vec_memory -- -D warnings
+          args: --no-default-features -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ script:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo check --benches --manifest-path=benches/Cargo.toml; fi
 # Make sure `no_std` version checks.
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo no-std-check --no-default-features --features core; fi
-# Check that `vec_memory` feature works.
-- cargo check --features vec_memory
+# Check that `virtual_memory` feature works.
+- cargo check --features virtual_memory
 - travis_wait 60 ./test.sh
 - TEST_NO_STD=1 travis_wait 60 ./test.sh
 - ./doc.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ std = [
 core = [
     # `core` doesn't support mmaped memory
     "vec_memory",
-    "validation/core",
     "libm"
 ]
 # Enforce using the linear memory implementation based on `Vec` instead of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ memory_units = "0.3.0"
 libm = "0.2.1"
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint"] }
 num-traits = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.58",  optional = true }
+libc = { version = "0.2.58", optional = true }
 errno = { version = "0.2.4", optional = true }
 downcast-rs = { version = "1.2.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ memory_units = "0.3.0"
 libm = "0.2.1"
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint"] }
 num-traits = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.58", default-features = false, optional = true }
+libc = { version = "0.2.58",  optional = true }
 errno = { version = "0.2.4", optional = true }
 downcast-rs = { version = "1.2.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ memory_units = "0.3.0"
 libm = "0.2.1"
 num-rational = { version = "0.2.2", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.58", optional = true}
+libc = { version = "0.2.58", default-features = false }
 errno = { version = "0.2.4", optional = true }
 downcast-rs = { version = "1.2.0", default-features = false }
 
@@ -36,7 +36,7 @@ std = [
     "num-rational/std",
     "num-rational/bigint-std",
     "num-traits/std",
-    "libc",
+    "libc/std",
     "downcast-rs/std"
 ]
 # Enforce using the linear memory implementation based on `Vec` instead of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 validation = { package = "wasmi-validation", version = "0.4", path = "validation", default-features = false }
 parity-wasm = { version = "0.42.0", default-features = false }
 memory_units = "0.3.0"
-libm = { version = "0.2.1", optional = true }
+libm = "0.2.1"
 num-rational = { version = "0.2.2", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 libc = { version = "0.2.58", optional = true}
@@ -38,12 +38,6 @@ std = [
     "num-traits/std",
     "libc",
     "downcast-rs/std"
-]
-# Enable for no_std support
-core = [
-    # `core` doesn't support mmaped memory
-    "vec_memory",
-    "libm"
 ]
 # Enforce using the linear memory implementation based on `Vec` instead of
 # mmap on unix systems.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ memory_units = "0.3.0"
 libm = "0.2.1"
 num-rational = { version = "0.2.2", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
-libc = { version = "0.2.58", default-features = false }
+libc = { version = "0.2.58", default-features = false, optional = true }
 errno = { version = "0.2.4", optional = true }
 downcast-rs = { version = "1.2.0", default-features = false }
 
@@ -29,7 +29,7 @@ wabt = "0.9"
 
 [features]
 default = ["std"]
-# Disable for no_std support
+# Use `no-default-features` for a `no_std` build.
 std = [
     "parity-wasm/std",
     "validation/std",
@@ -39,12 +39,13 @@ std = [
     "libc/std",
     "downcast-rs/std"
 ]
-# Enforce using the linear memory implementation based on `Vec` instead of
-# mmap on unix systems.
+# Enables OS supported virtual memory.
 #
-# Useful for tests and if you need to minimize unsafe usage at the cost of performance on some
-# workloads.
-vec_memory = []
+# Note
+#
+# - The default is to fall back is an inefficient vector based implementation.
+# - By nature this feature requires `libc` and the Rust standard library.
+virtual_memory = ["libc", "std"]
 
 reduced-stack-buffer = [ "parity-wasm/reduced-stack-buffer" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ std = [
     "num-rational/std",
     "num-rational/num-bigint-std",
     "num-traits/std",
-    "libc/std",
     "downcast-rs/std"
 ]
 # Enables OS supported virtual memory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,14 +105,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate core;
 
-#[cfg(test)]
-extern crate assert_matches;
-#[cfg(test)]
-extern crate wabt;
 
 use alloc::{
     boxed::Box,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
-
-
 use alloc::{
     boxed::Box,
     string::{String, ToString},

--- a/src/memory/mmap_bytebuf.rs
+++ b/src/memory/mmap_bytebuf.rs
@@ -5,7 +5,6 @@
 //! memory up to maximum. This might be a problem for systems that don't have a lot of virtual
 //! memory (i.e. 32-bit platforms).
 
-use alloc::string::{String, ToString};
 use core::ptr::{self, NonNull};
 use core::slice;
 

--- a/src/memory/mmap_bytebuf.rs
+++ b/src/memory/mmap_bytebuf.rs
@@ -5,8 +5,11 @@
 //! memory up to maximum. This might be a problem for systems that don't have a lot of virtual
 //! memory (i.e. 32-bit platforms).
 
-use std::ptr::{self, NonNull};
-use std::slice;
+use core::ptr::{self, NonNull};
+use core::slice;
+use alloc::{
+    string::{String, ToString},
+};
 
 struct Mmap {
     /// The pointer that points to the start of the mapping.

--- a/src/memory/mmap_bytebuf.rs
+++ b/src/memory/mmap_bytebuf.rs
@@ -5,11 +5,9 @@
 //! memory up to maximum. This might be a problem for systems that don't have a lot of virtual
 //! memory (i.e. 32-bit platforms).
 
+use alloc::string::{String, ToString};
 use core::ptr::{self, NonNull};
 use core::slice;
-use alloc::{
-    string::{String, ToString},
-};
 
 struct Mmap {
     /// The pointer that points to the start of the mapping.

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -10,11 +10,11 @@ use core::{
 };
 use parity_wasm::elements::ResizableLimits;
 
-#[cfg(all(unix, not(feature = "vec_memory")))]
+#[cfg(all(unix, feature = "virtual_memory"))]
 #[path = "mmap_bytebuf.rs"]
 mod bytebuf;
 
-#[cfg(any(not(unix), feature = "vec_memory"))]
+#[cfg(not(all(unix, feature = "virtual_memory")))]
 #[path = "vec_bytebuf.rs"]
 mod bytebuf;
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -754,9 +754,10 @@ impl<'a> NotStartedModuleRef<'a> {
     ///
     /// This function panics if original module contains `start` function.
     pub fn assert_no_start(self) -> ModuleRef {
-        if self.loaded_module.module().start_section().is_some() {
-            panic!("assert_no_start called on module with `start` function");
-        }
+        assert!(
+            self.loaded_module.module().start_section().is_some(),
+            "assert_no_start called on module with `start` function"
+        );
         self.instance
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -755,7 +755,7 @@ impl<'a> NotStartedModuleRef<'a> {
     /// This function panics if original module contains `start` function.
     pub fn assert_no_start(self) -> ModuleRef {
         assert!(
-            self.loaded_module.module().start_section().is_some(),
+            self.loaded_module.module().start_section().is_none(),
             "assert_no_start called on module with `start` function"
         );
         self.instance

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use parity_wasm::elements::Module;
 use validation::{validate_module, Error, Validator};
 
-#[cfg(feature = "core")]
+#[cfg(not(feature = "std"))]
 use crate::alloc::string::ToString;
 
 mod compile;

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -16,4 +16,3 @@ assert_matches = "1.1"
 [features]
 default = ["std"]
 std = ["parity-wasm/std"]
-core = []


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/270.

In summary this PR does the following:

- Removes the `core` crate feature. Explanation can be found in #270 .
- Replaces the `vec_memory` crate feature with the new `virtual_memory` crate feature.
    - The reason is that the new `virtual_memory` crate feature is additive unlike the old `vec_memory`.
    - Users of the crate are recommended to enable the `virtual_memory` crate feature if they are building `wasmi` for a platform that supports OS based virtual memory. Otherwise `wasmi` will fallback onto the vector based implementation.
