### PR TITLE
remove RuntimeValue::decode_{f32,f64} methods

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -5,6 +5,7 @@ use crate::{
     imports::ImportResolver,
     memory::MemoryRef,
     memory_units::Pages,
+    nan_preserving_float::{F32, F64},
     runner::StackRecycler,
     table::TableRef,
     types::{GlobalDescriptor, MemoryDescriptor, TableDescriptor},
@@ -788,8 +789,8 @@ fn eval_init_expr(init_expr: &InitExpr, module: &ModuleInstance) -> RuntimeValue
     match code[0] {
         Instruction::I32Const(v) => v.into(),
         Instruction::I64Const(v) => v.into(),
-        Instruction::F32Const(v) => RuntimeValue::decode_f32(v),
-        Instruction::F64Const(v) => RuntimeValue::decode_f64(v),
+        Instruction::F32Const(v) => F32::from_bits(v).into(),
+        Instruction::F64Const(v) => F64::from_bits(v).into(),
         Instruction::GetGlobal(idx) => {
             let global = module
                 .global_by_index(idx)

--- a/src/v1/module/instantiate.rs
+++ b/src/v1/module/instantiate.rs
@@ -29,7 +29,11 @@ use super::{
     },
     Module,
 };
-use crate::{RuntimeValue, ValueType};
+use crate::{
+    nan_preserving_float::{F32, F64},
+    RuntimeValue,
+    ValueType,
+};
 use core::{fmt, fmt::Display};
 use parity_wasm::elements as pwasm;
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
@@ -620,8 +624,8 @@ impl Module {
         match &operands[0] {
             pwasm::Instruction::I32Const(value) => RuntimeValue::from(*value),
             pwasm::Instruction::I64Const(value) => RuntimeValue::from(*value),
-            pwasm::Instruction::F32Const(value) => RuntimeValue::decode_f32(*value),
-            pwasm::Instruction::F64Const(value) => RuntimeValue::decode_f64(*value),
+            pwasm::Instruction::F32Const(value) => RuntimeValue::from(F32::from_bits(*value)),
+            pwasm::Instruction::F64Const(value) => RuntimeValue::from(F64::from_bits(*value)),
             pwasm::Instruction::GetGlobal(global_index) => {
                 let global = builder
                     .get_global(*global_index)

--- a/src/value.rs
+++ b/src/value.rs
@@ -192,16 +192,6 @@ impl RuntimeValue {
         }
     }
 
-    /// Creates new value by interpreting passed u32 as f32.
-    pub fn decode_f32(val: u32) -> Self {
-        RuntimeValue::F32(F32::from_bits(val))
-    }
-
-    /// Creates new value by interpreting passed u64 as f64.
-    pub fn decode_f64(val: u64) -> Self {
-        RuntimeValue::F64(F64::from_bits(val))
-    }
-
     /// Get variable type for this value.
     pub fn value_type(&self) -> ValueType {
         match *self {


### PR DESCRIPTION
Reason:
- Those methods expose details about the F32 and F64 that should not be handled or dealt by the RuntimeValue type but by those type respectively via their from_bits methods.
- Replacing those removed methods with their respetive F{32,64}::from_bits().into() is simple and therefore the gains of having those convenience methods is minimal to start with.