### PR TITLE
Optimize host calls in the wasmi interpreter

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -177,6 +177,7 @@ pub struct Interpreter {
     call_stack: CallStack,
     return_type: Option<ValueType>,
     state: InterpreterState,
+    scratch: Vec<RuntimeValue>,
 }
 
 impl Interpreter {
@@ -206,6 +207,7 @@ impl Interpreter {
             call_stack,
             return_type,
             state: InterpreterState::Initialized,
+            scratch: Vec::new(),
         })
     }
 
@@ -308,22 +310,29 @@ impl Interpreter {
                             self.call_stack.push(nested_context);
                         }
                         FuncInstanceInternal::Host { ref signature, .. } => {
-                            let args = prepare_function_args(signature, &mut self.value_stack);
+                            prepare_function_args(
+                                signature,
+                                &mut self.value_stack,
+                                &mut self.scratch,
+                            );
                             // We push the function context first. If the VM is not resumable, it does no harm. If it is, we then save the context here.
                             self.call_stack.push(function_context);
 
-                            let return_val =
-                                match FuncInstance::invoke(&nested_func, &args, externals) {
-                                    Ok(val) => val,
-                                    Err(trap) => {
-                                        if trap.kind().is_host() {
-                                            self.state = InterpreterState::Resumable(
-                                                nested_func.signature().return_type(),
-                                            );
-                                        }
-                                        return Err(trap);
+                            let return_val = match FuncInstance::invoke(
+                                &nested_func,
+                                &self.scratch,
+                                externals,
+                            ) {
+                                Ok(val) => val,
+                                Err(trap) => {
+                                    if trap.kind().is_host() {
+                                        self.state = InterpreterState::Resumable(
+                                            nested_func.signature().return_type(),
+                                        );
                                     }
-                                };
+                                    return Err(trap);
+                                }
+                            };
 
                             // Check if `return_val` matches the signature.
                             let value_ty = return_val.as_ref().map(|val| val.value_type());
@@ -1330,15 +1339,18 @@ fn effective_address(address: u32, offset: u32) -> Result<u32, TrapKind> {
 fn prepare_function_args(
     signature: &Signature,
     caller_stack: &mut ValueStack,
-) -> Vec<RuntimeValue> {
-    let mut out = signature
-        .params()
+    host_args: &mut Vec<RuntimeValue>,
+) {
+    let req_args = signature.params();
+    let len_args = req_args.len();
+    let stack_args = caller_stack.pop_as_slice(len_args);
+    assert_eq!(len_args, stack_args.len());
+    host_args.clear();
+    let prepared_args = req_args
         .iter()
-        .rev()
-        .map(|&param_ty| caller_stack.pop().with_type(param_ty))
-        .collect::<Vec<RuntimeValue>>();
-    out.reverse();
-    out
+        .zip(stack_args)
+        .map(|(req_arg, stack_arg)| stack_arg.with_type(*req_arg));
+    host_args.extend(prepared_args);
 }
 
 pub fn check_function_args(signature: &Signature, args: &[RuntimeValue]) -> Result<(), Trap> {
@@ -1454,6 +1466,21 @@ impl ValueStack {
     #[inline]
     fn len(&self) -> usize {
         self.sp
+    }
+
+    /// Pops the last `depth` stack entries and returns them as slice.
+    ///
+    /// Stack entries are returned in the order in which they got pushed
+    /// onto the value stack.
+    ///
+    /// # Panics
+    ///
+    /// If the value stack does not have at least `depth` stack entries.
+    pub fn pop_as_slice(&mut self, depth: usize) -> &[RuntimeValueInternal] {
+        self.sp -= depth;
+        let start = self.sp;
+        let end = self.sp + depth;
+        &self.buf[start..end]
     }
 }
 


### PR DESCRIPTION
This commit does two things to speed-up host calls:

- Reuse heap allocations for consecutive host calls to hold arguments.
- More efficient copying of stack values to host argument buffer.

## Benchmarks

No noticeable performance impact was measured, however, that's mainly because the current set of benchmarks do not cover the particular scenario of performing lots of host function calls.

### Before

```
test bench_regex_redux ... bench:   1,831,339 ns/iter (+/- 153,861)
test bench_rev_comp    ... bench:   1,661,062 ns/iter (+/- 146,230)
test bench_tiny_keccak ... bench:   1,276,610 ns/iter (+/- 132,734)
test fac_opt           ... bench:      23,268 ns/iter (+/- 4,547)
test fac_recursive     ... bench:      24,568 ns/iter (+/- 1,908)
test recursive_ok      ... bench:     615,655 ns/iter (+/- 43,826)
test recursive_trap    ... bench:      79,457 ns/iter (+/- 4,446)
```

### After

```
test bench_regex_redux ... bench:   1,802,265 ns/iter (+/- 130,377)
test bench_rev_comp    ... bench:   1,656,515 ns/iter (+/- 126,081)
test bench_tiny_keccak ... bench:   1,260,390 ns/iter (+/- 118,418)
test fac_opt           ... bench:      22,251 ns/iter (+/- 1,458)
test fac_recursive     ... bench:      23,990 ns/iter (+/- 2,073)
test recursive_ok      ... bench:     593,989 ns/iter (+/- 86,742)
test recursive_trap    ... bench:      78,235 ns/iter (+/- 5,871)
```