### PR TITLE
Apply some clippy suggestions for new #[must_use] lint

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -117,6 +117,7 @@ impl<'a> ImportsBuilder<'a> {
     }
 
     /// Register an resolver by a name.
+    #[must_use]
     pub fn with_resolver<N: Into<String>>(
         mut self,
         name: N,

--- a/src/nan_preserving_float.rs
+++ b/src/nan_preserving_float.rs
@@ -59,18 +59,22 @@ macro_rules! float {
                 self.to_float().is_nan()
             }
 
+            #[must_use]
             pub fn abs(self) -> Self {
                 $for(self.0 & !$sign_bit)
             }
 
+            #[must_use]
             pub fn fract(self) -> Self {
                 FloatCore::fract(self.to_float()).into()
             }
 
+            #[must_use]
             pub fn min(self, other: Self) -> Self {
                 Self::from(self.to_float().min(other.to_float()))
             }
 
+            #[must_use]
             pub fn max(self, other: Self) -> Self {
                 Self::from(self.to_float().max(other.to_float()))
             }


### PR DESCRIPTION
New lint in `clippy` 0.1.59 caused these new warnings to pop up.