### PR TITLE
Improve imports formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+edition = "2021"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
 imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
 edition = "2021"

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::process;
+use std::{env, process};
 
 fn main() {
     println!("cargo:rerun-if-changed=./wasm-kernel/");

--- a/examples/interpret.rs
+++ b/examples/interpret.rs
@@ -2,8 +2,7 @@
 
 extern crate wasmi;
 
-use std::env::args;
-use std::fs::File;
+use std::{env::args, fs::File};
 use wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, RuntimeValue};
 
 fn load_from_file(filename: &str) -> Module {

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -5,8 +5,19 @@ extern crate wasmi;
 
 use std::{env, fmt, fs::File};
 use wasmi::{
-    Error as InterpreterError, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder,
-    ModuleImportResolver, ModuleInstance, ModuleRef, RuntimeArgs, RuntimeValue, Signature, Trap,
+    Error as InterpreterError,
+    Externals,
+    FuncInstance,
+    FuncRef,
+    HostError,
+    ImportsBuilder,
+    ModuleImportResolver,
+    ModuleInstance,
+    ModuleRef,
+    RuntimeArgs,
+    RuntimeValue,
+    Signature,
+    Trap,
     ValueType,
 };
 

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -3,9 +3,7 @@
 extern crate parity_wasm;
 extern crate wasmi;
 
-use std::env;
-use std::fmt;
-use std::fs::File;
+use std::{env, fmt, fs::File};
 use wasmi::{
     Error as InterpreterError, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder,
     ModuleImportResolver, ModuleInstance, ModuleRef, RuntimeArgs, RuntimeValue, Signature, Trap,

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -5,9 +5,25 @@ extern crate wasmi;
 
 use std::{env::args, fs::File};
 use wasmi::{
-    memory_units::*, Error, FuncInstance, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef,
-    ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver,
-    ModuleInstance, NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance,
+    memory_units::*,
+    Error,
+    FuncInstance,
+    FuncRef,
+    GlobalDescriptor,
+    GlobalInstance,
+    GlobalRef,
+    ImportsBuilder,
+    MemoryDescriptor,
+    MemoryInstance,
+    MemoryRef,
+    Module,
+    ModuleImportResolver,
+    ModuleInstance,
+    NopExternals,
+    RuntimeValue,
+    Signature,
+    TableDescriptor,
+    TableInstance,
     TableRef,
 };
 

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -3,13 +3,12 @@
 
 extern crate wasmi;
 
-use std::env::args;
-use std::fs::File;
-use wasmi::memory_units::*;
+use std::{env::args, fs::File};
 use wasmi::{
-    Error, FuncInstance, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef, ImportsBuilder,
-    MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver, ModuleInstance,
-    NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef,
+    memory_units::*, Error, FuncInstance, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef,
+    ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver,
+    ModuleInstance, NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance,
+    TableRef,
 };
 
 fn load_from_file(filename: &str) -> Module {

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,10 +1,12 @@
-use crate::host::Externals;
-use crate::isa;
-use crate::module::ModuleInstance;
-use crate::runner::{check_function_args, Interpreter, InterpreterState, StackRecycler};
-use crate::types::ValueType;
-use crate::value::RuntimeValue;
-use crate::{Signature, Trap};
+use crate::{
+    host::Externals,
+    isa,
+    module::ModuleInstance,
+    runner::{check_function_args, Interpreter, InterpreterState, StackRecycler},
+    types::ValueType,
+    value::RuntimeValue,
+    Signature, Trap,
+};
 use alloc::{
     borrow::Cow,
     rc::{Rc, Weak},

--- a/src/func.rs
+++ b/src/func.rs
@@ -5,7 +5,8 @@ use crate::{
     runner::{check_function_args, Interpreter, InterpreterState, StackRecycler},
     types::ValueType,
     value::RuntimeValue,
-    Signature, Trap,
+    Signature,
+    Trap,
 };
 use alloc::{
     borrow::Cow,

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,6 +1,4 @@
-use crate::types::ValueType;
-use crate::value::RuntimeValue;
-use crate::Error;
+use crate::{types::ValueType, value::RuntimeValue, Error};
 use alloc::rc::Rc;
 use core::cell::Cell;
 use parity_wasm::elements::ValueType as EValueType;

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,7 @@
 use crate::{
     value::{FromRuntimeValue, RuntimeValue},
-    Trap, TrapKind,
+    Trap,
+    TrapKind,
 };
 
 use downcast_rs::{impl_downcast, DowncastSync};

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,5 +1,7 @@
-use crate::value::{FromRuntimeValue, RuntimeValue};
-use crate::{Trap, TrapKind};
+use crate::{
+    value::{FromRuntimeValue, RuntimeValue},
+    Trap, TrapKind,
+};
 
 use downcast_rs::{impl_downcast, DowncastSync};
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,10 +1,12 @@
-use crate::func::FuncRef;
-use crate::global::GlobalRef;
-use crate::memory::MemoryRef;
-use crate::module::ModuleRef;
-use crate::table::TableRef;
-use crate::types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor};
-use crate::{Error, Signature};
+use crate::{
+    func::FuncRef,
+    global::GlobalRef,
+    memory::MemoryRef,
+    module::ModuleRef,
+    table::TableRef,
+    types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor},
+    Error, Signature,
+};
 use alloc::{collections::BTreeMap, string::String};
 
 /// Resolver of a module's dependencies.

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -5,7 +5,8 @@ use crate::{
     module::ModuleRef,
     table::TableRef,
     types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor},
-    Error, Signature,
+    Error,
+    Signature,
 };
 use alloc::{collections::BTreeMap, string::String};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,21 +423,22 @@ mod value;
 #[cfg(test)]
 mod tests;
 
-pub use self::func::{FuncInstance, FuncInvocation, FuncRef, ResumableError};
-pub use self::global::{GlobalInstance, GlobalRef};
-pub use self::host::{Externals, HostError, NopExternals, RuntimeArgs};
-pub use self::imports::{ImportResolver, ImportsBuilder, ModuleImportResolver};
-pub use self::memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
-pub use self::module::{ExternVal, ModuleInstance, ModuleRef, NotStartedModuleRef};
-pub use self::runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT};
-pub use self::table::{TableInstance, TableRef};
-pub use self::types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType};
-pub use self::value::{Error as ValueError, FromRuntimeValue, LittleEndianConvert, RuntimeValue};
+pub use self::{
+    func::{FuncInstance, FuncInvocation, FuncRef, ResumableError},
+    global::{GlobalInstance, GlobalRef},
+    host::{Externals, HostError, NopExternals, RuntimeArgs},
+    imports::{ImportResolver, ImportsBuilder, ModuleImportResolver},
+    memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE},
+    module::{ExternVal, ModuleInstance, ModuleRef, NotStartedModuleRef},
+    runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT},
+    table::{TableInstance, TableRef},
+    types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType},
+    value::{Error as ValueError, FromRuntimeValue, LittleEndianConvert, RuntimeValue},
+};
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {
-    pub use memory_units::wasm32::*;
-    pub use memory_units::{size_of, ByteSize, Bytes, RoundUpTo};
+    pub use memory_units::{size_of, wasm32::*, ByteSize, Bytes, RoundUpTo};
 }
 
 /// Deserialized module prepared for instantiation.

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,7 +6,8 @@ use crate::{
 use alloc::{rc::Rc, string::ToString, vec::Vec};
 use core::{
     cell::{Cell, Ref, RefCell, RefMut},
-    cmp, fmt,
+    cmp,
+    fmt,
     ops::Range,
     u32,
 };

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,6 +1,8 @@
-use crate::memory_units::{Bytes, Pages, RoundUpTo};
-use crate::value::LittleEndianConvert;
-use crate::Error;
+use crate::{
+    memory_units::{Bytes, Pages, RoundUpTo},
+    value::LittleEndianConvert,
+    Error,
+};
 use alloc::{rc::Rc, string::ToString, vec::Vec};
 use core::{
     cell::{Cell, Ref, RefCell, RefMut},
@@ -577,8 +579,7 @@ impl MemoryInstance {
 mod tests {
 
     use super::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
-    use crate::memory_units::Pages;
-    use crate::Error;
+    use crate::{memory_units::Pages, Error};
     use alloc::rc::Rc;
 
     #[test]

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,22 +1,26 @@
-use crate::func::{FuncBody, FuncInstance, FuncRef};
-use crate::global::{GlobalInstance, GlobalRef};
-use crate::host::Externals;
-use crate::imports::ImportResolver;
-use crate::memory::MemoryRef;
-use crate::memory_units::Pages;
-use crate::runner::StackRecycler;
-use crate::table::TableRef;
-use crate::types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor};
-use crate::{Error, MemoryInstance, Module, RuntimeValue, Signature, TableInstance, Trap};
-use alloc::collections::BTreeMap;
+use crate::{
+    func::{FuncBody, FuncInstance, FuncRef},
+    global::{GlobalInstance, GlobalRef},
+    host::Externals,
+    imports::ImportResolver,
+    memory::MemoryRef,
+    memory_units::Pages,
+    runner::StackRecycler,
+    table::TableRef,
+    types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor},
+    Error, MemoryInstance, Module, RuntimeValue, Signature, TableInstance, Trap,
+};
 use alloc::{
     borrow::ToOwned,
+    collections::BTreeMap,
     rc::Rc,
     string::{String, ToString},
     vec::Vec,
 };
-use core::cell::{Ref, RefCell};
-use core::fmt;
+use core::{
+    cell::{Ref, RefCell},
+    fmt,
+};
 use parity_wasm::elements::{External, InitExpr, Instruction, Internal, ResizableLimits, Type};
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 
@@ -831,10 +835,12 @@ pub fn check_limits(limits: &ResizableLimits) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::{ExternVal, ModuleInstance};
-    use crate::func::FuncInstance;
-    use crate::imports::ImportsBuilder;
-    use crate::tests::parse_wat;
-    use crate::types::{Signature, ValueType};
+    use crate::{
+        func::FuncInstance,
+        imports::ImportsBuilder,
+        tests::parse_wat,
+        types::{Signature, ValueType},
+    };
 
     #[should_panic]
     #[test]

--- a/src/module.rs
+++ b/src/module.rs
@@ -8,7 +8,13 @@ use crate::{
     runner::StackRecycler,
     table::TableRef,
     types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor},
-    Error, MemoryInstance, Module, RuntimeValue, Signature, TableInstance, Trap,
+    Error,
+    MemoryInstance,
+    Module,
+    RuntimeValue,
+    Signature,
+    TableInstance,
+    Trap,
 };
 use alloc::{
     borrow::ToOwned,

--- a/src/nan_preserving_float.rs
+++ b/src/nan_preserving_float.rs
@@ -1,7 +1,9 @@
 #![allow(missing_docs)]
 
-use core::cmp::{Ordering, PartialEq, PartialOrd};
-use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use core::{
+    cmp::{Ordering, PartialEq, PartialOrd},
+    ops::{Add, Div, Mul, Neg, Rem, Sub},
+};
 use num_traits::float::FloatCore;
 
 macro_rules! impl_binop {

--- a/src/prepare/compile.rs
+++ b/src/prepare/compile.rs
@@ -3,12 +3,15 @@ use alloc::{string::String, vec::Vec};
 use parity_wasm::elements::{BlockType, FuncBody, Instruction};
 
 use crate::isa;
-use validation::func::{
-    require_label, top_label, BlockFrame, FunctionValidationContext, StackValueType, StartedWith,
+use validation::{
+    func::{
+        require_label, top_label, BlockFrame, FunctionValidationContext, StackValueType,
+        StartedWith,
+    },
+    stack::StackWithLimit,
+    util::Locals,
+    Error, FuncValidator,
 };
-use validation::stack::StackWithLimit;
-use validation::util::Locals;
-use validation::{Error, FuncValidator};
 
 /// Type of block frame.
 #[derive(Debug, Clone, Copy)]

--- a/src/prepare/compile.rs
+++ b/src/prepare/compile.rs
@@ -5,12 +5,17 @@ use parity_wasm::elements::{BlockType, FuncBody, Instruction};
 use crate::isa;
 use validation::{
     func::{
-        require_label, top_label, BlockFrame, FunctionValidationContext, StackValueType,
+        require_label,
+        top_label,
+        BlockFrame,
+        FunctionValidationContext,
+        StackValueType,
         StartedWith,
     },
     stack::StackWithLimit,
     util::Locals,
-    Error, FuncValidator,
+    Error,
+    FuncValidator,
 };
 
 /// Type of block frame.

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -56,7 +56,8 @@ pub fn compile_module(module: Module) -> Result<CompiledModule, Error> {
 pub fn deny_floating_point(module: &Module) -> Result<(), Error> {
     use parity_wasm::elements::{
         Instruction::{self, *},
-        Type, ValueType,
+        Type,
+        ValueType,
     };
 
     if let Some(code) = module.code_section() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -9,10 +9,20 @@ use crate::{
     module::ModuleRef,
     nan_preserving_float::{F32, F64},
     value::{
-        ArithmeticOps, ExtendInto, Float, Integer, LittleEndianConvert, RuntimeValue,
-        TransmuteInto, TryTruncateInto, WrapInto,
+        ArithmeticOps,
+        ExtendInto,
+        Float,
+        Integer,
+        LittleEndianConvert,
+        RuntimeValue,
+        TransmuteInto,
+        TryTruncateInto,
+        WrapInto,
     },
-    Signature, Trap, TrapKind, ValueType,
+    Signature,
+    Trap,
+    TrapKind,
+    ValueType,
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::{fmt, ops, u32, usize};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,21 +1,21 @@
 #![allow(clippy::unnecessary_wraps)]
 
-use crate::func::{FuncInstance, FuncInstanceInternal, FuncRef};
-use crate::host::Externals;
-use crate::isa;
-use crate::memory::MemoryRef;
-use crate::memory_units::Pages;
-use crate::module::ModuleRef;
-use crate::nan_preserving_float::{F32, F64};
-use crate::value::{
-    ArithmeticOps, ExtendInto, Float, Integer, LittleEndianConvert, RuntimeValue, TransmuteInto,
-    TryTruncateInto, WrapInto,
+use crate::{
+    func::{FuncInstance, FuncInstanceInternal, FuncRef},
+    host::Externals,
+    isa,
+    memory::MemoryRef,
+    memory_units::Pages,
+    module::ModuleRef,
+    nan_preserving_float::{F32, F64},
+    value::{
+        ArithmeticOps, ExtendInto, Float, Integer, LittleEndianConvert, RuntimeValue,
+        TransmuteInto, TryTruncateInto, WrapInto,
+    },
+    Signature, Trap, TrapKind, ValueType,
 };
-use crate::{Signature, Trap, TrapKind, ValueType};
 use alloc::{boxed::Box, vec::Vec};
-use core::fmt;
-use core::ops;
-use core::{u32, usize};
+use core::{fmt, ops, u32, usize};
 use parity_wasm::elements::Local;
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,10 +1,6 @@
-use crate::func::FuncRef;
-use crate::module::check_limits;
-use crate::Error;
+use crate::{func::FuncRef, module::check_limits, Error};
 use alloc::{rc::Rc, vec::Vec};
-use core::cell::RefCell;
-use core::fmt;
-use core::u32;
+use core::{cell::RefCell, fmt, u32};
 use parity_wasm::elements::ResizableLimits;
 
 /// Reference to a table (See [`TableInstance`] for details).

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -3,10 +3,29 @@ extern crate std;
 
 use super::parse_wat;
 use crate::{
-    memory_units::Pages, types::ValueType, Error, Externals, FuncInstance, FuncRef, HostError,
-    ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, ModuleImportResolver,
-    ModuleInstance, ModuleRef, ResumableError, RuntimeArgs, RuntimeValue, Signature,
-    TableDescriptor, TableInstance, TableRef, Trap, TrapKind,
+    memory_units::Pages,
+    types::ValueType,
+    Error,
+    Externals,
+    FuncInstance,
+    FuncRef,
+    HostError,
+    ImportsBuilder,
+    MemoryDescriptor,
+    MemoryInstance,
+    MemoryRef,
+    ModuleImportResolver,
+    ModuleInstance,
+    ModuleRef,
+    ResumableError,
+    RuntimeArgs,
+    RuntimeValue,
+    Signature,
+    TableDescriptor,
+    TableInstance,
+    TableRef,
+    Trap,
+    TrapKind,
 };
 use alloc::boxed::Box;
 use std::println;

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -2,12 +2,11 @@
 extern crate std;
 
 use super::parse_wat;
-use crate::memory_units::Pages;
-use crate::types::ValueType;
 use crate::{
-    Error, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder, MemoryDescriptor,
-    MemoryInstance, MemoryRef, ModuleImportResolver, ModuleInstance, ModuleRef, ResumableError,
-    RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef, Trap, TrapKind,
+    memory_units::Pages, types::ValueType, Error, Externals, FuncInstance, FuncRef, HostError,
+    ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, ModuleImportResolver,
+    ModuleInstance, ModuleRef, ResumableError, RuntimeArgs, RuntimeValue, Signature,
+    TableDescriptor, TableInstance, TableRef, Trap, TrapKind,
 };
 use alloc::boxed::Box;
 use std::println;

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -2,9 +2,24 @@
 extern crate std;
 
 use crate::{
-    memory_units::Pages, Error, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef,
-    ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver,
-    ModuleInstance, NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance,
+    memory_units::Pages,
+    Error,
+    FuncRef,
+    GlobalDescriptor,
+    GlobalInstance,
+    GlobalRef,
+    ImportsBuilder,
+    MemoryDescriptor,
+    MemoryInstance,
+    MemoryRef,
+    Module,
+    ModuleImportResolver,
+    ModuleInstance,
+    NopExternals,
+    RuntimeValue,
+    Signature,
+    TableDescriptor,
+    TableInstance,
     TableRef,
 };
 use alloc::vec::Vec;

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -1,11 +1,11 @@
 // Test-only code importing std for no-std testing
 extern crate std;
 
-use crate::memory_units::Pages;
 use crate::{
-    Error, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef, ImportsBuilder, MemoryDescriptor,
-    MemoryInstance, MemoryRef, Module, ModuleImportResolver, ModuleInstance, NopExternals,
-    RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef,
+    memory_units::Pages, Error, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef,
+    ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleImportResolver,
+    ModuleInstance, NopExternals, RuntimeValue, Signature, TableDescriptor, TableInstance,
+    TableRef,
 };
 use alloc::vec::Vec;
 use std::fs::File;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,11 @@
 use alloc::borrow::Cow;
 
 use parity_wasm::elements::{
-    FunctionType, GlobalType, MemoryType, TableType, ValueType as EValueType,
+    FunctionType,
+    GlobalType,
+    MemoryType,
+    TableType,
+    ValueType as EValueType,
 };
 
 /// Signature of a [function].

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,8 @@
-use crate::nan_preserving_float::{F32, F64};
-use crate::types::ValueType;
-use crate::TrapKind;
+use crate::{
+    nan_preserving_float::{F32, F64},
+    types::ValueType,
+    TrapKind,
+};
 use core::{f32, i32, i64, u32, u64};
 
 /// Error for `LittleEndianConvert`
@@ -827,8 +829,7 @@ mod fmath {
 
 #[cfg(not(feature = "std"))]
 mod fmath {
-    pub use super::libm_adapters::f32;
-    pub use super::libm_adapters::f64;
+    pub use super::libm_adapters::{f32, f64};
 }
 
 // We cannot call the math functions directly, because they are not all available in `core`.

--- a/tests/spec/run.rs
+++ b/tests/spec/run.rs
@@ -4,10 +4,30 @@ use std::{collections::HashMap, fs::File};
 
 use wabt::script::{self, Action, Command, CommandKind, ScriptParser, Value};
 use wasmi::{
-    memory_units::Pages, Error as InterpreterError, Externals, FuncInstance, FuncRef,
-    GlobalDescriptor, GlobalInstance, GlobalRef, ImportResolver, ImportsBuilder, MemoryDescriptor,
-    MemoryInstance, MemoryRef, Module, ModuleImportResolver, ModuleInstance, ModuleRef,
-    RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef, Trap,
+    memory_units::Pages,
+    Error as InterpreterError,
+    Externals,
+    FuncInstance,
+    FuncRef,
+    GlobalDescriptor,
+    GlobalInstance,
+    GlobalRef,
+    ImportResolver,
+    ImportsBuilder,
+    MemoryDescriptor,
+    MemoryInstance,
+    MemoryRef,
+    Module,
+    ModuleImportResolver,
+    ModuleInstance,
+    ModuleRef,
+    RuntimeArgs,
+    RuntimeValue,
+    Signature,
+    TableDescriptor,
+    TableInstance,
+    TableRef,
+    Trap,
 };
 
 fn spec_to_runtime_value(val: Value<u32, u64>) -> RuntimeValue {

--- a/tests/spec/run.rs
+++ b/tests/spec/run.rs
@@ -1,15 +1,13 @@
 #![cfg(test)]
 
-use std::collections::HashMap;
-use std::fs::File;
+use std::{collections::HashMap, fs::File};
 
 use wabt::script::{self, Action, Command, CommandKind, ScriptParser, Value};
-use wasmi::memory_units::Pages;
 use wasmi::{
-    Error as InterpreterError, Externals, FuncInstance, FuncRef, GlobalDescriptor, GlobalInstance,
-    GlobalRef, ImportResolver, ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module,
-    ModuleImportResolver, ModuleInstance, ModuleRef, RuntimeArgs, RuntimeValue, Signature,
-    TableDescriptor, TableInstance, TableRef, Trap,
+    memory_units::Pages, Error as InterpreterError, Externals, FuncInstance, FuncRef,
+    GlobalDescriptor, GlobalInstance, GlobalRef, ImportResolver, ImportsBuilder, MemoryDescriptor,
+    MemoryInstance, MemoryRef, Module, ModuleImportResolver, ModuleInstance, ModuleRef,
+    RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableInstance, TableRef, Trap,
 };
 
 fn spec_to_runtime_value(val: Value<u32, u64>) -> RuntimeValue {

--- a/validation/src/context.rs
+++ b/validation/src/context.rs
@@ -1,7 +1,12 @@
 use crate::Error;
 use alloc::vec::Vec;
 use parity_wasm::elements::{
-    BlockType, FunctionType, GlobalType, MemoryType, TableType, ValueType,
+    BlockType,
+    FunctionType,
+    GlobalType,
+    MemoryType,
+    TableType,
+    ValueType,
 };
 
 #[derive(Default, Debug)]

--- a/validation/src/func.rs
+++ b/validation/src/func.rs
@@ -1,6 +1,11 @@
 use crate::{
-    context::ModuleContext, stack::StackWithLimit, util::Locals, Error, FuncValidator,
-    DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX,
+    context::ModuleContext,
+    stack::StackWithLimit,
+    util::Locals,
+    Error,
+    FuncValidator,
+    DEFAULT_MEMORY_INDEX,
+    DEFAULT_TABLE_INDEX,
 };
 
 use core::u32;

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -26,8 +26,21 @@ use std::error;
 
 use self::context::ModuleContextBuilder;
 use parity_wasm::elements::{
-    BlockType, ExportEntry, External, FuncBody, GlobalEntry, GlobalType, InitExpr, Instruction,
-    Internal, MemoryType, Module, ResizableLimits, TableType, Type, ValueType,
+    BlockType,
+    ExportEntry,
+    External,
+    FuncBody,
+    GlobalEntry,
+    GlobalType,
+    InitExpr,
+    Instruction,
+    Internal,
+    MemoryType,
+    Module,
+    ResizableLimits,
+    TableType,
+    Type,
+    ValueType,
 };
 
 pub mod context;

--- a/validation/src/tests.rs
+++ b/validation/src/tests.rs
@@ -2,8 +2,18 @@ use crate::{Error, PlainValidator};
 use parity_wasm::{
     builder::module,
     elements::{
-        BlockType, External, GlobalEntry, GlobalType, ImportEntry, InitExpr, Instruction,
-        Instructions, MemoryType, Module, TableType, ValueType,
+        BlockType,
+        External,
+        GlobalEntry,
+        GlobalType,
+        ImportEntry,
+        InitExpr,
+        Instruction,
+        Instructions,
+        MemoryType,
+        Module,
+        TableType,
+        ValueType,
     },
 };
 


### PR DESCRIPTION
Introduces the following `rustfmt` formatting configurations:

- `imports_granularity = "Crate"`:
    - https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#crate
- `imports_layout = "HorizontalVertical"`:
    - https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#horizontalvertical

I have applied both formatting transformations in separate commits if you want to inspect their respective outcomes.
IMO it should not be a big deal to use `nightly` `rustfmt` toolchain instead of `stable` in our GitHub Actions CI.

I am aware that it is kinda biased to not apply standard `stable` Rust formatting and that introducing unstable formatting specifiers might be unpopular, however, both formatting specifiers have been "stable" for quite some time and are probably going to be stabilized as designed in the future.
Have imports merge automatically using `imports_granuality` instead of manually takes a lot of manual labor from developers.
The `imports_layout` formatting option makes Rust imports behave the same as everywhere else (e.g. in function arguments) which also conforms to a more unified formatting style.
Note: We are already using `nightly` Rust toolchain for `clippy` GitHub Actions CI.

A big advantage with vertical layouts is that Git diffs are more readable and provoke fewer merge conflicts.

There are some more `nightly` `rustfmt` options that we might want to explore using in the future in our CI, e.g.:

- https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#report_fixme
- https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#report_todo
- https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#license_template_path