### PR TITLE
Improve CI jobs mostly by adding '--workspace' where required

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features virtual_memory
+          args: --workspace --features virtual_memory
       - name: Build (no_std)
         uses: actions-rs/cargo@v1
         with:
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --no-default-features --target wasm32-unknown-unknown
+          args: --workspace --no-default-features --target wasm32-unknown-unknown
 
   test:
     name: Test
@@ -66,14 +66,14 @@ jobs:
           RUSTFLAGS: '--cfg debug_assertions'
         with:
           command: test
-          args: --release
+          args: --workspace --release
       - uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: '--cfg debug_assertions'
           TEST_FLAGS: ${{ matrix.test-args }}
         with:
           command: test
-          args: --release --features virtual_memory -- $TEST_FLAGS
+          args: --workspace --release --features virtual_memory -- $TEST_FLAGS
 
   fmt:
     name: Formatting
@@ -107,7 +107,7 @@ jobs:
           RUSTDOCFLAGS: '-D warnings'
         with:
           command: doc
-          args: --no-deps --document-private-items
+          args: --workspace --no-deps --document-private-items
 
   audit:
     name: Audit
@@ -142,11 +142,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features virtual_memory -- -D warnings
+          args: --workspace --features virtual_memory -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features -- -D warnings
+          args: --workspace --no-default-features -- -D warnings
 
   coverage:
     name: Coverage
@@ -167,7 +167,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.0'
-          args: ''
+          args: --workspace
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:


### PR DESCRIPTION
When working on `wasmi_core` sub crate I found that our current CI did not check certain properties of `wasmi_core`.