### PR TITLE
Fix Float::copysign impl

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -767,11 +767,6 @@ macro_rules! impl_float {
             }
             fn copysign(self, other: $type) -> $type {
                 use core::mem::size_of;
-
-                if self.is_nan() {
-                    return self;
-                }
-
                 let sign_mask: $iXX = 1 << ((size_of::<$iXX>() << 3) - 1);
                 let self_int: $iXX = self.transmute_into();
                 let other_int: $iXX = other.transmute_into();
@@ -793,6 +788,19 @@ impl_float!(f32, f32, i32);
 impl_float!(f64, f64, i64);
 impl_float!(F32, f32, i32);
 impl_float!(F64, f64, i64);
+
+#[test]
+fn copysign_regression_works() {
+    // This test has been directly extracted from a WebAssembly Specification assertion.
+    use Float as _;
+    assert!(F32::from_bits(0xFFC00000).is_nan());
+    assert_eq!(
+        F32::from_bits(0xFFC00000)
+            .copysign(F32::from_bits(0x0000_0000))
+            .to_bits(),
+        F32::from_bits(0x7FC00000).to_bits()
+    )
+}
 
 #[cfg(not(feature = "std"))]
 mod libm_adapters {


### PR DESCRIPTION
I discovered today that the official WebAssembly spec test suite assertions and `wasmi` results diverge in a particular case with the `copysign` instruction.
For `F32::from_bits(0xFFFC_0000).copysign(F32::from_bits(0))` the expected result according to the WebAssembly Spec test suite is `0x7FFC_0000`, however, `wasmi` currently returns `0xFFFC_0000`.
The Rust documentation mandates the same behavior from `copysign` as WebAssembly does: https://doc.rust-lang.org/std/primitive.f32.html#method.copysign

The bug was not caught because the current `wasmi` Wasm spec test runner seems to improperly handle `NaN` values.

Fortunately the bug fix was easy, however, I still wonder why we are going to great lengths like this.