### PR TITLE
Improve benchmarks for v1

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -2,6 +2,7 @@
 name = "benches"
 version = "0.1.0"
 authors = ["Sergey Pepyakin <s.pepyakin@gmail.com>"]
+edition = "2021"
 
 [dependencies]
 wasmi = { path = ".." }

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,11 +1,9 @@
 #![feature(test)]
 
-extern crate core;
 extern crate test;
-extern crate wasmi;
+
 #[macro_use]
 extern crate assert_matches;
-extern crate wabt;
 
 use core::slice;
 use std::{fs::File, io::Read as _};
@@ -63,18 +61,17 @@ fn load_file(file_name: &str) -> Vec<u8> {
 /// - If the benchmark Wasm file could not be opened, read or parsed.
 fn load_module(file_name: &str) -> Module {
     let buffer = load_file(file_name);
-    let module = Module::from_buffer(buffer).unwrap_or_else(|error| {
+    Module::from_buffer(buffer).unwrap_or_else(|error| {
         panic!(
             "could not parse Wasm module from file {}: {}",
             file_name, error
         )
-    });
-    module
+    })
 }
 
 const WASM_KERNEL: &str = "wasm-kernel/target/wasm32-unknown-unknown/release/wasm_kernel.wasm";
-const REVCOMP_INPUT: &'static [u8] = include_bytes!("./revcomp-input.txt");
-const REVCOMP_OUTPUT: &'static [u8] = include_bytes!("./revcomp-output.txt");
+const REVCOMP_INPUT: &[u8] = include_bytes!("./revcomp-input.txt");
+const REVCOMP_OUTPUT: &[u8] = include_bytes!("./revcomp-output.txt");
 
 #[bench]
 fn bench_compile_and_validate(b: &mut Bencher) {


### PR DESCRIPTION
- This PR adds the following benchmarks for the `v1` `wasmi` engine:

    - `recursive_trap_v1`
    - `bench_regex_redux_v1`
    - `bench_rev_comp_v1`

# Benchmarks

```
test bench_compile_and_validate    ... bench:   7,023,600 ns/iter (+/- 448,149)
test bench_compile_and_validate_v1 ... bench:   8,113,128 ns/iter (+/- 392,911)
test bench_instantiate_module      ... bench:     413,899 ns/iter (+/- 32,291)
test bench_instantiate_module_v1   ... bench:      61,358 ns/iter (+/- 4,092)
test bench_regex_redux             ... bench:   1,707,712 ns/iter (+/- 161,852)
test bench_regex_redux_v1          ... bench:   1,426,311 ns/iter (+/- 125,580)
test bench_rev_comp                ... bench:   1,622,877 ns/iter (+/- 175,789)
test bench_rev_comp_v1             ... bench:   1,236,591 ns/iter (+/- 84,843)
test bench_tiny_keccak             ... bench:   1,300,104 ns/iter (+/- 75,719)
test bench_tiny_keccak_v1          ... bench:   1,001,355 ns/iter (+/- 95,403)
test count_until                   ... bench:   1,906,888 ns/iter (+/- 154,041)
test count_until_v1                ... bench:   1,720,652 ns/iter (+/- 159,443)
test fac_opt                       ... bench:      23,906 ns/iter (+/- 1,311)
test fac_opt_v1                    ... bench:         738 ns/iter (+/- 87)
test fac_recursive                 ... bench:      25,213 ns/iter (+/- 3,958)
test fac_recursive_v1              ... bench:       1,465 ns/iter (+/- 300)
test host_calls                    ... bench:      80,189 ns/iter (+/- 7,499)
test host_calls_v1                 ... bench:      59,221 ns/iter (+/- 4,245)
test recursive_ok                  ... bench:     501,970 ns/iter (+/- 85,015)
test recursive_ok_v1               ... bench:     387,369 ns/iter (+/- 28,576)
test recursive_trap                ... bench:      71,238 ns/iter (+/- 4,871)
test recursive_trap_v1             ... bench:      40,395 ns/iter (+/- 3,494)
```