### PR TITLE
Add perf sensitive inline attributes in interpreter hot path

### DIFF
--- a/src/v1/engine/code_map.rs
+++ b/src/v1/engine/code_map.rs
@@ -183,7 +183,7 @@ impl<'a> ResolvedFuncBody<'a> {
     /// Visits the corresponding [`Instruction`] method from the given visitor.
     ///
     /// Returns the visitor's outcome value.
-    #[inline]
+    #[inline(always)]
     pub fn visit<T>(&self, index: usize, mut visitor: T) -> T::Outcome
     where
         T: VisitInstruction,

--- a/src/v1/engine/exec_context.rs
+++ b/src/v1/engine/exec_context.rs
@@ -57,6 +57,7 @@ impl<'engine, 'func> ExecutionContext<'engine, 'func> {
         })
     }
 
+    #[inline(always)]
     pub fn execute_frame(
         &mut self,
         mut ctx: impl AsContextMut,

--- a/src/v1/engine/exec_context.rs
+++ b/src/v1/engine/exec_context.rs
@@ -57,6 +57,12 @@ impl<'engine, 'func> ExecutionContext<'engine, 'func> {
         })
     }
 
+    /// Executes the current function frame.
+    ///
+    /// # Note
+    ///
+    /// This executes instructions sequentially until either the function
+    /// calls into another function or the function returns to its caller.
     #[inline(always)]
     pub fn execute_frame(
         &mut self,


### PR DESCRIPTION


# Benchmarks

## Before

```
test bench_compile_and_validate    ... bench:   7,390,310 ns/iter (+/- 745,235)
test bench_compile_and_validate_v1 ... bench:   8,379,948 ns/iter (+/- 548,240)
test bench_instantiate_module      ... bench:     449,365 ns/iter (+/- 67,005)
test bench_instantiate_module_v1   ... bench:      63,631 ns/iter (+/- 3,750)
test bench_tiny_keccak             ... bench:   1,330,325 ns/iter (+/- 135,642)
test bench_tiny_keccak_v1          ... bench:   1,272,542 ns/iter (+/- 54,177)
test count_until                   ... bench:   1,960,267 ns/iter (+/- 162,996)
test count_until_v1                ... bench:   1,816,740 ns/iter (+/- 94,504)
test fac_opt                       ... bench:      25,026 ns/iter (+/- 1,451)
test fac_opt_v1                    ... bench:         803 ns/iter (+/- 61)
test fac_recursive                 ... bench:      26,537 ns/iter (+/- 1,612)
test fac_recursive_v1              ... bench:       1,976 ns/iter (+/- 391)
test host_calls                    ... bench:      79,935 ns/iter (+/- 19,161)
test host_calls_v1                 ... bench:      75,570 ns/iter (+/- 4,639)
test recursive_ok                  ... bench:     522,977 ns/iter (+/- 30,800)
test recursive_ok_v1               ... bench:     551,408 ns/iter (+/- 50,004)
```

## After

```
test bench_compile_and_validate    ... bench:   7,199,332 ns/iter (+/- 498,541)
test bench_compile_and_validate_v1 ... bench:   8,243,990 ns/iter (+/- 354,092)
test bench_instantiate_module      ... bench:     452,300 ns/iter (+/- 33,185)
test bench_instantiate_module_v1   ... bench:      62,504 ns/iter (+/- 4,219)
test bench_tiny_keccak             ... bench:   1,293,648 ns/iter (+/- 65,996)
test bench_tiny_keccak_v1          ... bench:   1,261,176 ns/iter (+/- 73,573)
test count_until                   ... bench:   1,925,142 ns/iter (+/- 108,998)
test count_until_v1                ... bench:   1,817,523 ns/iter (+/- 95,787)
test fac_opt                       ... bench:      25,036 ns/iter (+/- 1,284)
test fac_opt_v1                    ... bench:         769 ns/iter (+/- 102)
test fac_recursive                 ... bench:      26,411 ns/iter (+/- 1,738)
test fac_recursive_v1              ... bench:       1,475 ns/iter (+/- 343)
test host_calls                    ... bench:      78,544 ns/iter (+/- 5,595)
test host_calls_v1                 ... bench:      59,922 ns/iter (+/- 3,222)
test recursive_ok                  ... bench:     515,199 ns/iter (+/- 90,251)
test recursive_ok_v1               ... bench:     388,068 ns/iter (+/- 24,985)
``` 

## Summary

- `fac_recursive_v1` improved by ~33% from `1,976 ns/iter` down to `1,475 ns/iter`.
- `host_calls_v1` improved by ~26% from `75,570 ns/iter` down to `59,922 ns/iter`.
- `recursive_ok_v1` improved by ~42% from `551,408 ns/iter` down to `388,068 ns/iter`.