### PR TITLE
Eliminate bounds check in interpreter hot path

### DIFF
--- a/src/v1/engine/code_map.rs
+++ b/src/v1/engine/code_map.rs
@@ -188,6 +188,11 @@ impl<'a> ResolvedFuncBody<'a> {
     where
         T: VisitInstruction,
     {
+        debug_assert!(
+            self.insts.get(index).is_some(),
+            "expect to find instruction at index {} due to validation but found none",
+            index
+        );
         // # Safety
         //
         // This access is safe since all possible accesses have already been

--- a/src/v1/engine/code_map.rs
+++ b/src/v1/engine/code_map.rs
@@ -188,7 +188,16 @@ impl<'a> ResolvedFuncBody<'a> {
     where
         T: VisitInstruction,
     {
-        let inst = &self.insts[index];
+        // # Safety
+        //
+        // This access is safe since all possible accesses have already been
+        // checked during Wasm validation. Functions and their instructions including
+        // jump addresses are immutable after Wasm function compilation and validation
+        // and therefore this bounds check can be safely eliminated.
+        //
+        // Note that eliminating this bounds check is extremely valuable since this
+        // part of the `wasmi` interpreter is part of the interpreter's hot path.
+        let inst = unsafe { self.insts.get_unchecked(index) };
         match inst {
             Instruction::GetLocal { local_depth } => visitor.visit_get_local(*local_depth),
             Instruction::SetLocal { local_depth } => visitor.visit_set_local(*local_depth),


### PR DESCRIPTION
Are we okay with allowing optimizations using `unsafe` Rust code in the interpreter's hot path if they are safe by design?

# Benchmarks

## Before

```
test bench_compile_and_validate    ... bench:   6,963,714 ns/iter (+/- 306,278)
test bench_compile_and_validate_v1 ... bench:   8,256,357 ns/iter (+/- 1,286,043)
test bench_instantiate_module      ... bench:     423,622 ns/iter (+/- 43,379)
test bench_instantiate_module_v1   ... bench:      61,506 ns/iter (+/- 5,551)
test bench_tiny_keccak             ... bench:   1,306,960 ns/iter (+/- 101,209)
test bench_tiny_keccak_v1          ... bench:   1,260,753 ns/iter (+/- 57,078)
test count_until                   ... bench:   1,912,327 ns/iter (+/- 122,611)
test count_until_v1                ... bench:   1,798,430 ns/iter (+/- 96,263)
test fac_opt                       ... bench:      24,607 ns/iter (+/- 2,192)
test fac_opt_v1                    ... bench:         761 ns/iter (+/- 122)
test fac_recursive                 ... bench:      25,915 ns/iter (+/- 1,248)
test fac_recursive_v1              ... bench:       1,392 ns/iter (+/- 173)
test host_calls                    ... bench:      78,389 ns/iter (+/- 5,180)
test host_calls_v1                 ... bench:      59,291 ns/iter (+/- 4,225)
test recursive_ok                  ... bench:     505,019 ns/iter (+/- 63,995)
test recursive_ok_v1               ... bench:     380,951 ns/iter (+/- 16,030)
```

## After

```
test bench_compile_and_validate    ... bench:   7,075,519 ns/iter (+/- 539,729)
test bench_compile_and_validate_v1 ... bench:   8,166,123 ns/iter (+/- 325,438)
test bench_instantiate_module      ... bench:     436,280 ns/iter (+/- 54,773)
test bench_instantiate_module_v1   ... bench:      62,351 ns/iter (+/- 8,141)
test bench_tiny_keccak             ... bench:   1,293,647 ns/iter (+/- 73,956)
test bench_tiny_keccak_v1          ... bench:     988,033 ns/iter (+/- 47,571)
test count_until                   ... bench:   1,924,053 ns/iter (+/- 95,093)
test count_until_v1                ... bench:   1,745,057 ns/iter (+/- 85,481)
test fac_opt                       ... bench:      24,021 ns/iter (+/- 1,997)
test fac_opt_v1                    ... bench:         752 ns/iter (+/- 107)
test fac_recursive                 ... bench:      25,559 ns/iter (+/- 1,741)
test fac_recursive_v1              ... bench:       1,480 ns/iter (+/- 294)
test host_calls                    ... bench:      78,259 ns/iter (+/- 5,017)
test host_calls_v1                 ... bench:      59,910 ns/iter (+/- 2,598)
test recursive_ok                  ... bench:     509,818 ns/iter (+/- 59,742)
test recursive_ok_v1               ... bench:     390,697 ns/iter (+/- 17,877)
```

## Summary

The notable improvement is in the `bench_tiny_keccak_v1` benchmark that improves by roughly 26% from `1,260,753 ns/iter` down to `988,033 ns/iter`.