### PR TITLE
Rename RuntimeValue to Value internally

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -24,7 +24,7 @@ use wasmi::{
     ModuleInstance,
     NopExternals,
     RuntimeArgs,
-    RuntimeValue,
+    Value,
     Signature,
     TableDescriptor,
     TableRef,
@@ -124,7 +124,7 @@ fn bench_tiny_keccak(b: &mut Bencher) {
         .assert_no_start();
     let test_data_ptr = assert_matches!(
 		instance.invoke_export("prepare_tiny_keccak", &[], &mut NopExternals),
-		Ok(Some(v @ RuntimeValue::I32(_))) => v
+		Ok(Some(v @ Value::I32(_))) => v
 	);
 
     b.iter(|| {
@@ -154,12 +154,12 @@ fn bench_tiny_keccak_v1(b: &mut Bencher) {
         .get_export(&store, "bench_tiny_keccak")
         .and_then(v1::Extern::into_func)
         .unwrap();
-    let mut test_data_ptr = RuntimeValue::I32(0);
+    let mut test_data_ptr = Value::I32(0);
 
     prepare
         .call(&mut store, &[], std::slice::from_mut(&mut test_data_ptr))
         .unwrap();
-    assert!(matches!(test_data_ptr, RuntimeValue::I32(_)));
+    assert!(matches!(test_data_ptr, Value::I32(_)));
     b.iter(|| {
         keccak
             .call(&mut store, std::slice::from_ref(&test_data_ptr), &mut [])
@@ -175,11 +175,11 @@ fn bench_rev_comp(b: &mut Bencher) {
         .assert_no_start();
 
     // Allocate buffers for the input and output.
-    let test_data_ptr: RuntimeValue = {
-        let input_size = RuntimeValue::I32(REVCOMP_INPUT.len() as i32);
+    let test_data_ptr: Value = {
+        let input_size = Value::I32(REVCOMP_INPUT.len() as i32);
         assert_matches!(
 			instance.invoke_export("prepare_rev_complement", &[input_size], &mut NopExternals),
-			Ok(Some(v @ RuntimeValue::I32(_))) => v,
+			Ok(Some(v @ Value::I32(_))) => v,
 			"",
 		)
     };
@@ -187,7 +187,7 @@ fn bench_rev_comp(b: &mut Bencher) {
     // Get the pointer to the input buffer.
     let input_data_mem_offset = assert_matches!(
         instance.invoke_export("rev_complement_input_ptr", &[test_data_ptr], &mut NopExternals),
-        Ok(Some(RuntimeValue::I32(v))) => v as u32,
+        Ok(Some(Value::I32(v))) => v as u32,
         "",
     );
 
@@ -211,7 +211,7 @@ fn bench_rev_comp(b: &mut Bencher) {
     // Verify the result.
     let output_data_mem_offset = assert_matches!(
         instance.invoke_export("rev_complement_output_ptr", &[test_data_ptr], &mut NopExternals),
-        Ok(Some(RuntimeValue::I32(v))) => v as u32,
+        Ok(Some(Value::I32(v))) => v as u32,
         "",
     );
     let mut result = vec![0x00_u8; REVCOMP_OUTPUT.len()];
@@ -229,11 +229,11 @@ fn bench_regex_redux(b: &mut Bencher) {
         .assert_no_start();
 
     // Allocate buffers for the input and output.
-    let test_data_ptr: RuntimeValue = {
-        let input_size = RuntimeValue::I32(REVCOMP_INPUT.len() as i32);
+    let test_data_ptr: Value = {
+        let input_size = Value::I32(REVCOMP_INPUT.len() as i32);
         assert_matches!(
 			instance.invoke_export("prepare_regex_redux", &[input_size], &mut NopExternals),
-			Ok(Some(v @ RuntimeValue::I32(_))) => v,
+			Ok(Some(v @ Value::I32(_))) => v,
 			"",
 		)
     };
@@ -241,7 +241,7 @@ fn bench_regex_redux(b: &mut Bencher) {
     // Get the pointer to the input buffer.
     let input_data_mem_offset = assert_matches!(
         instance.invoke_export("regex_redux_input_ptr", &[test_data_ptr], &mut NopExternals),
-        Ok(Some(RuntimeValue::I32(v))) => v as u32,
+        Ok(Some(Value::I32(v))) => v as u32,
         "",
     );
 
@@ -274,10 +274,10 @@ fn count_until(b: &mut Bencher) {
     b.iter(|| {
         let value = instance.invoke_export(
             "count_until",
-            &[RuntimeValue::I32(REPETITIONS)],
+            &[Value::I32(REPETITIONS)],
             &mut NopExternals,
         );
-        assert_matches!(value, Ok(Some(RuntimeValue::I32(REPETITIONS))));
+        assert_matches!(value, Ok(Some(Value::I32(REPETITIONS))));
     });
 }
 
@@ -298,12 +298,12 @@ fn count_until_v1(b: &mut Bencher) {
         .and_then(v1::Extern::into_func)
         .unwrap();
     const REPETITIONS: i32 = 100_000;
-    let mut result = [RuntimeValue::I32(0)];
+    let mut result = [Value::I32(0)];
     b.iter(|| {
         count_until
-            .call(&mut store, &[RuntimeValue::I32(REPETITIONS)], &mut result)
+            .call(&mut store, &[Value::I32(REPETITIONS)], &mut result)
             .unwrap();
-        assert_matches!(result, [RuntimeValue::I32(REPETITIONS)]);
+        assert_matches!(result, [Value::I32(REPETITIONS)]);
     });
 }
 
@@ -316,8 +316,8 @@ fn fac_recursive(b: &mut Bencher) {
         .assert_no_start();
 
     b.iter(|| {
-        let value = instance.invoke_export("fac-rec", &[RuntimeValue::I64(25)], &mut NopExternals);
-        assert_matches!(value, Ok(Some(RuntimeValue::I64(7034535277573963776))));
+        let value = instance.invoke_export("fac-rec", &[Value::I64(25)], &mut NopExternals);
+        assert_matches!(value, Ok(Some(Value::I64(7034535277573963776))));
     });
 }
 
@@ -337,12 +337,12 @@ fn fac_recursive_v1(b: &mut Bencher) {
         .get_export(&store, "fac-rec")
         .and_then(v1::Extern::into_func)
         .unwrap();
-    let mut result = [RuntimeValue::I64(0)];
+    let mut result = [Value::I64(0)];
 
     b.iter(|| {
-        fac.call(&mut store, &[RuntimeValue::I64(25)], &mut result)
+        fac.call(&mut store, &[Value::I64(25)], &mut result)
             .unwrap();
-        assert_matches!(result, [RuntimeValue::I64(7034535277573963776)]);
+        assert_matches!(result, [Value::I64(7034535277573963776)]);
     });
 }
 
@@ -355,8 +355,8 @@ fn fac_opt(b: &mut Bencher) {
         .assert_no_start();
 
     b.iter(|| {
-        let value = instance.invoke_export("fac-opt", &[RuntimeValue::I64(25)], &mut NopExternals);
-        assert_matches!(value, Ok(Some(RuntimeValue::I64(7034535277573963776))));
+        let value = instance.invoke_export("fac-opt", &[Value::I64(25)], &mut NopExternals);
+        assert_matches!(value, Ok(Some(Value::I64(7034535277573963776))));
     });
 }
 
@@ -376,12 +376,12 @@ fn fac_opt_v1(b: &mut Bencher) {
         .get_export(&store, "fac-opt")
         .and_then(v1::Extern::into_func)
         .unwrap();
-    let mut result = [RuntimeValue::I64(0)];
+    let mut result = [Value::I64(0)];
 
     b.iter(|| {
-        fac.call(&mut store, &[RuntimeValue::I64(25)], &mut result)
+        fac.call(&mut store, &[Value::I64(25)], &mut result)
             .unwrap();
-        assert_matches!(result, [RuntimeValue::I64(7034535277573963776)]);
+        assert_matches!(result, [Value::I64(7034535277573963776)]);
     });
 }
 
@@ -396,8 +396,8 @@ fn recursive_ok(b: &mut Bencher) {
         .assert_no_start();
 
     b.iter(|| {
-        let value = instance.invoke_export("call", &[RuntimeValue::I32(8000)], &mut NopExternals);
-        assert_matches!(value, Ok(Some(RuntimeValue::I32(0))));
+        let value = instance.invoke_export("call", &[Value::I32(8000)], &mut NopExternals);
+        assert_matches!(value, Ok(Some(Value::I32(0))));
     });
 }
 
@@ -417,13 +417,13 @@ fn recursive_ok_v1(b: &mut Bencher) {
         .get_export(&store, "call")
         .and_then(v1::Extern::into_func)
         .unwrap();
-    let mut result = [RuntimeValue::I32(0)];
+    let mut result = [Value::I32(0)];
 
     b.iter(|| {
         bench_call
-            .call(&mut store, &[RuntimeValue::I32(8000)], &mut result)
+            .call(&mut store, &[Value::I32(8000)], &mut result)
             .unwrap();
-        assert_matches!(result, [RuntimeValue::I32(0)]);
+        assert_matches!(result, [Value::I32(0)]);
     });
 }
 
@@ -436,7 +436,7 @@ fn recursive_trap(b: &mut Bencher) {
         .assert_no_start();
 
     b.iter(|| {
-        let value = instance.invoke_export("call", &[RuntimeValue::I32(1000)], &mut NopExternals);
+        let value = instance.invoke_export("call", &[Value::I32(1000)], &mut NopExternals);
         assert_matches!(value, Err(_));
     });
 }
@@ -463,7 +463,7 @@ fn host_calls(b: &mut Bencher) {
             &mut self,
             index: usize,
             args: RuntimeArgs,
-        ) -> Result<Option<RuntimeValue>, Trap> {
+        ) -> Result<Option<Value>, Trap> {
             match index {
                 HOST_CALL_INDEX => {
                     let arg = args.nth_value_checked(0)?;
@@ -536,10 +536,10 @@ fn host_calls(b: &mut Bencher) {
     b.iter(|| {
         let value = instance.invoke_export(
             "call",
-            &[RuntimeValue::I64(REPETITIONS)],
+            &[Value::I64(REPETITIONS)],
             &mut BenchExternals,
         );
-        assert_matches!(value, Ok(Some(RuntimeValue::I64(0))));
+        assert_matches!(value, Ok(Some(Value::I64(0))));
     });
 }
 
@@ -564,11 +564,11 @@ fn host_calls_v1(b: &mut Bencher) {
         .get_export(&store, "call")
         .and_then(v1::Extern::into_func)
         .unwrap();
-    let mut result = [RuntimeValue::I64(0)];
+    let mut result = [Value::I64(0)];
 
     b.iter(|| {
-        call.call(&mut store, &[RuntimeValue::I64(REPETITIONS)], &mut result)
+        call.call(&mut store, &[Value::I64(REPETITIONS)], &mut result)
             .unwrap();
-        assert_matches!(result, [RuntimeValue::I64(0)]);
+        assert_matches!(result, [Value::I64(0)]);
     });
 }

--- a/examples/interpret.rs
+++ b/examples/interpret.rs
@@ -3,7 +3,7 @@
 extern crate wasmi;
 
 use std::{env::args, fs::File};
-use wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, RuntimeValue};
+use wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, Value};
 
 fn load_from_file(filename: &str) -> Module {
     use std::io::prelude::*;
@@ -41,6 +41,6 @@ fn main() {
     // "_call" export of function to be executed with an i32 argument and prints the result of execution
     println!(
         "Result: {:?}",
-        main.invoke_export("_call", &[RuntimeValue::I32(argument)], &mut NopExternals)
+        main.invoke_export("_call", &[Value::I32(argument)], &mut NopExternals)
     );
 }

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -4,7 +4,7 @@ extern crate wasmi;
 use std::env::args;
 
 use parity_wasm::elements::{External, FunctionType, Internal, Module, Type, ValueType};
-use wasmi::{ImportsBuilder, ModuleInstance, NopExternals, RuntimeValue};
+use wasmi::{ImportsBuilder, ModuleInstance, NopExternals, Value};
 
 fn main() {
     let args: Vec<_> = args().collect();
@@ -72,30 +72,30 @@ fn main() {
             .iter()
             .enumerate()
             .map(|(i, value)| match value {
-                ValueType::I32 => RuntimeValue::I32(
+                ValueType::I32 => Value::I32(
                     program_args[i]
                         .parse::<i32>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as i32", program_args[i])),
                 ),
-                ValueType::I64 => RuntimeValue::I64(
+                ValueType::I64 => Value::I64(
                     program_args[i]
                         .parse::<i64>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as i64", program_args[i])),
                 ),
-                ValueType::F32 => RuntimeValue::F32(
+                ValueType::F32 => Value::F32(
                     program_args[i]
                         .parse::<f32>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as f32", program_args[i]))
                         .into(),
                 ),
-                ValueType::F64 => RuntimeValue::F64(
+                ValueType::F64 => Value::F64(
                     program_args[i]
                         .parse::<f64>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as f64", program_args[i]))
                         .into(),
                 ),
             })
-            .collect::<Vec<RuntimeValue>>()
+            .collect::<Vec<Value>>()
     };
 
     let loaded_module = wasmi::Module::from_parity_wasm_module(module).expect("Module to be valid");

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -15,9 +15,9 @@ use wasmi::{
     ModuleInstance,
     ModuleRef,
     RuntimeArgs,
-    Value,
     Signature,
     Trap,
+    Value,
     ValueType,
 };
 
@@ -152,11 +152,7 @@ const SET_FUNC_INDEX: usize = 0;
 const GET_FUNC_INDEX: usize = 1;
 
 impl<'a> Externals for Runtime<'a> {
-    fn invoke_index(
-        &mut self,
-        index: usize,
-        args: RuntimeArgs,
-    ) -> Result<Option<Value>, Trap> {
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
         match index {
             SET_FUNC_INDEX => {
                 let idx: i32 = args.nth(0);

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -15,7 +15,7 @@ use wasmi::{
     ModuleInstance,
     ModuleRef,
     RuntimeArgs,
-    RuntimeValue,
+    Value,
     Signature,
     Trap,
     ValueType,
@@ -156,7 +156,7 @@ impl<'a> Externals for Runtime<'a> {
         &mut self,
         index: usize,
         args: RuntimeArgs,
-    ) -> Result<Option<RuntimeValue>, Trap> {
+    ) -> Result<Option<Value>, Trap> {
         match index {
             SET_FUNC_INDEX => {
                 let idx: i32 = args.nth(0);

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -20,7 +20,7 @@ use wasmi::{
     ModuleImportResolver,
     ModuleInstance,
     NopExternals,
-    RuntimeValue,
+    Value,
     Signature,
     TableDescriptor,
     TableInstance,
@@ -48,7 +48,7 @@ impl ModuleImportResolver for ResolveAll {
         global_type: &GlobalDescriptor,
     ) -> Result<GlobalRef, Error> {
         Ok(GlobalInstance::alloc(
-            RuntimeValue::default(global_type.value_type()),
+            Value::default(global_type.value_type()),
             global_type.is_mutable(),
         ))
     }

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -20,11 +20,11 @@ use wasmi::{
     ModuleImportResolver,
     ModuleInstance,
     NopExternals,
-    Value,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
+    Value,
 };
 
 fn load_from_file(filename: &str) -> Module {

--- a/src/func.rs
+++ b/src/func.rs
@@ -4,7 +4,7 @@ use crate::{
     module::ModuleInstance,
     runner::{check_function_args, Interpreter, InterpreterState, StackRecycler},
     types::ValueType,
-    value::RuntimeValue,
+    value::Value,
     Signature,
     Trap,
 };
@@ -139,9 +139,9 @@ impl FuncInstance {
     /// [`Trap`]: #enum.Trap.html
     pub fn invoke<E: Externals>(
         func: &FuncRef,
-        args: &[RuntimeValue],
+        args: &[Value],
         externals: &mut E,
-    ) -> Result<Option<RuntimeValue>, Trap> {
+    ) -> Result<Option<Value>, Trap> {
         check_function_args(func.signature(), args)?;
         match *func.as_internal() {
             FuncInstanceInternal::Internal { .. } => {
@@ -164,10 +164,10 @@ impl FuncInstance {
     /// [`invoke`]: #method.invoke
     pub fn invoke_with_stack<E: Externals>(
         func: &FuncRef,
-        args: &[RuntimeValue],
+        args: &[Value],
         externals: &mut E,
         stack_recycler: &mut StackRecycler,
-    ) -> Result<Option<RuntimeValue>, Trap> {
+    ) -> Result<Option<Value>, Trap> {
         check_function_args(func.signature(), args)?;
         match *func.as_internal() {
             FuncInstanceInternal::Internal { .. } => {
@@ -199,7 +199,7 @@ impl FuncInstance {
     /// [`resume_execution`]: struct.FuncInvocation.html#method.resume_execution
     pub fn invoke_resumable<'args>(
         func: &FuncRef,
-        args: impl Into<Cow<'args, [RuntimeValue]>>,
+        args: impl Into<Cow<'args, [Value]>>,
     ) -> Result<FuncInvocation<'args>, Trap> {
         let args = args.into();
         check_function_args(func.signature(), &args)?;
@@ -262,7 +262,7 @@ pub struct FuncInvocation<'args> {
 enum FuncInvocationKind<'args> {
     Internal(Interpreter),
     Host {
-        args: Cow<'args, [RuntimeValue]>,
+        args: Cow<'args, [Value]>,
         host_func_index: usize,
         finished: bool,
     },
@@ -292,7 +292,7 @@ impl<'args> FuncInvocation<'args> {
     pub fn start_execution<'externals, E: Externals + 'externals>(
         &mut self,
         externals: &'externals mut E,
-    ) -> Result<Option<RuntimeValue>, ResumableError> {
+    ) -> Result<Option<Value>, ResumableError> {
         match self.kind {
             FuncInvocationKind::Internal(ref mut interpreter) => {
                 if interpreter.state() != &InterpreterState::Initialized {
@@ -324,9 +324,9 @@ impl<'args> FuncInvocation<'args> {
     /// [`is_resumable`]: #method.is_resumable
     pub fn resume_execution<'externals, E: Externals + 'externals>(
         &mut self,
-        return_val: Option<RuntimeValue>,
+        return_val: Option<Value>,
         externals: &'externals mut E,
-    ) -> Result<Option<RuntimeValue>, ResumableError> {
+    ) -> Result<Option<Value>, ResumableError> {
         use crate::TrapKind;
 
         if return_val.map(|v| v.value_type()) != self.resumable_value_type() {

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,4 +1,4 @@
-use crate::{types::ValueType, value::RuntimeValue, Error};
+use crate::{types::ValueType, value::Value, Error};
 use alloc::rc::Rc;
 use core::cell::Cell;
 use parity_wasm::elements::ValueType as EValueType;
@@ -27,11 +27,11 @@ impl ::core::ops::Deref for GlobalRef {
 /// Attempt to change value of immutable global or to change type of
 /// the value (e.g. assign [`I32`] value to a global that was created with [`I64`] type) will lead to an error.
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-/// [`I64`]: enum.RuntimeValue.html#variant.I64
+/// [`I32`]: enum.Value.html#variant.I32
+/// [`I64`]: enum.Value.html#variant.I64
 #[derive(Debug)]
 pub struct GlobalInstance {
-    val: Cell<RuntimeValue>,
+    val: Cell<Value>,
     mutable: bool,
 }
 
@@ -40,7 +40,7 @@ impl GlobalInstance {
     ///
     /// Since it is possible to export only immutable globals,
     /// users likely want to set `mutable` to `false`.
-    pub fn alloc(val: RuntimeValue, mutable: bool) -> GlobalRef {
+    pub fn alloc(val: Value, mutable: bool) -> GlobalRef {
         GlobalRef(Rc::new(GlobalInstance {
             val: Cell::new(val),
             mutable,
@@ -53,7 +53,7 @@ impl GlobalInstance {
     ///
     /// Returns `Err` if this global isn't mutable or if
     /// type of `val` doesn't match global's type.
-    pub fn set(&self, val: RuntimeValue) -> Result<(), Error> {
+    pub fn set(&self, val: Value) -> Result<(), Error> {
         if !self.mutable {
             return Err(Error::Global(
                 "Attempt to change an immutable variable".into(),
@@ -67,7 +67,7 @@ impl GlobalInstance {
     }
 
     /// Get the value of this global variable.
-    pub fn get(&self) -> RuntimeValue {
+    pub fn get(&self) -> Value {
         self.val.get()
     }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -209,11 +209,7 @@ impl_downcast!(HostError);
 /// ```
 pub trait Externals {
     /// Perform invoke of a host function by specified `index`.
-    fn invoke_index(
-        &mut self,
-        index: usize,
-        args: RuntimeArgs,
-    ) -> Result<Option<Value>, Trap>;
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap>;
 }
 
 /// Implementation of [`Externals`] that just traps on [`invoke_index`].
@@ -223,11 +219,7 @@ pub trait Externals {
 pub struct NopExternals;
 
 impl Externals for NopExternals {
-    fn invoke_index(
-        &mut self,
-        _index: usize,
-        _args: RuntimeArgs,
-    ) -> Result<Option<Value>, Trap> {
+    fn invoke_index(&mut self, _index: usize, _args: RuntimeArgs) -> Result<Option<Value>, Trap> {
         Err(TrapKind::Unreachable.into())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! extern crate wasmi;
 //! extern crate wabt;
 //!
-//! use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
+//! use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, Value};
 //!
 //! fn main() {
 //!     // Parse WAT (WebAssembly Text format) into wasm bytecode.
@@ -89,7 +89,7 @@
 //!             &[],
 //!             &mut NopExternals,
 //!         ).expect("failed to execute export"),
-//!         Some(RuntimeValue::I32(1337)),
+//!         Some(Value::I32(1337)),
 //!     );
 //! }
 //! ```
@@ -469,7 +469,7 @@ pub use self::{
     runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT},
     table::{TableInstance, TableRef},
     types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType},
-    value::{FromRuntimeValue, LittleEndianConvert, RuntimeValue},
+    value::{FromValue, LittleEndianConvert, Value},
 };
 
 /// WebAssembly-specific sizes and units.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,10 @@ use std::error;
 #[cfg(not(feature = "std"))]
 extern crate libm;
 
+#[doc(inline)]
+#[deprecated(note = "use `Value` instead")]
+pub use self::value::Value as RuntimeValue;
+
 /// Error type which can be thrown by wasm code or by host environment.
 ///
 /// Under some conditions, wasm execution may produce a `Trap`, which immediately aborts execution.
@@ -469,8 +473,9 @@ pub use self::{
     runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT},
     table::{TableInstance, TableRef},
     types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType},
-    value::{FromValue, LittleEndianConvert, Value},
+    value::{FromValue, LittleEndianConvert},
 };
+use self::value::Value;
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,9 +473,8 @@ pub use self::{
     runner::{StackRecycler, DEFAULT_CALL_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT},
     table::{TableInstance, TableRef},
     types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor, ValueType},
-    value::{FromValue, LittleEndianConvert},
+    value::{FromValue, LittleEndianConvert, Value},
 };
-use self::value::Value;
 
 /// WebAssembly-specific sizes and units.
 pub mod memory_units {

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,10 +11,10 @@ use crate::{
     Error,
     MemoryInstance,
     Module,
-    Value,
     Signature,
     TableInstance,
     Trap,
+    Value,
 };
 use alloc::{
     borrow::ToOwned,

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,7 +11,7 @@ use crate::{
     Error,
     MemoryInstance,
     Module,
-    RuntimeValue,
+    Value,
     Signature,
     TableInstance,
     Trap,
@@ -430,7 +430,7 @@ impl ModuleInstance {
                 .as_ref()
                 .expect("passive segments are rejected due to validation");
             let offset_val = match eval_init_expr(offset, &module_ref) {
-                RuntimeValue::I32(v) => v as u32,
+                Value::I32(v) => v as u32,
                 _ => panic!("Due to validation elem segment offset should evaluate to i32"),
             };
 
@@ -463,7 +463,7 @@ impl ModuleInstance {
                 .as_ref()
                 .expect("passive segments are rejected due to validation");
             let offset_val = match eval_init_expr(offset, &module_ref) {
-                RuntimeValue::I32(v) => v as u32,
+                Value::I32(v) => v as u32,
                 _ => panic!("Due to validation data segment offset should evaluate to i32"),
             };
 
@@ -604,7 +604,7 @@ impl ModuleInstance {
     /// ```rust
     /// # extern crate wasmi;
     /// # extern crate wabt;
-    /// # use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
+    /// # use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, Value};
     /// # fn main() {
     /// # let wasm_binary: Vec<u8> = wabt::wat2wasm(
     /// #   r#"
@@ -625,19 +625,19 @@ impl ModuleInstance {
     /// assert_eq!(
     ///     instance.invoke_export(
     ///         "add",
-    ///         &[RuntimeValue::I32(5), RuntimeValue::I32(3)],
+    ///         &[Value::I32(5), Value::I32(3)],
     ///         &mut NopExternals,
     ///     ).expect("failed to execute export"),
-    ///     Some(RuntimeValue::I32(8)),
+    ///     Some(Value::I32(8)),
     /// );
     /// # }
     /// ```
     pub fn invoke_export<E: Externals>(
         &self,
         func_name: &str,
-        args: &[RuntimeValue],
+        args: &[Value],
         externals: &mut E,
-    ) -> Result<Option<RuntimeValue>, Error> {
+    ) -> Result<Option<Value>, Error> {
         let func_instance = self.func_by_name(func_name)?;
 
         FuncInstance::invoke(&func_instance, args, externals).map_err(Error::Trap)
@@ -653,10 +653,10 @@ impl ModuleInstance {
     pub fn invoke_export_with_stack<E: Externals>(
         &self,
         func_name: &str,
-        args: &[RuntimeValue],
+        args: &[Value],
         externals: &mut E,
         stack_recycler: &mut StackRecycler,
-    ) -> Result<Option<RuntimeValue>, Error> {
+    ) -> Result<Option<Value>, Error> {
         let func_instance = self.func_by_name(func_name)?;
 
         FuncInstance::invoke_with_stack(&func_instance, args, externals, stack_recycler)
@@ -779,7 +779,7 @@ impl<'a> NotStartedModuleRef<'a> {
     }
 }
 
-fn eval_init_expr(init_expr: &InitExpr, module: &ModuleInstance) -> RuntimeValue {
+fn eval_init_expr(init_expr: &InitExpr, module: &ModuleInstance) -> Value {
     let code = init_expr.code();
     debug_assert!(
         code.len() == 2,
@@ -788,8 +788,8 @@ fn eval_init_expr(init_expr: &InitExpr, module: &ModuleInstance) -> RuntimeValue
     match code[0] {
         Instruction::I32Const(v) => v.into(),
         Instruction::I64Const(v) => v.into(),
-        Instruction::F32Const(v) => RuntimeValue::decode_f32(v),
-        Instruction::F64Const(v) => RuntimeValue::decode_f64(v),
+        Instruction::F32Const(v) => Value::decode_f32(v),
+        Instruction::F64Const(v) => Value::decode_f64(v),
         Instruction::GetGlobal(idx) => {
             let global = module
                 .global_by_index(idx)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,7 +14,7 @@ use crate::{
         Float,
         Integer,
         LittleEndianConvert,
-        RuntimeValue,
+        Value,
         TransmuteInto,
         TryTruncateInto,
         WrapInto,
@@ -42,93 +42,93 @@ pub const DEFAULT_CALL_STACK_LIMIT: usize = 64 * 1024;
 /// spec tests) and not undefined behaviour.
 ///
 /// At the boundary between the interpreter and the outside world we convert to the public
-/// `RuntimeValue` type, which can then be matched on. We can create a `RuntimeValue` from
-/// a `RuntimeValueInternal` only when the type is statically known, which it always is
+/// `Value` type, which can then be matched on. We can create a `Value` from
+/// a `ValueInternal` only when the type is statically known, which it always is
 /// at these boundaries.
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
 #[repr(transparent)]
-struct RuntimeValueInternal(pub u64);
+struct ValueInternal(pub u64);
 
-impl RuntimeValueInternal {
-    pub fn with_type(self, ty: ValueType) -> RuntimeValue {
+impl ValueInternal {
+    pub fn with_type(self, ty: ValueType) -> Value {
         match ty {
-            ValueType::I32 => RuntimeValue::I32(<_>::from_runtime_value_internal(self)),
-            ValueType::I64 => RuntimeValue::I64(<_>::from_runtime_value_internal(self)),
-            ValueType::F32 => RuntimeValue::F32(<_>::from_runtime_value_internal(self)),
-            ValueType::F64 => RuntimeValue::F64(<_>::from_runtime_value_internal(self)),
+            ValueType::I32 => Value::I32(<_>::from_value_internal(self)),
+            ValueType::I64 => Value::I64(<_>::from_value_internal(self)),
+            ValueType::F32 => Value::F32(<_>::from_value_internal(self)),
+            ValueType::F64 => Value::F64(<_>::from_value_internal(self)),
         }
     }
 }
 
-trait FromRuntimeValueInternal
+trait FromValueInternal
 where
     Self: Sized,
 {
-    fn from_runtime_value_internal(val: RuntimeValueInternal) -> Self;
+    fn from_value_internal(val: ValueInternal) -> Self;
 }
 
-macro_rules! impl_from_runtime_value_internal {
+macro_rules! impl_from_value_internal {
 	($($t:ty),*) =>	{
 		$(
-			impl FromRuntimeValueInternal for $t {
-				fn from_runtime_value_internal(
-					RuntimeValueInternal(val): RuntimeValueInternal,
+			impl FromValueInternal for $t {
+				fn from_value_internal(
+					ValueInternal(val): ValueInternal,
 				) -> Self {
 					val	as _
 				}
 			}
 
-			impl From<$t> for RuntimeValueInternal {
+			impl From<$t> for ValueInternal {
 				fn from(other: $t) -> Self {
-					RuntimeValueInternal(other as _)
+					ValueInternal(other as _)
 				}
 			}
 		)*
 	};
 }
 
-macro_rules! impl_from_runtime_value_internal_float	{
+macro_rules! impl_from_value_internal_float	{
 	($($t:ty),*) =>	{
 		$(
-			impl FromRuntimeValueInternal for $t {
-				fn from_runtime_value_internal(
-					RuntimeValueInternal(val): RuntimeValueInternal,
+			impl FromValueInternal for $t {
+				fn from_value_internal(
+					ValueInternal(val): ValueInternal,
 				) -> Self {
 					<$t>::from_bits(val	as _)
 				}
 			}
 
-			impl From<$t> for RuntimeValueInternal {
+			impl From<$t> for ValueInternal {
 				fn from(other: $t) -> Self {
-					RuntimeValueInternal(other.to_bits() as	_)
+					ValueInternal(other.to_bits() as	_)
 				}
 			}
 		)*
 	};
 }
 
-impl_from_runtime_value_internal!(i8, u8, i16, u16, i32, u32, i64, u64);
-impl_from_runtime_value_internal_float!(f32, f64, F32, F64);
+impl_from_value_internal!(i8, u8, i16, u16, i32, u32, i64, u64);
+impl_from_value_internal_float!(f32, f64, F32, F64);
 
-impl From<bool> for RuntimeValueInternal {
+impl From<bool> for ValueInternal {
     fn from(other: bool) -> Self {
         (if other { 1 } else { 0 }).into()
     }
 }
 
-impl FromRuntimeValueInternal for bool {
-    fn from_runtime_value_internal(RuntimeValueInternal(val): RuntimeValueInternal) -> Self {
+impl FromValueInternal for bool {
+    fn from_value_internal(ValueInternal(val): ValueInternal) -> Self {
         val != 0
     }
 }
 
-impl From<RuntimeValue> for RuntimeValueInternal {
-    fn from(other: RuntimeValue) -> Self {
+impl From<Value> for ValueInternal {
+    fn from(other: Value) -> Self {
         match other {
-            RuntimeValue::I32(val) => val.into(),
-            RuntimeValue::I64(val) => val.into(),
-            RuntimeValue::F32(val) => val.into(),
-            RuntimeValue::F64(val) => val.into(),
+            Value::I32(val) => val.into(),
+            Value::I64(val) => val.into(),
+            Value::F32(val) => val.into(),
+            Value::F64(val) => val.into(),
         }
     }
 }
@@ -177,13 +177,13 @@ pub struct Interpreter {
     call_stack: CallStack,
     return_type: Option<ValueType>,
     state: InterpreterState,
-    scratch: Vec<RuntimeValue>,
+    scratch: Vec<Value>,
 }
 
 impl Interpreter {
     pub fn new(
         func: &FuncRef,
-        args: &[RuntimeValue],
+        args: &[Value],
         mut stack_recycler: Option<&mut StackRecycler>,
     ) -> Result<Interpreter, Trap> {
         let mut value_stack = StackRecycler::recreate_value_stack(&mut stack_recycler);
@@ -218,7 +218,7 @@ impl Interpreter {
     pub fn start_execution<'a, E: Externals + 'a>(
         &mut self,
         externals: &'a mut E,
-    ) -> Result<Option<RuntimeValue>, Trap> {
+    ) -> Result<Option<Value>, Trap> {
         // Ensure that the VM has not been executed. This is checked in `FuncInvocation::start_execution`.
         assert!(self.state == InterpreterState::Initialized);
 
@@ -237,9 +237,9 @@ impl Interpreter {
 
     pub fn resume_execution<'a, E: Externals + 'a>(
         &mut self,
-        return_val: Option<RuntimeValue>,
+        return_val: Option<Value>,
         externals: &'a mut E,
-    ) -> Result<Option<RuntimeValue>, Trap> {
+    ) -> Result<Option<Value>, Trap> {
         use core::mem::swap;
 
         // Ensure that the VM is resumable. This is checked in `FuncInvocation::resume_execution`.
@@ -703,7 +703,7 @@ impl Interpreter {
     fn run_select(&mut self) -> Result<InstructionOutcome, TrapKind> {
         let (left, mid, right) = self.value_stack.pop_triple();
 
-        let condition = <_>::from_runtime_value_internal(right);
+        let condition = <_>::from_value_internal(right);
         let val = if condition { left } else { mid };
         self.value_stack.push(val)?;
         Ok(InstructionOutcome::RunNextInstruction)
@@ -763,7 +763,7 @@ impl Interpreter {
         offset: u32,
     ) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
+        ValueInternal: From<T>,
         T: LittleEndianConvert,
     {
         let raw_address = self.value_stack.pop_as();
@@ -785,7 +785,7 @@ impl Interpreter {
     ) -> Result<InstructionOutcome, TrapKind>
     where
         T: ExtendInto<U>,
-        RuntimeValueInternal: From<U>,
+        ValueInternal: From<U>,
         T: LittleEndianConvert,
     {
         let raw_address = self.value_stack.pop_as();
@@ -809,7 +809,7 @@ impl Interpreter {
         offset: u32,
     ) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal,
+        T: FromValueInternal,
         T: LittleEndianConvert,
     {
         let stack_value = self.value_stack.pop_as::<T>();
@@ -830,11 +830,11 @@ impl Interpreter {
         offset: u32,
     ) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal,
+        T: FromValueInternal,
         T: WrapInto<U>,
         U: LittleEndianConvert,
     {
-        let stack_value: T = <_>::from_runtime_value_internal(self.value_stack.pop());
+        let stack_value: T = <_>::from_value_internal(self.value_stack.pop());
         let stack_value = stack_value.wrap_into();
         let raw_address = self.value_stack.pop_as::<u32>();
         let address = effective_address(offset, raw_address)?;
@@ -854,7 +854,7 @@ impl Interpreter {
             .memory()
             .expect("Due to validation memory should exists");
         let s = m.current_size().0;
-        self.value_stack.push(RuntimeValueInternal(s as _))?;
+        self.value_stack.push(ValueInternal(s as _))?;
         Ok(InstructionOutcome::RunNextInstruction)
     }
 
@@ -870,11 +870,11 @@ impl Interpreter {
             Ok(Pages(new_size)) => new_size as u32,
             Err(_) => u32::MAX, // Returns -1 (or 0xFFFFFFFF) in case of error.
         };
-        self.value_stack.push(RuntimeValueInternal(m as _))?;
+        self.value_stack.push(ValueInternal(m as _))?;
         Ok(InstructionOutcome::RunNextInstruction)
     }
 
-    fn run_const(&mut self, val: RuntimeValue) -> Result<InstructionOutcome, TrapKind> {
+    fn run_const(&mut self, val: Value) -> Result<InstructionOutcome, TrapKind> {
         self.value_stack
             .push(val.into())
             .map_err(Into::into)
@@ -883,14 +883,14 @@ impl Interpreter {
 
     fn run_relop<T, F>(&mut self, f: F) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal,
+        T: FromValueInternal,
         F: FnOnce(T, T) -> bool,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = if f(left, right) {
-            RuntimeValueInternal(1)
+            ValueInternal(1)
         } else {
-            RuntimeValueInternal(0)
+            ValueInternal(0)
         };
         self.value_stack.push(v)?;
         Ok(InstructionOutcome::RunNextInstruction)
@@ -898,53 +898,53 @@ impl Interpreter {
 
     fn run_eqz<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal,
+        T: FromValueInternal,
         T: PartialEq<T> + Default,
     {
         let v = self.value_stack.pop_as::<T>();
-        let v = RuntimeValueInternal(if v == Default::default() { 1 } else { 0 });
+        let v = ValueInternal(if v == Default::default() { 1 } else { 0 });
         self.value_stack.push(v)?;
         Ok(InstructionOutcome::RunNextInstruction)
     }
 
     fn run_eq<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal + PartialEq<T>,
+        T: FromValueInternal + PartialEq<T>,
     {
         self.run_relop(|left: T, right: T| left == right)
     }
 
     fn run_ne<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal + PartialEq<T>,
+        T: FromValueInternal + PartialEq<T>,
     {
         self.run_relop(|left: T, right: T| left != right)
     }
 
     fn run_lt<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal + PartialOrd<T>,
+        T: FromValueInternal + PartialOrd<T>,
     {
         self.run_relop(|left: T, right: T| left < right)
     }
 
     fn run_gt<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal + PartialOrd<T>,
+        T: FromValueInternal + PartialOrd<T>,
     {
         self.run_relop(|left: T, right: T| left > right)
     }
 
     fn run_lte<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal + PartialOrd<T>,
+        T: FromValueInternal + PartialOrd<T>,
     {
         self.run_relop(|left: T, right: T| left <= right)
     }
 
     fn run_gte<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        T: FromRuntimeValueInternal + PartialOrd<T>,
+        T: FromValueInternal + PartialOrd<T>,
     {
         self.run_relop(|left: T, right: T| left >= right)
     }
@@ -952,8 +952,8 @@ impl Interpreter {
     fn run_unop<T, U, F>(&mut self, f: F) -> Result<InstructionOutcome, TrapKind>
     where
         F: FnOnce(T) -> U,
-        T: FromRuntimeValueInternal,
-        RuntimeValueInternal: From<U>,
+        T: FromValueInternal,
+        ValueInternal: From<U>,
     {
         let v = self.value_stack.pop_as::<T>();
         let v = f(v);
@@ -963,32 +963,32 @@ impl Interpreter {
 
     fn run_clz<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Integer<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Integer<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.leading_zeros())
     }
 
     fn run_ctz<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Integer<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Integer<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.trailing_zeros())
     }
 
     fn run_popcnt<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Integer<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Integer<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.count_ones())
     }
 
     fn run_add<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: ArithmeticOps<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: ArithmeticOps<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.add(right);
@@ -998,8 +998,8 @@ impl Interpreter {
 
     fn run_sub<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: ArithmeticOps<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: ArithmeticOps<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.sub(right);
@@ -1009,8 +1009,8 @@ impl Interpreter {
 
     fn run_mul<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: ArithmeticOps<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: ArithmeticOps<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.mul(right);
@@ -1020,8 +1020,8 @@ impl Interpreter {
 
     fn run_div<T, U>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: TransmuteInto<U> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: TransmuteInto<U> + FromValueInternal,
         U: ArithmeticOps<U> + TransmuteInto<T>,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
@@ -1034,8 +1034,8 @@ impl Interpreter {
 
     fn run_rem<T, U>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: TransmuteInto<U> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: TransmuteInto<U> + FromValueInternal,
         U: Integer<U> + TransmuteInto<T>,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
@@ -1048,8 +1048,8 @@ impl Interpreter {
 
     fn run_and<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<<T as ops::BitAnd>::Output>,
-        T: ops::BitAnd<T> + FromRuntimeValueInternal,
+        ValueInternal: From<<T as ops::BitAnd>::Output>,
+        T: ops::BitAnd<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.bitand(right);
@@ -1059,8 +1059,8 @@ impl Interpreter {
 
     fn run_or<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<<T as ops::BitOr>::Output>,
-        T: ops::BitOr<T> + FromRuntimeValueInternal,
+        ValueInternal: From<<T as ops::BitOr>::Output>,
+        T: ops::BitOr<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.bitor(right);
@@ -1070,8 +1070,8 @@ impl Interpreter {
 
     fn run_xor<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<<T as ops::BitXor>::Output>,
-        T: ops::BitXor<T> + FromRuntimeValueInternal,
+        ValueInternal: From<<T as ops::BitXor>::Output>,
+        T: ops::BitXor<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.bitxor(right);
@@ -1081,8 +1081,8 @@ impl Interpreter {
 
     fn run_shl<T>(&mut self, mask: T) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<<T as ops::Shl<T>>::Output>,
-        T: ops::Shl<T> + ops::BitAnd<T, Output = T> + FromRuntimeValueInternal,
+        ValueInternal: From<<T as ops::Shl<T>>::Output>,
+        T: ops::Shl<T> + ops::BitAnd<T, Output = T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.shl(right & mask);
@@ -1092,8 +1092,8 @@ impl Interpreter {
 
     fn run_shr<T, U>(&mut self, mask: U) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: TransmuteInto<U> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: TransmuteInto<U> + FromValueInternal,
         U: ops::Shr<U> + ops::BitAnd<U, Output = U>,
         <U as ops::Shr<U>>::Output: TransmuteInto<T>,
     {
@@ -1107,8 +1107,8 @@ impl Interpreter {
 
     fn run_rotl<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Integer<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Integer<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.rotl(right);
@@ -1118,8 +1118,8 @@ impl Interpreter {
 
     fn run_rotr<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Integer<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Integer<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.rotr(right);
@@ -1129,64 +1129,64 @@ impl Interpreter {
 
     fn run_abs<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.abs())
     }
 
     fn run_neg<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<<T as ops::Neg>::Output>,
-        T: ops::Neg + FromRuntimeValueInternal,
+        ValueInternal: From<<T as ops::Neg>::Output>,
+        T: ops::Neg + FromValueInternal,
     {
         self.run_unop(|v: T| v.neg())
     }
 
     fn run_ceil<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.ceil())
     }
 
     fn run_floor<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.floor())
     }
 
     fn run_trunc<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.trunc())
     }
 
     fn run_nearest<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.nearest())
     }
 
     fn run_sqrt<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         self.run_unop(|v: T| v.sqrt())
     }
 
     fn run_min<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.min(right);
@@ -1196,8 +1196,8 @@ impl Interpreter {
 
     fn run_max<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.max(right);
@@ -1207,8 +1207,8 @@ impl Interpreter {
 
     fn run_copysign<T>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<T>,
-        T: Float<T> + FromRuntimeValueInternal,
+        ValueInternal: From<T>,
+        T: Float<T> + FromValueInternal,
     {
         let (left, right) = self.value_stack.pop_pair_as::<T>();
         let v = left.copysign(right);
@@ -1218,16 +1218,16 @@ impl Interpreter {
 
     fn run_wrap<T, U>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<U>,
-        T: WrapInto<U> + FromRuntimeValueInternal,
+        ValueInternal: From<U>,
+        T: WrapInto<U> + FromValueInternal,
     {
         self.run_unop(|v: T| v.wrap_into())
     }
 
     fn run_trunc_to_int<T, U, V>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<V>,
-        T: TryTruncateInto<U, TrapKind> + FromRuntimeValueInternal,
+        ValueInternal: From<V>,
+        T: TryTruncateInto<U, TrapKind> + FromValueInternal,
         U: TransmuteInto<V>,
     {
         let v = self.value_stack.pop_as::<T>();
@@ -1240,8 +1240,8 @@ impl Interpreter {
 
     fn run_extend<T, U, V>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<V>,
-        T: ExtendInto<U> + FromRuntimeValueInternal,
+        ValueInternal: From<V>,
+        T: ExtendInto<U> + FromValueInternal,
         U: TransmuteInto<V>,
     {
         let v = self.value_stack.pop_as::<T>();
@@ -1254,8 +1254,8 @@ impl Interpreter {
 
     fn run_reinterpret<T, U>(&mut self) -> Result<InstructionOutcome, TrapKind>
     where
-        RuntimeValueInternal: From<U>,
-        T: FromRuntimeValueInternal,
+        ValueInternal: From<U>,
+        T: FromValueInternal,
         T: TransmuteInto<U>,
     {
         let v = self.value_stack.pop_as::<T>();
@@ -1339,7 +1339,7 @@ fn effective_address(address: u32, offset: u32) -> Result<u32, TrapKind> {
 fn prepare_function_args(
     signature: &Signature,
     caller_stack: &mut ValueStack,
-    host_args: &mut Vec<RuntimeValue>,
+    host_args: &mut Vec<Value>,
 ) {
     let req_args = signature.params();
     let len_args = req_args.len();
@@ -1353,7 +1353,7 @@ fn prepare_function_args(
     host_args.extend(prepared_args);
 }
 
-pub fn check_function_args(signature: &Signature, args: &[RuntimeValue]) -> Result<(), Trap> {
+pub fn check_function_args(signature: &Signature, args: &[Value]) -> Result<(), Trap> {
     if signature.params().len() != args.len() {
         return Err(TrapKind::UnexpectedSignature.into());
     }
@@ -1371,7 +1371,7 @@ pub fn check_function_args(signature: &Signature, args: &[RuntimeValue]) -> Resu
 }
 
 struct ValueStack {
-    buf: Box<[RuntimeValueInternal]>,
+    buf: Box<[ValueInternal]>,
     /// Index of the first free place in the stack.
     sp: usize,
 }
@@ -1400,17 +1400,17 @@ impl ValueStack {
     #[inline]
     fn pop_as<T>(&mut self) -> T
     where
-        T: FromRuntimeValueInternal,
+        T: FromValueInternal,
     {
         let value = self.pop();
 
-        T::from_runtime_value_internal(value)
+        T::from_value_internal(value)
     }
 
     #[inline]
     fn pop_pair_as<T>(&mut self) -> (T, T)
     where
-        T: FromRuntimeValueInternal,
+        T: FromValueInternal,
     {
         let right = self.pop_as();
         let left = self.pop_as();
@@ -1421,9 +1421,9 @@ impl ValueStack {
     fn pop_triple(
         &mut self,
     ) -> (
-        RuntimeValueInternal,
-        RuntimeValueInternal,
-        RuntimeValueInternal,
+        ValueInternal,
+        ValueInternal,
+        ValueInternal,
     ) {
         let right = self.pop();
         let mid = self.pop();
@@ -1432,27 +1432,27 @@ impl ValueStack {
     }
 
     #[inline]
-    fn top(&self) -> &RuntimeValueInternal {
+    fn top(&self) -> &ValueInternal {
         self.pick(1)
     }
 
-    fn pick(&self, depth: usize) -> &RuntimeValueInternal {
+    fn pick(&self, depth: usize) -> &ValueInternal {
         &self.buf[self.sp - depth]
     }
 
     #[inline]
-    fn pick_mut(&mut self, depth: usize) -> &mut RuntimeValueInternal {
+    fn pick_mut(&mut self, depth: usize) -> &mut ValueInternal {
         &mut self.buf[self.sp - depth]
     }
 
     #[inline]
-    fn pop(&mut self) -> RuntimeValueInternal {
+    fn pop(&mut self) -> ValueInternal {
         self.sp -= 1;
         self.buf[self.sp]
     }
 
     #[inline]
-    fn push(&mut self, value: RuntimeValueInternal) -> Result<(), TrapKind> {
+    fn push(&mut self, value: ValueInternal) -> Result<(), TrapKind> {
         let cell = self.buf.get_mut(self.sp).ok_or(TrapKind::StackOverflow)?;
         *cell = value;
         self.sp += 1;
@@ -1484,7 +1484,7 @@ impl ValueStack {
     /// # Panics
     ///
     /// If the value stack does not have at least `depth` stack entries.
-    pub fn pop_slice(&mut self, depth: usize) -> &[RuntimeValueInternal] {
+    pub fn pop_slice(&mut self, depth: usize) -> &[ValueInternal] {
         self.sp -= depth;
         let start = self.sp;
         let end = self.sp + depth;
@@ -1517,7 +1517,7 @@ impl CallStack {
 
 /// Used to recycle stacks instead of allocating them repeatedly.
 pub struct StackRecycler {
-    value_stack_buf: Option<Box<[RuntimeValueInternal]>>,
+    value_stack_buf: Option<Box<[ValueInternal]>>,
     value_stack_limit: usize,
     call_stack_buf: Option<Vec<FunctionContext>>,
     call_stack_limit: usize,
@@ -1547,7 +1547,7 @@ impl StackRecycler {
     pub fn clear(&mut self) {
         if let Some(buf) = &mut self.value_stack_buf {
             for cell in buf.iter_mut() {
-                *cell = RuntimeValueInternal(0);
+                *cell = ValueInternal(0);
             }
         }
     }
@@ -1556,7 +1556,7 @@ impl StackRecycler {
         let limit = this
             .as_ref()
             .map_or(DEFAULT_VALUE_STACK_LIMIT, |this| this.value_stack_limit)
-            / ::core::mem::size_of::<RuntimeValueInternal>();
+            / ::core::mem::size_of::<ValueInternal>();
 
         let buf = this
             .as_mut()
@@ -1564,7 +1564,7 @@ impl StackRecycler {
             .unwrap_or_else(|| {
                 let mut buf = Vec::new();
                 buf.reserve_exact(limit);
-                buf.resize(limit, RuntimeValueInternal(0));
+                buf.resize(limit, ValueInternal(0));
                 buf.into_boxed_slice()
             });
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,9 +14,9 @@ use crate::{
         Float,
         Integer,
         LittleEndianConvert,
-        Value,
         TransmuteInto,
         TryTruncateInto,
+        Value,
         WrapInto,
     },
     Signature,
@@ -1418,13 +1418,7 @@ impl ValueStack {
     }
 
     #[inline]
-    fn pop_triple(
-        &mut self,
-    ) -> (
-        ValueInternal,
-        ValueInternal,
-        ValueInternal,
-    ) {
+    fn pop_triple(&mut self) -> (ValueInternal, ValueInternal, ValueInternal) {
         let right = self.pop();
         let mid = self.pop();
         let left = self.pop();

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -19,13 +19,13 @@ use crate::{
     ModuleRef,
     ResumableError,
     RuntimeArgs,
-    Value,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
     Trap,
     TrapKind,
+    Value,
 };
 use alloc::boxed::Box;
 use std::println;
@@ -108,11 +108,7 @@ const RECURSE_FUNC_INDEX: usize = 4;
 const TRAP_SUB_FUNC_INDEX: usize = 5;
 
 impl Externals for TestHost {
-    fn invoke_index(
-        &mut self,
-        index: usize,
-        args: RuntimeArgs,
-    ) -> Result<Option<Value>, Trap> {
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
         match index {
             SUB_FUNC_INDEX => {
                 let a: i32 = args.nth(0);
@@ -602,11 +598,7 @@ fn defer_providing_externals() {
     }
 
     impl<'a> Externals for HostExternals<'a> {
-        fn invoke_index(
-            &mut self,
-            index: usize,
-            args: RuntimeArgs,
-        ) -> Result<Option<Value>, Trap> {
+        fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
             match index {
                 INC_FUNC_INDEX => {
                     let a = args.nth::<u32>(0);
@@ -807,9 +799,7 @@ fn dynamically_add_host_func() {
 
                     Ok(Some(Value::I32(table_index as i32)))
                 }
-                index if index as u32 <= self.added_funcs => {
-                    Ok(Some(Value::I32(index as i32)))
-                }
+                index if index as u32 <= self.added_funcs => Ok(Some(Value::I32(index as i32))),
                 _ => panic!("'env' module doesn't provide function at index {}", index),
             }
         }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,20 +20,20 @@ fn assert_error_properties() {
 }
 
 /// Test that converting an u32 (u64) that does not fit in an i32 (i64)
-/// to a RuntimeValue and back works as expected and the number remains unchanged.
+/// to a Value and back works as expected and the number remains unchanged.
 #[test]
-fn unsigned_to_runtime_value() {
-    use super::RuntimeValue;
+fn unsigned_to_value() {
+    use super::Value;
 
     let overflow_i32: u32 = ::core::i32::MAX as u32 + 1;
     assert_eq!(
-        RuntimeValue::from(overflow_i32).try_into::<u32>().unwrap(),
+        Value::from(overflow_i32).try_into::<u32>().unwrap(),
         overflow_i32
     );
 
     let overflow_i64: u64 = ::core::i64::MAX as u64 + 1;
     assert_eq!(
-        RuntimeValue::from(overflow_i64).try_into::<u64>().unwrap(),
+        Value::from(overflow_i64).try_into::<u64>().unwrap(),
         overflow_i64
     );
 }

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -16,7 +16,7 @@ use crate::{
     ModuleImportResolver,
     ModuleInstance,
     NopExternals,
-    RuntimeValue,
+    Value,
     Signature,
     TableDescriptor,
     TableInstance,
@@ -35,8 +35,8 @@ struct Env {
 impl Env {
     fn new() -> Env {
         Env {
-            table_base: GlobalInstance::alloc(RuntimeValue::I32(0), false),
-            memory_base: GlobalInstance::alloc(RuntimeValue::I32(0), false),
+            table_base: GlobalInstance::alloc(Value::I32(0), false),
+            memory_base: GlobalInstance::alloc(Value::I32(0), false),
             memory: MemoryInstance::alloc(Pages(256), None).unwrap(),
             table: TableInstance::alloc(64, None).unwrap(),
         }
@@ -120,8 +120,8 @@ fn interpreter_inc_i32() {
 
     let i32_val = 42;
     // the functions expects a single i32 parameter
-    let args = &[RuntimeValue::I32(i32_val)];
-    let exp_retval = Some(RuntimeValue::I32(i32_val + 1));
+    let args = &[Value::I32(i32_val)];
+    let exp_retval = Some(Value::I32(i32_val + 1));
 
     let retval = instance
         .invoke_export(FUNCTION_NAME, args, &mut NopExternals)
@@ -154,8 +154,8 @@ fn interpreter_accumulate_u8() {
 
     // Set up the function argument list and invoke the function
     let args = &[
-        RuntimeValue::I32(BUF.len() as i32),
-        RuntimeValue::I32(offset as i32),
+        Value::I32(BUF.len() as i32),
+        Value::I32(offset as i32),
     ];
     let retval = instance
         .invoke_export(FUNCTION_NAME, args, &mut NopExternals)
@@ -163,7 +163,7 @@ fn interpreter_accumulate_u8() {
 
     // For verification, repeat accumulation using native code
     let accu = BUF.iter().fold(0_i32, |a, b| a + *b as i32);
-    let exp_retval: Option<RuntimeValue> = Some(RuntimeValue::I32(accu));
+    let exp_retval: Option<Value> = Some(Value::I32(accu));
 
     // Verify calculation from WebAssembly runtime is identical to expected result
     assert_eq!(exp_retval, retval);

--- a/src/tests/wasm.rs
+++ b/src/tests/wasm.rs
@@ -16,11 +16,11 @@ use crate::{
     ModuleImportResolver,
     ModuleInstance,
     NopExternals,
-    Value,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
+    Value,
 };
 use alloc::vec::Vec;
 use std::fs::File;
@@ -153,10 +153,7 @@ fn interpreter_accumulate_u8() {
     let _ = env_memory.set(offset, BUF);
 
     // Set up the function argument list and invoke the function
-    let args = &[
-        Value::I32(BUF.len() as i32),
-        Value::I32(offset as i32),
-    ];
+    let args = &[Value::I32(BUF.len() as i32), Value::I32(offset as i32)];
     let retval = instance
         .invoke_export(FUNCTION_NAME, args, &mut NopExternals)
         .expect("Failed to execute function");

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,9 +79,9 @@ impl Signature {
 
 /// Type of a value.
 ///
-/// See [`RuntimeValue`] for details.
+/// See [`Value`] for details.
 ///
-/// [`RuntimeValue`]: enum.RuntimeValue.html
+/// [`Value`]: enum.Value.html
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ValueType {
     /// 32-bit signed or unsigned integer.

--- a/src/v1/engine/inst_builder.rs
+++ b/src/v1/engine/inst_builder.rs
@@ -6,7 +6,7 @@ use super::{
     FuncBody,
     Instruction,
 };
-use crate::{RuntimeValue, ValueType};
+use crate::{Value, ValueType};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Display, mem};
 
@@ -413,12 +413,12 @@ impl InstructionsBuilder {
     /// - `i64.const`
     /// - `f32.const`
     /// - `f64.const`
-    pub fn constant(&mut self, value: RuntimeValue) -> InstructionIdx {
+    pub fn constant(&mut self, value: Value) -> InstructionIdx {
         let inst = match value {
-            RuntimeValue::I32(value) => Instruction::I32Const(value),
-            RuntimeValue::I64(value) => Instruction::I64Const(value),
-            RuntimeValue::F32(value) => Instruction::F32Const(value),
-            RuntimeValue::F64(value) => Instruction::F64Const(value),
+            Value::I32(value) => Instruction::I32Const(value),
+            Value::I64(value) => Instruction::I64Const(value),
+            Value::F32(value) => Instruction::F32Const(value),
+            Value::F64(value) => Instruction::F64Const(value),
         };
         self.push_inst(inst)
     }

--- a/src/v1/engine/mod.rs
+++ b/src/v1/engine/mod.rs
@@ -21,9 +21,9 @@ use self::{
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func, Signature};
 use crate::{
-    Value,
     Trap,
     TrapKind,
+    Value,
     ValueType,
     DEFAULT_CALL_STACK_LIMIT,
     DEFAULT_VALUE_STACK_LIMIT,

--- a/src/v1/engine/mod.rs
+++ b/src/v1/engine/mod.rs
@@ -21,7 +21,7 @@ use self::{
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func, Signature};
 use crate::{
-    RuntimeValue,
+    Value,
     Trap,
     TrapKind,
     ValueType,
@@ -167,8 +167,8 @@ impl Engine {
         &mut self,
         ctx: impl AsContextMut,
         func: Func,
-        args: &[RuntimeValue],
-        results: &mut [RuntimeValue],
+        args: &[Value],
+        results: &mut [Value],
     ) -> Result<(), Trap> {
         self.inner.lock().execute_func(ctx, func, args, results)
     }
@@ -184,7 +184,7 @@ pub struct EngineInner {
     /// Stores all Wasm function bodies that the interpreter is aware of.
     code_map: CodeMap,
     /// Scratch buffer for intermediate results and data.
-    scratch: Vec<RuntimeValue>,
+    scratch: Vec<Value>,
 }
 
 impl EngineInner {
@@ -224,8 +224,8 @@ impl EngineInner {
         &mut self,
         mut ctx: impl AsContextMut,
         func: Func,
-        args: &[RuntimeValue],
-        results: &mut [RuntimeValue],
+        args: &[Value],
+        results: &mut [Value],
     ) -> Result<(), Trap> {
         match func.as_internal(&ctx) {
             FuncEntityInternal::Wasm(wasm_func) => {
@@ -256,8 +256,8 @@ impl EngineInner {
         &mut self,
         mut ctx: impl AsContextMut,
         signature: Signature,
-        args: &[RuntimeValue],
-        results: &mut [RuntimeValue],
+        args: &[Value],
+        results: &mut [Value],
         func: Func,
     ) -> Result<(), Trap> {
         self.value_stack.clear();
@@ -286,7 +286,7 @@ impl EngineInner {
     fn write_results_back(
         &mut self,
         result_types: &[ValueType],
-        results: &mut [RuntimeValue],
+        results: &mut [Value],
     ) -> Result<(), Trap> {
         assert_eq!(
             self.value_stack.len(),
@@ -354,7 +354,7 @@ impl EngineInner {
                             debug_assert_eq!(self.scratch.len(), input_types.len());
                             let len_inputs = input_types.len();
                             let len_outputs = output_types.len();
-                            let zeros = output_types.iter().copied().map(RuntimeValue::default);
+                            let zeros = output_types.iter().copied().map(Value::default);
                             self.scratch.extend(zeros);
                             // At this point the scratch buffer holds the host function input arguments
                             // as well as a zero initialized entry per expected host function output value.
@@ -401,7 +401,7 @@ impl EngineInner {
     fn prepare_host_function_args(
         input_types: &[ValueType],
         value_stack: &mut ValueStack,
-        host_args: &mut Vec<RuntimeValue>,
+        host_args: &mut Vec<Value>,
     ) {
         let len_args = input_types.len();
         let stack_args = value_stack.pop_as_slice(len_args);
@@ -415,7 +415,7 @@ impl EngineInner {
     }
 
     /// Initializes the value stack with the given arguments `args`.
-    fn initialize_args(&mut self, args: &[RuntimeValue]) {
+    fn initialize_args(&mut self, args: &[Value]) {
         assert!(
             self.value_stack.is_empty(),
             "encountered non-empty value stack upon function execution initialization",
@@ -434,8 +434,8 @@ impl EngineInner {
     fn check_signature(
         ctx: impl AsContext,
         signature: Signature,
-        params: &[RuntimeValue],
-        results: &[RuntimeValue],
+        params: &[Value],
+        results: &[Value],
     ) -> Result<(), Trap> {
         let expected_inputs = signature.inputs(ctx.as_context());
         let expected_outputs = signature.outputs(ctx.as_context());

--- a/src/v1/engine/value_stack.rs
+++ b/src/v1/engine/value_stack.rs
@@ -3,9 +3,9 @@
 use super::DropKeep;
 use crate::{
     nan_preserving_float::{F32, F64},
-    Value,
     Trap,
     TrapKind,
+    Value,
     ValueType,
     DEFAULT_VALUE_STACK_LIMIT,
 };

--- a/src/v1/engine/value_stack.rs
+++ b/src/v1/engine/value_stack.rs
@@ -3,7 +3,7 @@
 use super::DropKeep;
 use crate::{
     nan_preserving_float::{F32, F64},
-    RuntimeValue,
+    Value,
     Trap,
     TrapKind,
     ValueType,
@@ -24,8 +24,8 @@ use core::{fmt, fmt::Debug, iter, mem};
 /// occur, e.g. interpreting a value of 42 as a [`bool`] value.
 ///
 /// At the boundary between the interpreter and the outside world we convert the
-/// stack entry value into the required `RuntimeValue` type which can then be matched on.
-/// It is only possible to convert a [`StackEntry`] into a [`RuntimeValue`] if and only if
+/// stack entry value into the required `Value` type which can then be matched on.
+/// It is only possible to convert a [`StackEntry`] into a [`Value`] if and only if
 /// the type is statically known which always is the case at these boundaries.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
@@ -37,24 +37,24 @@ impl StackEntry {
         self.0
     }
 
-    /// Converts the untyped [`StackEntry`] value into a typed [`RuntimeValue`].
-    pub fn with_type(self, value_type: ValueType) -> RuntimeValue {
+    /// Converts the untyped [`StackEntry`] value into a typed [`Value`].
+    pub fn with_type(self, value_type: ValueType) -> Value {
         match value_type {
-            ValueType::I32 => RuntimeValue::I32(<_>::from_stack_entry(self)),
-            ValueType::I64 => RuntimeValue::I64(<_>::from_stack_entry(self)),
-            ValueType::F32 => RuntimeValue::F32(<_>::from_stack_entry(self)),
-            ValueType::F64 => RuntimeValue::F64(<_>::from_stack_entry(self)),
+            ValueType::I32 => Value::I32(<_>::from_stack_entry(self)),
+            ValueType::I64 => Value::I64(<_>::from_stack_entry(self)),
+            ValueType::F32 => Value::F32(<_>::from_stack_entry(self)),
+            ValueType::F64 => Value::F64(<_>::from_stack_entry(self)),
         }
     }
 }
 
-impl From<RuntimeValue> for StackEntry {
-    fn from(value: RuntimeValue) -> Self {
+impl From<Value> for StackEntry {
+    fn from(value: Value) -> Self {
         match value {
-            RuntimeValue::I32(value) => value.into(),
-            RuntimeValue::I64(value) => value.into(),
-            RuntimeValue::F32(value) => value.into(),
-            RuntimeValue::F64(value) => value.into(),
+            Value::I32(value) => value.into(),
+            Value::I64(value) => value.into(),
+            Value::F32(value) => value.into(),
+            Value::F64(value) => value.into(),
         }
     }
 }

--- a/src/v1/func/into_func.rs
+++ b/src/v1/func/into_func.rs
@@ -1,7 +1,7 @@
-use super::{super::SignatureEntity, Caller, HostFuncTrampoline, RuntimeValue, ValueType};
+use super::{super::SignatureEntity, Caller, HostFuncTrampoline, Value, ValueType};
 use crate::{
     nan_preserving_float::{F32, F64},
-    FromRuntimeValue,
+    FromValue,
     Trap,
     TrapKind,
 };
@@ -76,8 +76,8 @@ macro_rules! impl_into_func {
                 #[allow(unused_mut, unused_variables)]
                 let trampoline = move |
                     caller: Caller<T>,
-                    inputs: &[RuntimeValue],
-                    outputs: &mut [RuntimeValue],
+                    inputs: &[Value],
+                    outputs: &mut [Value],
                 | -> Result<(), Trap> {
                     if inputs.len() != len_inputs || outputs.len() != len_outputs {
                         return Err(Trap::new(TrapKind::UnexpectedSignature))
@@ -104,14 +104,14 @@ macro_rules! impl_into_func {
 for_each_function_signature!(impl_into_func);
 
 pub trait WriteOutputs {
-    fn write_outputs(self, outputs: &mut [RuntimeValue]) -> Result<(), Trap>;
+    fn write_outputs(self, outputs: &mut [Value]) -> Result<(), Trap>;
 }
 
 impl<T1> WriteOutputs for T1
 where
-    T1: Into<RuntimeValue>,
+    T1: Into<Value>,
 {
-    fn write_outputs(self, outputs: &mut [RuntimeValue]) -> Result<(), Trap> {
+    fn write_outputs(self, outputs: &mut [Value]) -> Result<(), Trap> {
         if outputs.len() != 1 {
             return Err(Trap::new(TrapKind::UnexpectedSignature));
         }
@@ -126,11 +126,11 @@ macro_rules! impl_write_outputs {
         impl<$($args),*> WriteOutputs for ($($args,)*)
         where
             $(
-                $args: Into<RuntimeValue>
+                $args: Into<Value>
             ),*
         {
             #[allow(unused_mut, unused_variables)]
-            fn write_outputs(self, outputs: &mut [RuntimeValue]) -> Result<(), Trap> {
+            fn write_outputs(self, outputs: &mut [Value]) -> Result<(), Trap> {
                 if outputs.len() != $n {
                     return Err(Trap::new(TrapKind::UnexpectedSignature));
                 }
@@ -147,18 +147,18 @@ macro_rules! impl_write_outputs {
 for_each_function_signature!(impl_write_outputs);
 
 pub trait ReadInputs: Sized {
-    fn read_inputs(inputs: &[RuntimeValue]) -> Result<Self, Trap>;
+    fn read_inputs(inputs: &[Value]) -> Result<Self, Trap>;
 }
 
 impl<T1> ReadInputs for T1
 where
-    T1: FromRuntimeValue,
+    T1: FromValue,
 {
-    fn read_inputs(inputs: &[RuntimeValue]) -> Result<Self, Trap> {
+    fn read_inputs(inputs: &[Value]) -> Result<Self, Trap> {
         if inputs.len() != 1 {
             return Err(Trap::new(TrapKind::UnexpectedSignature));
         }
-        RuntimeValue::try_into::<T1>(inputs[0])
+        Value::try_into::<T1>(inputs[0])
             .ok_or_else(|| Trap::new(TrapKind::UnexpectedSignature))
     }
 }
@@ -168,11 +168,11 @@ macro_rules! impl_read_inputs {
         impl<$($args),*> ReadInputs for ($($args,)*)
         where
             $(
-                $args: FromRuntimeValue
+                $args: FromValue
             ),*
         {
             #[allow(unused_mut, unused_variables)]
-            fn read_inputs(inputs: &[RuntimeValue]) -> Result<Self, Trap> {
+            fn read_inputs(inputs: &[Value]) -> Result<Self, Trap> {
                 if inputs.len() != $n {
                     return Err(Trap::new(TrapKind::UnexpectedSignature))
                 }
@@ -182,7 +182,7 @@ macro_rules! impl_read_inputs {
                         inputs
                             .next()
                             .copied()
-                            .map(RuntimeValue::try_into::<$args>)
+                            .map(Value::try_into::<$args>)
                             .flatten()
                             .ok_or(Trap::new(TrapKind::UnexpectedSignature))?,
                     )*
@@ -193,7 +193,7 @@ macro_rules! impl_read_inputs {
 }
 for_each_function_signature!(impl_read_inputs);
 
-pub trait WasmType: FromRuntimeValue + Into<RuntimeValue> {
+pub trait WasmType: FromValue + Into<Value> {
     /// The underlying ABI type.
     type Abi: Copy;
 

--- a/src/v1/func/into_func.rs
+++ b/src/v1/func/into_func.rs
@@ -158,8 +158,7 @@ where
         if inputs.len() != 1 {
             return Err(Trap::new(TrapKind::UnexpectedSignature));
         }
-        Value::try_into::<T1>(inputs[0])
-            .ok_or_else(|| Trap::new(TrapKind::UnexpectedSignature))
+        Value::try_into::<T1>(inputs[0]).ok_or_else(|| Trap::new(TrapKind::UnexpectedSignature))
     }
 }
 

--- a/src/v1/func/mod.rs
+++ b/src/v1/func/mod.rs
@@ -12,7 +12,7 @@ use super::{
     StoreContext,
     Stored,
 };
-use crate::{Value, Trap, ValueType};
+use crate::{Trap, Value, ValueType};
 use alloc::sync::Arc;
 use core::{fmt, fmt::Debug};
 
@@ -153,10 +153,8 @@ impl<T> Clone for HostFuncEntity<T> {
     }
 }
 
-type HostFuncTrampolineFn<T> = dyn Fn(Caller<T>, &[Value], &mut [Value]) -> Result<(), Trap>
-    + Send
-    + Sync
-    + 'static;
+type HostFuncTrampolineFn<T> =
+    dyn Fn(Caller<T>, &[Value], &mut [Value]) -> Result<(), Trap> + Send + Sync + 'static;
 
 pub struct HostFuncTrampoline<T> {
     closure: Arc<HostFuncTrampolineFn<T>>,

--- a/src/v1/func/mod.rs
+++ b/src/v1/func/mod.rs
@@ -12,7 +12,7 @@ use super::{
     StoreContext,
     Stored,
 };
-use crate::{RuntimeValue, Trap, ValueType};
+use crate::{Value, Trap, ValueType};
 use alloc::sync::Arc;
 use core::{fmt, fmt::Debug};
 
@@ -153,7 +153,7 @@ impl<T> Clone for HostFuncEntity<T> {
     }
 }
 
-type HostFuncTrampolineFn<T> = dyn Fn(Caller<T>, &[RuntimeValue], &mut [RuntimeValue]) -> Result<(), Trap>
+type HostFuncTrampolineFn<T> = dyn Fn(Caller<T>, &[Value], &mut [Value]) -> Result<(), Trap>
     + Send
     + Sync
     + 'static;
@@ -202,8 +202,8 @@ impl<T> HostFuncEntity<T> {
         &self,
         mut ctx: impl AsContextMut<UserState = T>,
         instance: Option<Instance>,
-        inputs: &[RuntimeValue],
-        outputs: &mut [RuntimeValue],
+        inputs: &[Value],
+        outputs: &mut [Value],
     ) -> Result<(), Trap> {
         let caller = <Caller<T>>::new(&mut ctx, instance);
         (self.trampoline.closure)(caller, inputs, outputs)
@@ -246,8 +246,8 @@ impl Func {
     pub fn call<T>(
         &self,
         mut ctx: impl AsContextMut<UserState = T>,
-        inputs: &[RuntimeValue],
-        outputs: &mut [RuntimeValue],
+        inputs: &[Value],
+        outputs: &mut [Value],
     ) -> Result<(), Trap> {
         // Cloning an engine is a cheap operation.
         ctx.as_context().store.engine().clone().execute_func(

--- a/src/v1/global.rs
+++ b/src/v1/global.rs
@@ -133,11 +133,7 @@ impl Global {
     }
 
     /// Creates a new global variable to the store.
-    pub fn new(
-        mut ctx: impl AsContextMut,
-        initial_value: Value,
-        mutability: Mutability,
-    ) -> Self {
+    pub fn new(mut ctx: impl AsContextMut, initial_value: Value, mutability: Mutability) -> Self {
         ctx.as_context_mut()
             .store
             .alloc_global(GlobalEntity::new(initial_value, mutability))
@@ -171,11 +167,7 @@ impl Global {
     /// # Panics
     ///
     /// Panics if `ctx` does not own this [`Global`].
-    pub fn set(
-        &self,
-        mut ctx: impl AsContextMut,
-        new_value: Value,
-    ) -> Result<(), GlobalError> {
+    pub fn set(&self, mut ctx: impl AsContextMut, new_value: Value) -> Result<(), GlobalError> {
         ctx.as_context_mut()
             .store
             .resolve_global_mut(*self)

--- a/src/v1/global.rs
+++ b/src/v1/global.rs
@@ -1,5 +1,5 @@
 use super::{AsContext, AsContextMut, Index, Stored};
-use crate::{RuntimeValue, ValueType};
+use crate::{Value, ValueType};
 use core::{fmt, fmt::Display};
 
 /// A raw index to a global variable entity.
@@ -61,13 +61,13 @@ pub enum Mutability {
 /// A global variable entitiy.
 #[derive(Debug)]
 pub struct GlobalEntity {
-    value: RuntimeValue,
+    value: Value,
     mutability: Mutability,
 }
 
 impl GlobalEntity {
     /// Creates a new global entity with the given initial value and mutability.
-    pub fn new(initial_value: RuntimeValue, mutability: Mutability) -> Self {
+    pub fn new(initial_value: Value, mutability: Mutability) -> Self {
         Self {
             value: initial_value,
             mutability,
@@ -90,7 +90,7 @@ impl GlobalEntity {
     ///
     /// - If the global variable is immutable.
     /// - If there is a type mismatch between the global variable and the new value.
-    pub fn set(&mut self, new_value: RuntimeValue) -> Result<(), GlobalError> {
+    pub fn set(&mut self, new_value: Value) -> Result<(), GlobalError> {
         if !self.is_mutable() {
             return Err(GlobalError::ImmutableWrite);
         }
@@ -105,7 +105,7 @@ impl GlobalEntity {
     }
 
     /// Returns the current value of the global variable.
-    pub fn get(&self) -> RuntimeValue {
+    pub fn get(&self) -> Value {
         self.value
     }
 }
@@ -135,7 +135,7 @@ impl Global {
     /// Creates a new global variable to the store.
     pub fn new(
         mut ctx: impl AsContextMut,
-        initial_value: RuntimeValue,
+        initial_value: Value,
         mutability: Mutability,
     ) -> Self {
         ctx.as_context_mut()
@@ -174,7 +174,7 @@ impl Global {
     pub fn set(
         &self,
         mut ctx: impl AsContextMut,
-        new_value: RuntimeValue,
+        new_value: Value,
     ) -> Result<(), GlobalError> {
         ctx.as_context_mut()
             .store
@@ -187,7 +187,7 @@ impl Global {
     /// # Panics
     ///
     /// Panics if `ctx` does not own this [`Global`].
-    pub fn get(&self, ctx: impl AsContext) -> RuntimeValue {
+    pub fn get(&self, ctx: impl AsContext) -> Value {
         ctx.as_context().store.resolve_global(*self).get()
     }
 }

--- a/src/v1/module/compile/mod.rs
+++ b/src/v1/module/compile/mod.rs
@@ -9,7 +9,7 @@ mod utils;
 use self::control_frame::ControlFrame;
 use super::{
     super::{
-        super::{RuntimeValue, ValueType},
+        super::{Value, ValueType},
         engine::{
             bytecode::{FuncIdx, GlobalIdx, LocalIdx, Offset, SignatureIdx},
             inst_builder::{Reloc, Signedness, WasmFloatType, WasmIntType},
@@ -397,16 +397,16 @@ impl<'engine> FuncBodyTranslator<'engine> {
                 self.validate_translate(validator, inst, InstructionsBuilder::memory_grow)?
             }
             Inst::I32Const(value) => self.validate_translate(validator, inst, |inst_builder| {
-                inst_builder.constant(RuntimeValue::from(*value))
+                inst_builder.constant(Value::from(*value))
             })?,
             Inst::I64Const(value) => self.validate_translate(validator, inst, |inst_builder| {
-                inst_builder.constant(RuntimeValue::from(*value))
+                inst_builder.constant(Value::from(*value))
             })?,
             Inst::F32Const(value) => self.validate_translate(validator, inst, |inst_builder| {
-                inst_builder.constant(RuntimeValue::from(*value))
+                inst_builder.constant(Value::from(*value))
             })?,
             Inst::F64Const(value) => self.validate_translate(validator, inst, |inst_builder| {
-                inst_builder.constant(RuntimeValue::from(*value))
+                inst_builder.constant(Value::from(*value))
             })?,
             Inst::I32Eqz => self.validate_translate(validator, inst, |inst_builder| {
                 inst_builder.int_eqz(WasmIntType::I32)

--- a/src/v1/module/instantiate.rs
+++ b/src/v1/module/instantiate.rs
@@ -29,7 +29,7 @@ use super::{
     },
     Module,
 };
-use crate::{RuntimeValue, ValueType};
+use crate::{Value, ValueType};
 use core::{fmt, fmt::Display};
 use parity_wasm::elements as pwasm;
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
@@ -608,7 +608,7 @@ impl Module {
         context: impl AsContext,
         builder: &InstanceEntityBuilder,
         init_expr: &pwasm::InitExpr,
-    ) -> RuntimeValue {
+    ) -> Value {
         let operands = init_expr.code();
         debug_assert_eq!(
             operands.len(),
@@ -618,10 +618,10 @@ impl Module {
         );
         debug_assert!(matches!(operands[1], pwasm::Instruction::End));
         match &operands[0] {
-            pwasm::Instruction::I32Const(value) => RuntimeValue::from(*value),
-            pwasm::Instruction::I64Const(value) => RuntimeValue::from(*value),
-            pwasm::Instruction::F32Const(value) => RuntimeValue::decode_f32(*value),
-            pwasm::Instruction::F64Const(value) => RuntimeValue::decode_f64(*value),
+            pwasm::Instruction::I32Const(value) => Value::from(*value),
+            pwasm::Instruction::I64Const(value) => Value::from(*value),
+            pwasm::Instruction::F32Const(value) => Value::decode_f32(*value),
+            pwasm::Instruction::F64Const(value) => Value::decode_f64(*value),
             pwasm::Instruction::GetGlobal(global_index) => {
                 let global = builder
                     .get_global(*global_index)

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,7 +13,7 @@ use core::{f32, i32, i64, u32, u64};
 /// There is no distinction between signed and unsigned integer types. Instead, integers are
 /// interpreted by respective operations as either unsigned or signed in two’s complement representation.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum RuntimeValue {
+pub enum Value {
     /// Value of 32-bit signed or unsigned integer.
     I32(i32),
     /// Value of 64-bit signed or unsigned integer.
@@ -24,26 +24,26 @@ pub enum RuntimeValue {
     F64(F64),
 }
 
-/// Trait for creating value from a [`RuntimeValue`].
+/// Trait for creating value from a [`Value`].
 ///
 /// Typically each implementation can create a value from the specific type.
 /// For example, values of type `bool` or `u32` are both represented by [`I32`] and `f64` values are represented by
 /// [`F64`].
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-/// [`F64`]: enum.RuntimeValue.html#variant.F64
-/// [`RuntimeValue`]: enum.RuntimeValue.html
-pub trait FromRuntimeValue
+/// [`I32`]: enum.Value.html#variant.I32
+/// [`F64`]: enum.Value.html#variant.F64
+/// [`Value`]: enum.Value.html
+pub trait FromValue
 where
     Self: Sized,
 {
-    /// Create a value of type `Self` from a given [`RuntimeValue`].
+    /// Create a value of type `Self` from a given [`Value`].
     ///
-    /// Returns `None` if the [`RuntimeValue`] is of type different than
+    /// Returns `None` if the [`Value`] is of type different than
     /// expected by the conversion in question.
     ///
-    /// [`RuntimeValue`]: enum.RuntimeValue.html
-    fn from_runtime_value(val: RuntimeValue) -> Option<Self>;
+    /// [`Value`]: enum.Value.html
+    fn from_value(val: Value) -> Option<Self>;
 }
 
 /// Convert one type to another by wrapping.
@@ -181,115 +181,115 @@ pub trait Float<T>: ArithmeticOps<T> {
     fn copysign(self, other: T) -> T;
 }
 
-impl RuntimeValue {
+impl Value {
     /// Creates new default value of given type.
     pub fn default(value_type: ValueType) -> Self {
         match value_type {
-            ValueType::I32 => RuntimeValue::I32(0),
-            ValueType::I64 => RuntimeValue::I64(0),
-            ValueType::F32 => RuntimeValue::F32(0f32.into()),
-            ValueType::F64 => RuntimeValue::F64(0f64.into()),
+            ValueType::I32 => Value::I32(0),
+            ValueType::I64 => Value::I64(0),
+            ValueType::F32 => Value::F32(0f32.into()),
+            ValueType::F64 => Value::F64(0f64.into()),
         }
     }
 
     /// Creates new value by interpreting passed u32 as f32.
     pub fn decode_f32(val: u32) -> Self {
-        RuntimeValue::F32(F32::from_bits(val))
+        Value::F32(F32::from_bits(val))
     }
 
     /// Creates new value by interpreting passed u64 as f64.
     pub fn decode_f64(val: u64) -> Self {
-        RuntimeValue::F64(F64::from_bits(val))
+        Value::F64(F64::from_bits(val))
     }
 
     /// Get variable type for this value.
     pub fn value_type(&self) -> ValueType {
         match *self {
-            RuntimeValue::I32(_) => ValueType::I32,
-            RuntimeValue::I64(_) => ValueType::I64,
-            RuntimeValue::F32(_) => ValueType::F32,
-            RuntimeValue::F64(_) => ValueType::F64,
+            Value::I32(_) => ValueType::I32,
+            Value::I64(_) => ValueType::I64,
+            Value::F32(_) => ValueType::F32,
+            Value::F64(_) => ValueType::F64,
         }
     }
 
-    /// Returns `T` if this particular [`RuntimeValue`] contains
+    /// Returns `T` if this particular [`Value`] contains
     /// appropriate type.
     ///
-    /// See [`FromRuntimeValue`] for details.
+    /// See [`FromValue`] for details.
     ///
-    /// [`FromRuntimeValue`]: trait.FromRuntimeValue.html
-    /// [`RuntimeValue`]: enum.RuntimeValue.html
-    pub fn try_into<T: FromRuntimeValue>(self) -> Option<T> {
-        FromRuntimeValue::from_runtime_value(self)
+    /// [`FromValue`]: trait.FromValue.html
+    /// [`Value`]: enum.Value.html
+    pub fn try_into<T: FromValue>(self) -> Option<T> {
+        FromValue::from_value(self)
     }
 }
 
-impl From<i8> for RuntimeValue {
+impl From<i8> for Value {
     fn from(val: i8) -> Self {
-        RuntimeValue::I32(val as i32)
+        Value::I32(val as i32)
     }
 }
 
-impl From<i16> for RuntimeValue {
+impl From<i16> for Value {
     fn from(val: i16) -> Self {
-        RuntimeValue::I32(val as i32)
+        Value::I32(val as i32)
     }
 }
 
-impl From<i32> for RuntimeValue {
+impl From<i32> for Value {
     fn from(val: i32) -> Self {
-        RuntimeValue::I32(val)
+        Value::I32(val)
     }
 }
 
-impl From<i64> for RuntimeValue {
+impl From<i64> for Value {
     fn from(val: i64) -> Self {
-        RuntimeValue::I64(val)
+        Value::I64(val)
     }
 }
 
-impl From<u8> for RuntimeValue {
+impl From<u8> for Value {
     fn from(val: u8) -> Self {
-        RuntimeValue::I32(val as i32)
+        Value::I32(val as i32)
     }
 }
 
-impl From<u16> for RuntimeValue {
+impl From<u16> for Value {
     fn from(val: u16) -> Self {
-        RuntimeValue::I32(val as i32)
+        Value::I32(val as i32)
     }
 }
 
-impl From<u32> for RuntimeValue {
+impl From<u32> for Value {
     fn from(val: u32) -> Self {
-        RuntimeValue::I32(val.transmute_into())
+        Value::I32(val.transmute_into())
     }
 }
 
-impl From<u64> for RuntimeValue {
+impl From<u64> for Value {
     fn from(val: u64) -> Self {
-        RuntimeValue::I64(val.transmute_into())
+        Value::I64(val.transmute_into())
     }
 }
 
-impl From<F32> for RuntimeValue {
+impl From<F32> for Value {
     fn from(val: F32) -> Self {
-        RuntimeValue::F32(val)
+        Value::F32(val)
     }
 }
 
-impl From<F64> for RuntimeValue {
+impl From<F64> for Value {
     fn from(val: F64) -> Self {
-        RuntimeValue::F64(val)
+        Value::F64(val)
     }
 }
 
-macro_rules! impl_from_runtime_value {
+macro_rules! impl_from_value {
     ($expected_rt_ty: ident, $into: ty) => {
-        impl FromRuntimeValue for $into {
-            fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+        impl FromValue for $into {
+            fn from_value(val: Value) -> Option<Self> {
                 match val {
-                    RuntimeValue::$expected_rt_ty(val) => Some(val.transmute_into()),
+                    Value::$expected_rt_ty(val) => Some(val.transmute_into()),
                     _ => None,
                 }
             }
@@ -300,11 +300,11 @@ macro_rules! impl_from_runtime_value {
 /// This conversion assumes that boolean values are represented by
 /// [`I32`] type.
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-impl FromRuntimeValue for bool {
-    fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+/// [`I32`]: enum.Value.html#variant.I32
+impl FromValue for bool {
+    fn from_value(val: Value) -> Option<Self> {
         match val {
-            RuntimeValue::I32(val) => Some(val != 0),
+            Value::I32(val) => Some(val != 0),
             _ => None,
         }
     }
@@ -312,13 +312,13 @@ impl FromRuntimeValue for bool {
 
 ///  This conversion assumes that `i8` is represented as an [`I32`].
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-impl FromRuntimeValue for i8 {
-    fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+/// [`I32`]: enum.Value.html#variant.I32
+impl FromValue for i8 {
+    fn from_value(val: Value) -> Option<Self> {
         let min = i8::min_value() as i32;
         let max = i8::max_value() as i32;
         match val {
-            RuntimeValue::I32(val) if min <= val && val <= max => Some(val as i8),
+            Value::I32(val) if min <= val && val <= max => Some(val as i8),
             _ => None,
         }
     }
@@ -326,13 +326,13 @@ impl FromRuntimeValue for i8 {
 
 ///  This conversion assumes that `i16` is represented as an [`I32`].
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-impl FromRuntimeValue for i16 {
-    fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+/// [`I32`]: enum.Value.html#variant.I32
+impl FromValue for i16 {
+    fn from_value(val: Value) -> Option<Self> {
         let min = i16::min_value() as i32;
         let max = i16::max_value() as i32;
         match val {
-            RuntimeValue::I32(val) if min <= val && val <= max => Some(val as i16),
+            Value::I32(val) if min <= val && val <= max => Some(val as i16),
             _ => None,
         }
     }
@@ -340,13 +340,13 @@ impl FromRuntimeValue for i16 {
 
 ///  This conversion assumes that `u8` is represented as an [`I32`].
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-impl FromRuntimeValue for u8 {
-    fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+/// [`I32`]: enum.Value.html#variant.I32
+impl FromValue for u8 {
+    fn from_value(val: Value) -> Option<Self> {
         let min = u8::min_value() as i32;
         let max = u8::max_value() as i32;
         match val {
-            RuntimeValue::I32(val) if min <= val && val <= max => Some(val as u8),
+            Value::I32(val) if min <= val && val <= max => Some(val as u8),
             _ => None,
         }
     }
@@ -354,24 +354,24 @@ impl FromRuntimeValue for u8 {
 
 ///  This conversion assumes that `u16` is represented as an [`I32`].
 ///
-/// [`I32`]: enum.RuntimeValue.html#variant.I32
-impl FromRuntimeValue for u16 {
-    fn from_runtime_value(val: RuntimeValue) -> Option<Self> {
+/// [`I32`]: enum.Value.html#variant.I32
+impl FromValue for u16 {
+    fn from_value(val: Value) -> Option<Self> {
         let min = u16::min_value() as i32;
         let max = u16::max_value() as i32;
         match val {
-            RuntimeValue::I32(val) if min <= val && val <= max => Some(val as u16),
+            Value::I32(val) if min <= val && val <= max => Some(val as u16),
             _ => None,
         }
     }
 }
 
-impl_from_runtime_value!(I32, i32);
-impl_from_runtime_value!(I64, i64);
-impl_from_runtime_value!(F32, F32);
-impl_from_runtime_value!(F64, F64);
-impl_from_runtime_value!(I32, u32);
-impl_from_runtime_value!(I64, u64);
+impl_from_value!(I32, i32);
+impl_from_value!(I64, i64);
+impl_from_value!(F32, F32);
+impl_from_value!(F64, F64);
+impl_from_value!(I32, u32);
+impl_from_value!(I64, u64);
 
 macro_rules! impl_wrap_into {
     ($from:ident, $into:ident) => {

--- a/tests/spec/v0/run.rs
+++ b/tests/spec/v0/run.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, fs::File};
 
-use wabt::script::{self, Action, Command, CommandKind, ScriptParser, Value};
+use wabt::script::{self, Action, Command, CommandKind, ScriptParser, Value as WabtValue};
 use wasmi::{
     memory_units::Pages,
     Error as InterpreterError,
@@ -22,21 +22,21 @@ use wasmi::{
     ModuleInstance,
     ModuleRef,
     RuntimeArgs,
-    RuntimeValue,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
     Trap,
+    Value,
 };
 
-fn spec_to_runtime_value(val: Value<u32, u64>) -> RuntimeValue {
+fn spec_to_value(val: WabtValue<u32, u64>) -> Value {
     match val {
-        Value::I32(v) => RuntimeValue::I32(v),
-        Value::I64(v) => RuntimeValue::I64(v),
-        Value::F32(v) => RuntimeValue::F32(v.into()),
-        Value::F64(v) => RuntimeValue::F64(v.into()),
-        Value::V128(_) => panic!("v128 is not supported"),
+        WabtValue::I32(v) => Value::I32(v),
+        WabtValue::I64(v) => Value::I64(v),
+        WabtValue::F32(v) => Value::F32(v.into()),
+        WabtValue::F64(v) => Value::F64(v.into()),
+        WabtValue::V128(_) => panic!("v128 is not supported"),
     }
 }
 
@@ -73,9 +73,9 @@ impl SpecModule {
         SpecModule {
             table: TableInstance::alloc(10, Some(20)).unwrap(),
             memory: MemoryInstance::alloc(Pages(1), Some(Pages(2))).unwrap(),
-            global_i32: GlobalInstance::alloc(RuntimeValue::I32(666), false),
-            global_f32: GlobalInstance::alloc(RuntimeValue::F32(666.0.into()), false),
-            global_f64: GlobalInstance::alloc(RuntimeValue::F64(666.0.into()), false),
+            global_i32: GlobalInstance::alloc(Value::I32(666), false),
+            global_f32: GlobalInstance::alloc(Value::F32(666.0.into()), false),
+            global_f64: GlobalInstance::alloc(Value::F64(666.0.into()), false),
         }
     }
 }
@@ -83,11 +83,7 @@ impl SpecModule {
 const PRINT_FUNC_INDEX: usize = 0;
 
 impl Externals for SpecModule {
-    fn invoke_index(
-        &mut self,
-        index: usize,
-        args: RuntimeArgs,
-    ) -> Result<Option<RuntimeValue>, Trap> {
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
         match index {
             PRINT_FUNC_INDEX => {
                 println!("print: {:?}", args);
@@ -310,7 +306,7 @@ fn load_module(
 fn run_action(
     program: &mut SpecDriver,
     action: &Action<u32, u64>,
-) -> Result<Option<RuntimeValue>, InterpreterError> {
+) -> Result<Option<Value>, InterpreterError> {
     match *action {
         Action::Invoke {
             ref module,
@@ -320,11 +316,7 @@ fn run_action(
             let module = program
                 .module_or_last(module.as_ref().map(|x| x.as_ref()))
                 .unwrap_or_else(|_| panic!("Expected program to have loaded module {:?}", module));
-            let vec_args = args
-                .iter()
-                .cloned()
-                .map(spec_to_runtime_value)
-                .collect::<Vec<_>>();
+            let vec_args = args.iter().cloned().map(spec_to_value).collect::<Vec<_>>();
             module.invoke_export(field, &vec_args, program.spec_module())
         }
         Action::Get {
@@ -401,21 +393,21 @@ fn try_spec(name: &str) -> Result<(), Error> {
                         let spec_expected = expected
                             .iter()
                             .cloned()
-                            .map(spec_to_runtime_value)
+                            .map(spec_to_value)
                             .collect::<Vec<_>>();
-                        let actual_result = result.into_iter().collect::<Vec<RuntimeValue>>();
+                        let actual_result = result.into_iter().collect::<Vec<Value>>();
                         for (actual_result, spec_expected) in
                             actual_result.iter().zip(spec_expected.iter())
                         {
                             assert_eq!(actual_result.value_type(), spec_expected.value_type());
                             // f32::NAN != f32::NAN
                             match spec_expected {
-                                RuntimeValue::F32(val) if val.is_nan() => match actual_result {
-                                    RuntimeValue::F32(val) => assert!(val.is_nan()),
+                                Value::F32(val) if val.is_nan() => match actual_result {
+                                    Value::F32(val) => assert!(val.is_nan()),
                                     _ => unreachable!(), // checked above that types are same
                                 },
-                                RuntimeValue::F64(val) if val.is_nan() => match actual_result {
-                                    RuntimeValue::F64(val) => assert!(val.is_nan()),
+                                Value::F64(val) if val.is_nan() => match actual_result {
+                                    Value::F64(val) => assert!(val.is_nan()),
                                     _ => unreachable!(), // checked above that types are same
                                 },
                                 spec_expected => assert_eq!(actual_result, spec_expected),
@@ -432,14 +424,14 @@ fn try_spec(name: &str) -> Result<(), Error> {
                 let result = run_action(&mut spec_driver, &action);
                 match result {
                     Ok(result) => {
-                        for actual_result in result.into_iter().collect::<Vec<RuntimeValue>>() {
+                        for actual_result in result.into_iter().collect::<Vec<Value>>() {
                             match actual_result {
-                                RuntimeValue::F32(val) => {
+                                Value::F32(val) => {
                                     if !val.is_nan() {
                                         panic!("Expected nan value, got {:?}", val)
                                     }
                                 }
-                                RuntimeValue::F64(val) => {
+                                Value::F64(val) => {
                                     if !val.is_nan() {
                                         panic!("Expected nan value, got {:?}", val)
                                     }

--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -18,7 +18,7 @@ use wasmi::{
         Table,
         TableType,
     },
-    RuntimeValue,
+    Value,
 };
 use wast::Id;
 
@@ -40,7 +40,7 @@ pub struct TestContext<'a> {
     /// Profiling during the Wasm spec test run.
     profile: TestProfile,
     /// Intermediate results buffer that can be reused for calling Wasm functions.
-    results: Vec<RuntimeValue>,
+    results: Vec<Value>,
     /// The descriptor of the test.
     ///
     /// Useful for printing better debug messages in case of failure.
@@ -55,15 +55,15 @@ impl<'a> TestContext<'a> {
         let mut store = Store::new(&engine, ());
         let default_memory = Memory::new(&mut store, MemoryType::new(1, Some(2))).unwrap();
         let default_table = Table::new(&mut store, TableType::new(10, Some(20)));
-        let global_i32 = Global::new(&mut store, RuntimeValue::I32(666), Mutability::Const);
+        let global_i32 = Global::new(&mut store, Value::I32(666), Mutability::Const);
         let global_f32 = Global::new(
             &mut store,
-            RuntimeValue::F32(666.0.into()),
+            Value::F32(666.0.into()),
             Mutability::Const,
         );
         let global_f64 = Global::new(
             &mut store,
-            RuntimeValue::F64(666.0.into()),
+            Value::F64(666.0.into()),
             Mutability::Const,
         );
         let print = Func::wrap(&mut store, || {
@@ -229,8 +229,8 @@ impl TestContext<'_> {
         &mut self,
         module_name: Option<&str>,
         func_name: &str,
-        args: &[RuntimeValue],
-    ) -> Result<&[RuntimeValue], TestError> {
+        args: &[Value],
+    ) -> Result<&[Value], TestError> {
         let instance = self.instance_by_name_or_last(module_name)?;
         let func = instance
             .get_export(&self.store, func_name)
@@ -241,7 +241,7 @@ impl TestContext<'_> {
             })?;
         let len_results = func.signature(&self.store).outputs(&self.store).len();
         self.results.clear();
-        self.results.resize(len_results, RuntimeValue::I32(0));
+        self.results.resize(len_results, Value::I32(0));
         func.call(&mut self.store, args, &mut self.results)?;
         Ok(&self.results)
     }
@@ -256,7 +256,7 @@ impl TestContext<'_> {
         &self,
         module_name: Option<Id>,
         global_name: &str,
-    ) -> Result<RuntimeValue, TestError> {
+    ) -> Result<Value, TestError> {
         let module_name = module_name.map(|id| id.name());
         let instance = self.instance_by_name_or_last(module_name)?;
         let global = instance

--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -56,16 +56,8 @@ impl<'a> TestContext<'a> {
         let default_memory = Memory::new(&mut store, MemoryType::new(1, Some(2))).unwrap();
         let default_table = Table::new(&mut store, TableType::new(10, Some(20)));
         let global_i32 = Global::new(&mut store, Value::I32(666), Mutability::Const);
-        let global_f32 = Global::new(
-            &mut store,
-            Value::F32(666.0.into()),
-            Mutability::Const,
-        );
-        let global_f64 = Global::new(
-            &mut store,
-            Value::F64(666.0.into()),
-            Mutability::Const,
-        );
+        let global_f32 = Global::new(&mut store, Value::F32(666.0.into()), Mutability::Const);
+        let global_f64 = Global::new(&mut store, Value::F64(666.0.into()), Mutability::Const);
         let print = Func::wrap(&mut store, || {
             println!("print");
         });

--- a/tests/spec/v1/run.rs
+++ b/tests/spec/v1/run.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use wasmi::{
     nan_preserving_float::{F32, F64},
     v1::Error as WasmiError,
-    RuntimeValue,
+    Value,
 };
 use wast::{
     parser::ParseBuffer,
@@ -216,19 +216,19 @@ fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message
 fn assert_results(
     context: &TestContext,
     span: wast::Span,
-    results: &[RuntimeValue],
+    results: &[Value],
     expected: &[AssertExpression],
 ) {
     assert_eq!(results.len(), expected.len());
     for (result, expected) in results.iter().zip(expected) {
         match (result, expected) {
-            (RuntimeValue::I32(result), AssertExpression::I32(expected)) => {
+            (Value::I32(result), AssertExpression::I32(expected)) => {
                 assert_eq!(result, expected, "in {}", context.spanned(span))
             }
-            (RuntimeValue::I64(result), AssertExpression::I64(expected)) => {
+            (Value::I64(result), AssertExpression::I64(expected)) => {
                 assert_eq!(result, expected, "in {}", context.spanned(span))
             }
-            (RuntimeValue::F32(result), AssertExpression::F32(expected)) => match expected {
+            (Value::F32(result), AssertExpression::F32(expected)) => match expected {
                 NanPattern::CanonicalNan | NanPattern::ArithmeticNan => assert!(result.is_nan()),
                 NanPattern::Value(expected) => {
                     assert_eq!(
@@ -239,13 +239,13 @@ fn assert_results(
                     );
                 }
             },
-            (RuntimeValue::F32(result), AssertExpression::LegacyArithmeticNaN) => {
+            (Value::F32(result), AssertExpression::LegacyArithmeticNaN) => {
                 assert!(result.is_nan(), "in {}", context.spanned(span))
             }
-            (RuntimeValue::F32(result), AssertExpression::LegacyCanonicalNaN) => {
+            (Value::F32(result), AssertExpression::LegacyCanonicalNaN) => {
                 assert!(result.is_nan(), "in {}", context.spanned(span))
             }
-            (RuntimeValue::F64(result), AssertExpression::F64(expected)) => match expected {
+            (Value::F64(result), AssertExpression::F64(expected)) => match expected {
                 NanPattern::CanonicalNan | NanPattern::ArithmeticNan => {
                     assert!(result.is_nan(), "in {}", context.spanned(span))
                 }
@@ -258,10 +258,10 @@ fn assert_results(
                     );
                 }
             },
-            (RuntimeValue::F64(result), AssertExpression::LegacyArithmeticNaN) => {
+            (Value::F64(result), AssertExpression::LegacyArithmeticNaN) => {
                 assert!(result.is_nan(), "in {}", context.spanned(span))
             }
-            (RuntimeValue::F64(result), AssertExpression::LegacyCanonicalNaN) => {
+            (Value::F64(result), AssertExpression::LegacyCanonicalNaN) => {
                 assert!(result.is_nan(), "in {}", context.spanned(span))
             }
             (result, expected) => panic!(
@@ -307,7 +307,7 @@ fn execute_wast_execute(
     context: &mut TestContext,
     span: wast::Span,
     execute: WastExecute,
-) -> Result<Vec<RuntimeValue>, TestError> {
+) -> Result<Vec<Value>, TestError> {
     match execute {
         WastExecute::Invoke(invoke) => {
             execute_wast_invoke(context, span, invoke).map_err(Into::into)
@@ -323,10 +323,10 @@ fn execute_wast_invoke(
     context: &mut TestContext,
     span: wast::Span,
     invoke: WastInvoke,
-) -> Result<Vec<RuntimeValue>, TestError> {
+) -> Result<Vec<Value>, TestError> {
     let module_name = invoke.module.map(|id| id.name());
     let field_name = invoke.name;
-    let mut args = <Vec<RuntimeValue>>::new();
+    let mut args = <Vec<Value>>::new();
     for arg in invoke.args {
         assert_eq!(
             arg.instrs.len(),
@@ -336,10 +336,10 @@ fn execute_wast_invoke(
             arg.instrs
         );
         let arg = match &arg.instrs[0] {
-            wast::Instruction::I32Const(value) => RuntimeValue::I32(*value),
-            wast::Instruction::I64Const(value) => RuntimeValue::I64(*value),
-            wast::Instruction::F32Const(value) => RuntimeValue::F32(F32::from_bits(value.bits)),
-            wast::Instruction::F64Const(value) => RuntimeValue::F64(F64::from_bits(value.bits)),
+            wast::Instruction::I32Const(value) => Value::I32(*value),
+            wast::Instruction::I64Const(value) => Value::I64(*value),
+            wast::Instruction::F32Const(value) => Value::F32(F32::from_bits(value.bits)),
+            wast::Instruction::F64Const(value) => Value::F64(F64::from_bits(value.bits)),
             unsupported => panic!(
                 "{}: encountered unsupported invoke instruction: {:?}",
                 context.spanned(span),


### PR DESCRIPTION
The `RuntimeValue` type is one of the most commonly used types and therefore should have a short name, however, it has one of the longest type names throughout the `wasmi` codebase.
Other Wasm engines such as Wasmtime go even further and just call it `Val`.

Since the next update is going to be a breaking one (due to the introduction of `v1`) I thought it is okay to ship with some other breaking changes. We could technically provide a type alias
```rust
#[deprecated(note = "just use Value")]
pub type RuntimeValue = Value;
```
To signal users what to do in case they don't read the changelog.

To reviewers: Review commit by commit since I separated formatting from renaming.