### PR TITLE
Add #[inline(always)] to improve compile performance of v1

### DIFF
--- a/src/v1/module/compile/mod.rs
+++ b/src/v1/module/compile/mod.rs
@@ -67,6 +67,7 @@ impl<'engine> FuncValidator for FuncBodyTranslator<'engine> {
         FuncBodyTranslator::new(engine, inst_builder, len_locals)
     }
 
+    #[inline(always)]
     fn next_instruction(
         &mut self,
         ctx: &mut FunctionValidationContext,
@@ -169,6 +170,7 @@ impl<'engine> FuncBodyTranslator<'engine> {
     }
 
     /// Validate the Wasm `inst` and translate the respective `wasmi` bytecode.
+    #[inline(always)]
     fn validate_translate<F, R>(
         &mut self,
         validator: &mut FunctionValidationContext,
@@ -188,6 +190,7 @@ impl<'engine> FuncBodyTranslator<'engine> {
     /// # Errors
     ///
     /// If there are validation or translation problems.
+    #[inline(always)]
     fn translate_instruction(
         &mut self,
         validator: &mut FunctionValidationContext,


### PR DESCRIPTION
Benchmarks show a performance improvement by roughly 5%.
More performance improvements are expected to be gained by transitioning to the wasmparser crate.