### PR TITLE
Remove .cargo/config folder

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"


### PR DESCRIPTION
Was required for our old CI but since the old CI no longer exists this also is no longer needed.