### PR TITLE
Optimize marshalling

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -169,7 +169,9 @@ fn bench_execute_rev_comp_v0(c: &mut Criterion) {
         .set(input_data_mem_offset, REVCOMP_INPUT)
         .expect("can't load test data into a wasm memory");
 
+    let mut ran_benchmarks = false;
     c.bench_function("execute/rev_complement/v0", |b| {
+        ran_benchmarks = true;
         b.iter(|| {
             instance
                 .invoke_export(
@@ -181,17 +183,19 @@ fn bench_execute_rev_comp_v0(c: &mut Criterion) {
         })
     });
 
-    // Verify the result.
-    let output_data_mem_offset = assert_matches!(
-        instance.invoke_export("rev_complement_output_ptr", &[test_data_ptr], &mut v0::NopExternals),
-        Ok(Some(Value::I32(v))) => v as u32,
-        "",
-    );
-    let mut result = vec![0x00_u8; REVCOMP_OUTPUT.len()];
-    memory
-        .get_into(output_data_mem_offset, &mut result)
-        .expect("can't get result data from a wasm memory");
-    assert_eq!(&*result, REVCOMP_OUTPUT);
+    if ran_benchmarks {
+        // Verify the result.
+        let output_data_mem_offset = assert_matches!(
+            instance.invoke_export("rev_complement_output_ptr", &[test_data_ptr], &mut v0::NopExternals),
+            Ok(Some(Value::I32(v))) => v as u32,
+            "",
+        );
+        let mut result = vec![0x00_u8; REVCOMP_OUTPUT.len()];
+        memory
+            .get_into(output_data_mem_offset, &mut result)
+            .expect("can't get result data from a wasm memory");
+        assert_eq!(&*result, REVCOMP_OUTPUT);
+    }
 }
 
 fn bench_execute_rev_comp_v1(c: &mut Criterion) {

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,3 +1,6 @@
 //! End-to-end tests for `wasmi`.
 
 mod v0;
+
+#[cfg(feature = "v1")]
+mod v1;

--- a/tests/e2e/v1/func.rs
+++ b/tests/e2e/v1/func.rs
@@ -1,0 +1,210 @@
+//! Tests for the `Func` type in `wasmi_v1`.
+
+use wasmi::{
+    v1::{Engine, Func, Store},
+    Value,
+};
+use wasmi_core::{F32, F64};
+
+fn test_setup() -> Store<()> {
+    let engine = Engine::default();
+    Store::new(&engine, ())
+}
+
+#[test]
+fn add2_works() {
+    let mut store = test_setup();
+    // This host function represents a simple binary addition.
+    let add2 = Func::wrap(&mut store, |lhs: i32, rhs: i32| lhs + rhs);
+    let result_add2 = {
+        let mut result = [Value::I32(0)];
+        add2.call(&mut store, &[Value::I32(1), Value::I32(2)], &mut result)
+            .unwrap();
+        result[0]
+    };
+    assert_eq!(result_add2, Value::I32(3));
+}
+
+#[test]
+fn add3_works() {
+    let mut store = test_setup();
+    // This host function performance a three-way addition.
+    let add3 = Func::wrap(&mut store, |v0: i32, v1: i32, v2: i32| v0 + v1 + v2);
+    let result_add3 = {
+        let mut result = [Value::I32(0)];
+        add3.call(
+            &mut store,
+            &[Value::I32(1), Value::I32(2), Value::I32(3)],
+            &mut result,
+        )
+        .unwrap();
+        result[0]
+    };
+    assert_eq!(result_add3, Value::I32(6));
+}
+
+#[test]
+fn duplicate_works() {
+    let mut store = test_setup();
+    // This host function takes one `i32` argument and returns it twice.
+    let duplicate = Func::wrap(&mut store, |value: i32| (value, value));
+    let result_duplicate = {
+        let mut result = [Value::I32(0), Value::I32(0)];
+        duplicate
+            .call(&mut store, &[Value::I32(10)], &mut result)
+            .unwrap();
+        (result[0], result[1])
+    };
+    assert_eq!(result_duplicate, (Value::I32(10), Value::I32(10)));
+}
+
+#[test]
+fn many_params_works() {
+    let mut store = test_setup();
+    // Function taking 16 arguments (maximum) and doing nothing.
+    let func = Func::wrap(
+        &mut store,
+        |_0: i32,
+         _1: i32,
+         _2: i32,
+         _3: i32,
+         _4: i32,
+         _5: i32,
+         _6: i32,
+         _7: i32,
+         _8: i32,
+         _9: i32,
+         _10: i32,
+         _11: i32,
+         _12: i32,
+         _13: i32,
+         _14: i32,
+         _15: i32| (),
+    );
+    func.call(
+        &mut store,
+        &[
+            Value::I32(0),
+            Value::I32(1),
+            Value::I32(2),
+            Value::I32(3),
+            Value::I32(4),
+            Value::I32(5),
+            Value::I32(6),
+            Value::I32(7),
+            Value::I32(8),
+            Value::I32(9),
+            Value::I32(10),
+            Value::I32(11),
+            Value::I32(12),
+            Value::I32(13),
+            Value::I32(14),
+            Value::I32(15),
+        ],
+        &mut [],
+    )
+    .unwrap();
+}
+
+#[test]
+fn many_results_works() {
+    let mut store = test_setup();
+    // Function taking no arguments and returning 16 results as tuple (maximum).
+    let func = Func::wrap(&mut store, || {
+        (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    });
+    let mut results = [Value::I32(0); 16];
+    func.call(&mut store, &[], &mut results).unwrap();
+    assert_eq!(
+        results,
+        [
+            Value::I32(0),
+            Value::I32(1),
+            Value::I32(2),
+            Value::I32(3),
+            Value::I32(4),
+            Value::I32(5),
+            Value::I32(6),
+            Value::I32(7),
+            Value::I32(8),
+            Value::I32(9),
+            Value::I32(10),
+            Value::I32(11),
+            Value::I32(12),
+            Value::I32(13),
+            Value::I32(14),
+            Value::I32(15),
+        ]
+    )
+}
+
+#[test]
+fn many_params_many_results_works() {
+    let mut store = test_setup();
+    // Function taking no arguments and returning 16 results as tuple (maximum).
+    let func = Func::wrap(
+        &mut store,
+        |v0: i32,
+         v1: i32,
+         v2: i32,
+         v3: i32,
+         v4: i32,
+         v5: i32,
+         v6: i32,
+         v7: i32,
+         v8: i32,
+         v9: i32,
+         v10: i32,
+         v11: i32,
+         v12: i32,
+         v13: i32,
+         v14: i32,
+         v15: i32| {
+            (
+                v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15,
+            )
+        },
+    );
+    let mut results = [Value::I32(0); 16];
+    let inputs = [
+        Value::I32(0),
+        Value::I32(1),
+        Value::I32(2),
+        Value::I32(3),
+        Value::I32(4),
+        Value::I32(5),
+        Value::I32(6),
+        Value::I32(7),
+        Value::I32(8),
+        Value::I32(9),
+        Value::I32(10),
+        Value::I32(11),
+        Value::I32(12),
+        Value::I32(13),
+        Value::I32(14),
+        Value::I32(15),
+    ];
+    func.call(&mut store, &inputs, &mut results).unwrap();
+    assert_eq!(&results, &inputs)
+}
+
+#[test]
+fn many_types_works() {
+    let mut store = test_setup();
+    // Function taking no arguments and returning 16 results as tuple (maximum).
+    let func = Func::wrap(
+        &mut store,
+        |v0: i32, v1: u32, v2: i64, v3: u64, v4: F32, v5: F64| (v0, v1, v2, v3, v4, v5),
+    );
+    let mut results = [Value::I32(0); 6];
+    let inputs = [
+        Value::I32(0),
+        Value::I32(1),
+        Value::I64(2),
+        Value::I64(3),
+        Value::F32(4.0.into()),
+        Value::F64(5.0.into()),
+    ];
+    func.call(&mut store, &inputs, &mut results).unwrap();
+    assert_eq!(&results, &inputs)
+}

--- a/tests/e2e/v1/mod.rs
+++ b/tests/e2e/v1/mod.rs
@@ -1,0 +1,1 @@
+mod func;

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -62,7 +62,7 @@ impl<'a> FuncParams<'a> {
     where
         T: WriteResults,
     {
-        let mut results_buffer = &mut self.params_results[..self.len_results];
+        let results_buffer = &mut self.params_results[..self.len_results];
         <T as WriteResults>::write_results(results, results_buffer);
         FuncResults {}
     }

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -1,5 +1,6 @@
 use super::{FromStackEntry, StackEntry};
 use core::cmp;
+use crate::foreach_tuple::for_each_tuple;
 
 #[derive(Debug)]
 pub struct FuncParams<'a> {
@@ -74,28 +75,6 @@ impl<'a> FuncParams<'a> {
 pub trait WasmType: FromStackEntry + Into<StackEntry> {}
 
 impl<T> WasmType for T where T: FromStackEntry + Into<StackEntry> {}
-
-macro_rules! for_each_tuple {
-    ($mac:ident) => {
-        $mac!( 0 );
-        $mac!( 1 T1);
-        $mac!( 2 T1 T2);
-        $mac!( 3 T1 T2 T3);
-        $mac!( 4 T1 T2 T3 T4);
-        $mac!( 5 T1 T2 T3 T4 T5);
-        $mac!( 6 T1 T2 T3 T4 T5 T6);
-        $mac!( 7 T1 T2 T3 T4 T5 T6 T7);
-        $mac!( 8 T1 T2 T3 T4 T5 T6 T7 T8);
-        $mac!( 9 T1 T2 T3 T4 T5 T6 T7 T8 T9);
-        $mac!(10 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10);
-        $mac!(11 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11);
-        $mac!(12 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12);
-        $mac!(13 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13);
-        $mac!(14 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14);
-        $mac!(15 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
-        $mac!(16 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16);
-    }
-}
 
 /// Type sequences that can read host function parameters from the [`ValueStack`].
 pub trait ReadParams {

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -86,16 +86,6 @@ pub trait ReadParams {
     fn read_params(params: &[StackEntry]) -> Self;
 }
 
-impl<T1> ReadParams for T1
-where
-    T1: WasmType,
-{
-    fn read_params(results: &[StackEntry]) -> Self {
-        assert_eq!(results.len(), 1);
-        <T1 as FromStackEntry>::from_stack_entry(results[0])
-    }
-}
-
 macro_rules! impl_read_params {
     ( $n:literal $( $tuple:ident )* ) => {
         impl<$($tuple),*> ReadParams for ($($tuple,)*)
@@ -134,16 +124,6 @@ pub trait WriteResults {
     ///
     /// If the length of the [`ValueStack`] region does not match.
     fn write_results(self, results: &mut [StackEntry]);
-}
-
-impl<T1> WriteResults for T1
-where
-    T1: WasmType,
-{
-    fn write_results(self, results: &mut [StackEntry]) {
-        assert_eq!(results.len(), 1);
-        results[0] = self.into();
-    }
 }
 
 macro_rules! impl_write_params {

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -1,6 +1,6 @@
 use super::{FromStackEntry, StackEntry};
-use core::cmp;
 use crate::foreach_tuple::for_each_tuple;
+use core::cmp;
 
 #[derive(Debug)]
 pub struct FuncParams<'a> {

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -77,12 +77,16 @@ pub trait WasmType: FromStackEntry + Into<StackEntry> {}
 impl<T> WasmType for T where T: FromStackEntry + Into<StackEntry> {}
 
 /// Type sequences that can read host function parameters from the [`ValueStack`].
+///
+/// [`ValueStack`]: [`crate::engine::ValueStack`]
 pub trait ReadParams {
     /// Reads the host parameters from the given [`ValueStack`] region.
     ///
     /// # Panics
     ///
     /// If the length of the [`ValueStack`] region does not match.
+    ///
+    /// [`ValueStack`]: [`crate::engine::ValueStack`]
     fn read_params(params: &[StackEntry]) -> Self;
 }
 
@@ -117,12 +121,16 @@ macro_rules! impl_read_params {
 for_each_tuple!(impl_read_params);
 
 /// Type sequences that can write results back into the [`ValueStack`].
+///
+/// [`ValueStack`]: [`crate::engine::ValueStack`]
 pub trait WriteResults {
     /// Writes the `results` into the given [`ValueStack`] region.
     ///
     /// # Panics
     ///
     /// If the length of the [`ValueStack`] region does not match.
+    ///
+    /// [`ValueStack`]: [`crate::engine::ValueStack`]
     fn write_results(self, results: &mut [StackEntry]);
 }
 

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -1,0 +1,454 @@
+use super::{FromStackEntry, StackEntry};
+use core::cmp;
+
+#[derive(Debug)]
+pub struct FuncParams<'a> {
+    /// Slice holding the raw (encoded but untyped) parameters
+    /// of the host function invocation before the call and the
+    /// results of the host function invocation after the call.
+    ///
+    /// Therefore the length of the slice must be large enough
+    /// to hold all parameters and all results but not both at
+    /// the same time.
+    params_results: &'a mut [StackEntry],
+    /// The length of the expected parameters of the function invocation.
+    len_params: usize,
+    /// The length of the expected results of the function invocation.
+    len_results: usize,
+}
+
+#[derive(Debug)]
+pub struct FuncResults {}
+
+impl<'a> FuncParams<'a> {
+    /// Create new [`FuncParams`].
+    ///
+    /// # Panics
+    ///
+    /// If the length of hte `params_results` slice does not match the maximum
+    /// of the `len_params` and `Len_results`.
+    pub fn new(
+        params_results: &'a mut [StackEntry],
+        len_params: usize,
+        len_results: usize,
+    ) -> Self {
+        assert_eq!(params_results.len(), cmp::max(len_params, len_results));
+        Self {
+            params_results,
+            len_params,
+            len_results,
+        }
+    }
+
+    /// Returns the host function parameters as `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the number of function parameters dictated by `T` does not match.
+    pub fn read_params<T>(&self) -> T
+    where
+        T: ReadParams,
+    {
+        let params_buffer = &self.params_results[..self.len_params];
+        <T as ReadParams>::read_params(&params_buffer)
+    }
+
+    /// Sets the results of the function invocation.
+    ///
+    /// # Panics
+    ///
+    /// If the number of results does not match the expected amount.
+    pub fn write_results<T>(self, results: T) -> FuncResults
+    where
+        T: WriteResults,
+    {
+        let mut results_buffer = &mut self.params_results[..self.len_results];
+        <T as WriteResults>::write_results(results, &mut results_buffer);
+        FuncResults {}
+    }
+}
+
+pub trait WasmType: FromStackEntry + Into<StackEntry> {}
+
+impl<T> WasmType for T where T: FromStackEntry + Into<StackEntry> {}
+
+pub trait ReadParams {
+    fn read_params(params: &[StackEntry]) -> Self;
+}
+
+impl ReadParams for () {
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 0);
+        ()
+    }
+}
+
+impl<T1> ReadParams for T1
+where
+    T1: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 1);
+        <T1 as FromStackEntry>::from_stack_entry(results[0])
+    }
+}
+
+impl<T1> ReadParams for (T1,)
+where
+    T1: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 1);
+        (<T1 as FromStackEntry>::from_stack_entry(results[0]),)
+    }
+}
+
+impl<T1, T2> ReadParams for (T1, T2)
+where
+    T1: WasmType,
+    T2: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 2);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+        )
+    }
+}
+
+impl<T1, T2, T3> ReadParams for (T1, T2, T3)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 3);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+        )
+    }
+}
+
+impl<T1, T2, T3, T4> ReadParams for (T1, T2, T3, T4)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 4);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+            <T4 as FromStackEntry>::from_stack_entry(results[3]),
+        )
+    }
+}
+
+impl<T1, T2, T3, T4, T5> ReadParams for (T1, T2, T3, T4, T5)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 5);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+            <T4 as FromStackEntry>::from_stack_entry(results[3]),
+            <T5 as FromStackEntry>::from_stack_entry(results[4]),
+        )
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> ReadParams for (T1, T2, T3, T4, T5, T6)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 6);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+            <T4 as FromStackEntry>::from_stack_entry(results[3]),
+            <T5 as FromStackEntry>::from_stack_entry(results[4]),
+            <T6 as FromStackEntry>::from_stack_entry(results[5]),
+        )
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7> ReadParams for (T1, T2, T3, T4, T5, T6, T7)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+    T7: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 7);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+            <T4 as FromStackEntry>::from_stack_entry(results[3]),
+            <T5 as FromStackEntry>::from_stack_entry(results[4]),
+            <T6 as FromStackEntry>::from_stack_entry(results[5]),
+            <T7 as FromStackEntry>::from_stack_entry(results[6]),
+        )
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8> ReadParams for (T1, T2, T3, T4, T5, T6, T7, T8)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+    T7: WasmType,
+    T8: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 8);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+            <T4 as FromStackEntry>::from_stack_entry(results[3]),
+            <T5 as FromStackEntry>::from_stack_entry(results[4]),
+            <T6 as FromStackEntry>::from_stack_entry(results[5]),
+            <T7 as FromStackEntry>::from_stack_entry(results[6]),
+            <T8 as FromStackEntry>::from_stack_entry(results[7]),
+        )
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8, T9> ReadParams for (T1, T2, T3, T4, T5, T6, T7, T8, T9)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+    T7: WasmType,
+    T8: WasmType,
+    T9: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 9);
+        (
+            <T1 as FromStackEntry>::from_stack_entry(results[0]),
+            <T2 as FromStackEntry>::from_stack_entry(results[1]),
+            <T3 as FromStackEntry>::from_stack_entry(results[2]),
+            <T4 as FromStackEntry>::from_stack_entry(results[3]),
+            <T5 as FromStackEntry>::from_stack_entry(results[4]),
+            <T6 as FromStackEntry>::from_stack_entry(results[5]),
+            <T7 as FromStackEntry>::from_stack_entry(results[6]),
+            <T8 as FromStackEntry>::from_stack_entry(results[7]),
+            <T9 as FromStackEntry>::from_stack_entry(results[8]),
+        )
+    }
+}
+
+pub trait WriteResults {
+    fn write_results(self, results: &mut [StackEntry]);
+}
+
+impl WriteResults for () {
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 0);
+    }
+}
+
+impl<T1> WriteResults for T1
+where
+    T1: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 1);
+        results[0] = self.into();
+    }
+}
+
+impl<T1> WriteResults for (T1,)
+where
+    T1: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 1);
+        results[0] = self.0.into();
+    }
+}
+
+impl<T1, T2> WriteResults for (T1, T2)
+where
+    T1: WasmType,
+    T2: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 2);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+    }
+}
+
+impl<T1, T2, T3> WriteResults for (T1, T2, T3)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 3);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+    }
+}
+
+impl<T1, T2, T3, T4> WriteResults for (T1, T2, T3, T4)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 4);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+        results[3] = self.3.into();
+    }
+}
+
+impl<T1, T2, T3, T4, T5> WriteResults for (T1, T2, T3, T4, T5)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 5);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+        results[3] = self.3.into();
+        results[4] = self.4.into();
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> WriteResults for (T1, T2, T3, T4, T5, T6)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 6);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+        results[3] = self.3.into();
+        results[4] = self.4.into();
+        results[5] = self.5.into();
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7> WriteResults for (T1, T2, T3, T4, T5, T6, T7)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+    T7: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 7);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+        results[3] = self.3.into();
+        results[4] = self.4.into();
+        results[5] = self.5.into();
+        results[6] = self.6.into();
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8> WriteResults for (T1, T2, T3, T4, T5, T6, T7, T8)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+    T7: WasmType,
+    T8: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 8);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+        results[3] = self.3.into();
+        results[4] = self.4.into();
+        results[5] = self.5.into();
+        results[6] = self.6.into();
+        results[7] = self.7.into();
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8, T9> WriteResults for (T1, T2, T3, T4, T5, T6, T7, T8, T9)
+where
+    T1: WasmType,
+    T2: WasmType,
+    T3: WasmType,
+    T4: WasmType,
+    T5: WasmType,
+    T6: WasmType,
+    T7: WasmType,
+    T8: WasmType,
+    T9: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 9);
+        results[0] = self.0.into();
+        results[1] = self.1.into();
+        results[2] = self.2.into();
+        results[3] = self.3.into();
+        results[4] = self.4.into();
+        results[5] = self.5.into();
+        results[6] = self.6.into();
+        results[7] = self.7.into();
+        results[8] = self.8.into();
+    }
+}

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -90,6 +90,16 @@ pub trait ReadParams {
     fn read_params(params: &[StackEntry]) -> Self;
 }
 
+impl<T1> ReadParams for T1
+where
+    T1: WasmType,
+{
+    fn read_params(results: &[StackEntry]) -> Self {
+        assert_eq!(results.len(), 1);
+        <T1 as FromStackEntry>::from_stack_entry(results[0])
+    }
+}
+
 macro_rules! impl_read_params {
     ( $n:literal $( $tuple:ident )* ) => {
         impl<$($tuple),*> ReadParams for ($($tuple,)*)
@@ -132,6 +142,16 @@ pub trait WriteResults {
     ///
     /// [`ValueStack`]: [`crate::engine::ValueStack`]
     fn write_results(self, results: &mut [StackEntry]);
+}
+
+impl<T1> WriteResults for T1
+where
+    T1: WasmType,
+{
+    fn write_results(self, results: &mut [StackEntry]) {
+        assert_eq!(results.len(), 1);
+        results[0] = self.into();
+    }
 }
 
 macro_rules! impl_write_params {

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -17,6 +17,8 @@ pub struct FuncParams<'a> {
     len_results: usize,
 }
 
+/// Utility type to ensure at compile time that host functions always
+/// call [`FuncParams::write_results`] at the end of their execution.
 #[derive(Debug)]
 pub struct FuncResults {}
 
@@ -68,11 +70,18 @@ impl<'a> FuncParams<'a> {
     }
 }
 
+/// Types that can be used with the `wasmi` `v1` engine as inputs and outputs.
 pub trait WasmType: FromStackEntry + Into<StackEntry> {}
 
 impl<T> WasmType for T where T: FromStackEntry + Into<StackEntry> {}
 
+/// Type sequences that can read host function parameters from the [`ValueStack`].
 pub trait ReadParams {
+    /// Reads the host parameters from the given [`ValueStack`] region.
+    ///
+    /// # Panics
+    ///
+    /// If the length of the [`ValueStack`] region does not match.
     fn read_params(params: &[StackEntry]) -> Self;
 }
 
@@ -270,7 +279,13 @@ where
     }
 }
 
+/// Type sequences that can write results back into the [`ValueStack`].
 pub trait WriteResults {
+    /// Writes the `results` into the given [`ValueStack`] region.
+    ///
+    /// # Panics
+    ///
+    /// If the length of the [`ValueStack`] region does not match.
     fn write_results(self, results: &mut [StackEntry]);
 }
 

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -50,7 +50,7 @@ impl<'a> FuncParams<'a> {
         T: ReadParams,
     {
         let params_buffer = &self.params_results[..self.len_params];
-        <T as ReadParams>::read_params(&params_buffer)
+        <T as ReadParams>::read_params(params_buffer)
     }
 
     /// Sets the results of the function invocation.
@@ -63,7 +63,7 @@ impl<'a> FuncParams<'a> {
         T: WriteResults,
     {
         let mut results_buffer = &mut self.params_results[..self.len_results];
-        <T as WriteResults>::write_results(results, &mut results_buffer);
+        <T as WriteResults>::write_results(results, results_buffer);
         FuncResults {}
     }
 }
@@ -79,7 +79,6 @@ pub trait ReadParams {
 impl ReadParams for () {
     fn read_params(results: &[StackEntry]) -> Self {
         assert_eq!(results.len(), 0);
-        ()
     }
 }
 

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -363,11 +363,12 @@ impl EngineInner {
         // we are required to extend the value stack.
         let len_inputs = input_types.len();
         let len_outputs = output_types.len();
+        let len_inout = cmp::max(len_inputs, len_outputs);
+        self.value_stack.reserve(len_inout)?;
         if len_outputs > len_inputs {
             let delta = len_outputs - len_inputs;
-            self.value_stack.reserve(delta)?;
+            self.value_stack.extend_zeros(delta)?;
         }
-        let len_inout = cmp::max(len_inputs, len_outputs);
         let params_results = FuncParams::new(
             self.value_stack.peek_as_slice_mut(len_inout),
             len_inputs,

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -4,9 +4,11 @@ pub mod bytecode;
 pub mod call_stack;
 pub mod code_map;
 pub mod exec_context;
+mod func_args;
 pub mod inst_builder;
 pub mod value_stack;
 
+pub(crate) use self::func_args::{FuncParams, FuncResults, ReadParams, WasmType, WriteResults};
 pub use self::{
     bytecode::{DropKeep, Target},
     code_map::FuncBody,
@@ -20,8 +22,9 @@ use self::{
     value_stack::{FromStackEntry, StackEntry, ValueStack},
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func, Signature};
-use crate::{Trap, TrapCode, Value, ValueType};
-use alloc::{sync::Arc, vec::Vec};
+use crate::{func::HostFuncEntity, Instance, Trap, TrapCode, Value, ValueType};
+use alloc::sync::Arc;
+use core::cmp;
 use spin::mutex::Mutex;
 
 /// Maximum number of bytes on the value stack.
@@ -182,8 +185,6 @@ pub struct EngineInner {
     call_stack: CallStack,
     /// Stores all Wasm function bodies that the interpreter is aware of.
     code_map: CodeMap,
-    /// Scratch buffer for intermediate results and data.
-    scratch: Vec<Value>,
 }
 
 impl EngineInner {
@@ -192,7 +193,6 @@ impl EngineInner {
             value_stack: ValueStack::new(64, config.value_stack_limit),
             call_stack: CallStack::new(config.call_stack_limit),
             code_map: CodeMap::default(),
-            scratch: Vec::new(),
         }
     }
 
@@ -232,9 +232,11 @@ impl EngineInner {
                 self.execute_wasm_func(&mut ctx, signature, args, results, func)?;
             }
             FuncEntityInternal::Host(host_func) => {
-                let signature = host_func.signature();
-                Self::check_signature(ctx.as_context(), signature, args, results)?;
-                host_func.clone().call(&mut ctx, None, args, results)?;
+                self.initialize_args(args);
+                let host_func = host_func.clone();
+                self.execute_host_func(&mut ctx, host_func.clone(), None)?;
+                let result_types = host_func.signature().outputs(&ctx);
+                self.write_results_back(result_types, results);
             }
         }
         Ok(())
@@ -328,14 +330,6 @@ impl EngineInner {
                                 .map_err(|_| TrapCode::StackOverflow)?;
                         }
                         FuncEntityInternal::Host(host_func) => {
-                            let signature = host_func.signature();
-                            let (input_types, output_types) =
-                                signature.inputs_outputs(ctx.as_context());
-                            Self::prepare_host_function_args(
-                                input_types,
-                                &mut self.value_stack,
-                                &mut self.scratch,
-                            );
                             // Note: We push the function context before calling the host function.
                             //       If the VM is not resumable, it does no harm.
                             //       If it is, we then save the context here.
@@ -343,39 +337,8 @@ impl EngineInner {
                             self.call_stack
                                 .push(function_frame)
                                 .map_err(|_| TrapCode::StackOverflow)?;
-                            // Prepare scratch buffer to hold both, inputs and outputs of the call.
-                            // We are going to split the scratch buffer in the middle right before the call.
-                            debug_assert_eq!(self.scratch.len(), input_types.len());
-                            let len_inputs = input_types.len();
-                            let len_outputs = output_types.len();
-                            let zeros = output_types.iter().copied().map(Value::default);
-                            self.scratch.extend(zeros);
-                            // At this point the scratch buffer holds the host function input arguments
-                            // as well as a zero initialized entry per expected host function output value.
-                            let (inputs, outputs) = self.scratch.split_at_mut(len_inputs);
-                            debug_assert_eq!(inputs.len(), len_inputs);
-                            debug_assert_eq!(outputs.len(), len_outputs);
-                            // Now we are ready to perform the host function call.
-                            // Note: We need to clone the host function due to some borrowing issues.
-                            //       This should not be a big deal since host functions usually are cheap to clone.
-                            host_func.clone().call(
-                                ctx.as_context_mut(),
-                                Some(instance),
-                                inputs,
-                                outputs,
-                            )?;
-                            // Check if the returned values match their expected types.
-                            let output_types = signature.outputs(ctx.as_context());
-                            for (required_type, output_value) in
-                                output_types.iter().copied().zip(&*outputs)
-                            {
-                                if required_type != output_value.value_type() {
-                                    return Err(TrapCode::UnexpectedSignature).map_err(Into::into);
-                                }
-                            }
-                            // Copy host function output values to the value stack.
-                            self.value_stack
-                                .extend(outputs.iter().copied().map(|value| value.into()));
+                            let host_func = host_func.clone();
+                            self.execute_host_func(&mut ctx, host_func, Some(instance))?;
                         }
                     }
                 }
@@ -383,29 +346,48 @@ impl EngineInner {
         }
     }
 
-    /// Prepares the inputs arguments to the host function execution.
-    ///
-    /// # Note
-    ///
-    /// This will pop the last `n` values from the `value_stack` where
-    /// `n` is the number of required input arguments to the host function
-    /// and equal to the number of elements in `input_types`.
-    /// The `input_types` slice represents the value types required by the
-    /// host function that is about to be called.
-    fn prepare_host_function_args(
-        input_types: &[ValueType],
-        value_stack: &mut ValueStack,
-        host_args: &mut Vec<Value>,
-    ) {
-        let len_args = input_types.len();
-        let stack_args = value_stack.pop_as_slice(len_args);
-        assert_eq!(len_args, stack_args.len());
-        host_args.clear();
-        let prepared_args = input_types
-            .iter()
-            .zip(stack_args)
-            .map(|(input_type, host_arg)| host_arg.with_type(*input_type));
-        host_args.extend(prepared_args);
+    #[inline(always)]
+    fn execute_host_func<C>(
+        &mut self,
+        mut ctx: C,
+        host_func: HostFuncEntity<<C as AsContext>::UserState>,
+        instance: Option<Instance>,
+    ) -> Result<(), Trap>
+    where
+        C: AsContextMut,
+    {
+        // The host function signature is required for properly
+        // adjusting, inspecting and manipulating the value stack.
+        let signature = host_func.signature();
+        let (input_types, output_types) = signature.inputs_outputs(ctx.as_context());
+        // In case the host function returns more values than it takes
+        // we are required to extend the value stack.
+        let len_inputs = input_types.len();
+        let len_outputs = output_types.len();
+        if len_outputs > len_inputs {
+            let delta = len_outputs - len_inputs;
+            self.value_stack.reserve(delta)?;
+        }
+        let len_inout = cmp::max(len_inputs, len_outputs);
+        let params_results = FuncParams::new(
+            self.value_stack.peek_as_slice_mut(len_inout),
+            len_inputs,
+            len_outputs,
+        );
+        // Now we are ready to perform the host function call.
+        // Note: We need to clone the host function due to some borrowing issues.
+        //       This should not be a big deal since host functions usually are cheap to clone.
+        host_func.call(ctx.as_context_mut(), instance, params_results)?;
+        // If the host functions returns fewer results than it receives parameters
+        // the value stack needs to be shrinked for the delta.
+        if len_outputs < len_inputs {
+            let delta = len_inputs - len_outputs;
+            self.value_stack.drop(delta);
+        }
+        // At this point the host function has been called and has directly
+        // written its results into the value stack so that the last entries
+        // in the value stack are the result values of the host function call.
+        Ok(())
     }
 
     /// Initializes the value stack with the given arguments `args`.

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -346,7 +346,6 @@ impl EngineInner {
         }
     }
 
-    #[inline(always)]
     fn execute_host_func<C>(
         &mut self,
         mut ctx: C,

--- a/wasmi_v1/src/engine/value_stack.rs
+++ b/wasmi_v1/src/engine/value_stack.rs
@@ -301,6 +301,10 @@ impl ValueStack {
         self.entries[self.stack_ptr]
     }
 
+    pub fn drop(&mut self, depth: usize) {
+        self.stack_ptr -= depth;
+    }
+
     /// Pops the last [`StackEntry`] from the [`ValueStack`] as `T`.
     pub fn pop_as<T>(&mut self) -> T
     where
@@ -414,19 +418,11 @@ impl ValueStack {
         &self.entries[0..len]
     }
 
-    /// Pops the last `depth` stack entries and returns them as slice.
-    ///
-    /// Stack entries are returned in the order in which they got pushed
-    /// onto the value stack.
-    ///
-    /// # Panics
-    ///
-    /// If the value stack does not have at least `depth` stack entries.
-    pub fn pop_as_slice(&mut self, depth: usize) -> &[StackEntry] {
-        self.stack_ptr -= depth;
-        let start = self.stack_ptr;
-        let end = self.stack_ptr + depth;
-        &self.entries[start..end]
+    /// Returns an exclusive slice to the last `depth` entries in the value stack.
+    pub fn peek_as_slice_mut(&mut self, depth: usize) -> &mut [StackEntry] {
+        let start = self.stack_ptr - depth;
+        let end = self.stack_ptr;
+        &mut self.entries[start..end]
     }
 
     /// Clears the [`ValueStack`] entirely.

--- a/wasmi_v1/src/foreach_tuple.rs
+++ b/wasmi_v1/src/foreach_tuple.rs
@@ -1,4 +1,3 @@
-
 /// Macro to help implement generic trait implementations for tuple types.
 macro_rules! for_each_tuple {
     ($mac:ident) => {

--- a/wasmi_v1/src/foreach_tuple.rs
+++ b/wasmi_v1/src/foreach_tuple.rs
@@ -1,0 +1,26 @@
+
+/// Macro to help implement generic trait implementations for tuple types.
+macro_rules! for_each_tuple {
+    ($mac:ident) => {
+        $mac!( 0 );
+        $mac!( 1 T1);
+        $mac!( 2 T1 T2);
+        $mac!( 3 T1 T2 T3);
+        $mac!( 4 T1 T2 T3 T4);
+        $mac!( 5 T1 T2 T3 T4 T5);
+        $mac!( 6 T1 T2 T3 T4 T5 T6);
+        $mac!( 7 T1 T2 T3 T4 T5 T6 T7);
+        $mac!( 8 T1 T2 T3 T4 T5 T6 T7 T8);
+        $mac!( 9 T1 T2 T3 T4 T5 T6 T7 T8 T9);
+        $mac!(10 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10);
+        $mac!(11 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11);
+        $mac!(12 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12);
+        $mac!(13 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13);
+        $mac!(14 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14);
+        $mac!(15 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
+        $mac!(16 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16);
+    }
+}
+
+#[doc(inline)]
+pub(crate) use for_each_tuple;

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -34,10 +34,10 @@ macro_rules! impl_into_func {
             $(
                 $tuple: WasmType,
             )*
-            R: WasmReturnType,
+            R: WasmResults,
         {
             type Params = ($($tuple,)*);
-            type Results = <R as WasmReturnType>::Ok;
+            type Results = <R as WasmResults>::Ok;
 
             #[allow(non_snake_case)]
             fn into_func(self) -> (SignatureEntity, HostFuncTrampoline<T>) {
@@ -61,10 +61,10 @@ macro_rules! impl_into_func {
             $(
                 $tuple: WasmType,
             )*
-            R: WasmReturnType,
+            R: WasmResults,
         {
             type Params = ($($tuple,)*);
-            type Results = <R as WasmReturnType>::Ok;
+            type Results = <R as WasmResults>::Ok;
 
             #[allow(non_snake_case)]
             fn into_func(self) -> (SignatureEntity, HostFuncTrampoline<T>) {
@@ -88,15 +88,15 @@ macro_rules! impl_into_func {
 for_each_tuple!(impl_into_func);
 
 /// Types and type sequences that can be used as return values of host functions.
-pub trait WasmReturnType {
+pub trait WasmResults {
     #[doc(hidden)]
     type Ok: WasmTypeList;
 
     #[doc(hidden)]
-    fn into_fallible(self) -> Result<<Self as WasmReturnType>::Ok, Trap>;
+    fn into_fallible(self) -> Result<<Self as WasmResults>::Ok, Trap>;
 }
 
-impl<T1> WasmReturnType for T1
+impl<T1> WasmResults for T1
 where
     T1: WasmType,
 {
@@ -109,7 +109,7 @@ where
 
 macro_rules! impl_wasm_return_type {
     ( $n:literal $( $tuple:ident )* ) => {
-        impl<$($tuple),*> WasmReturnType for ($($tuple,)*)
+        impl<$($tuple),*> WasmResults for ($($tuple,)*)
         where
             $(
                 $tuple: WasmType
@@ -122,7 +122,7 @@ macro_rules! impl_wasm_return_type {
             }
         }
 
-        impl<$($tuple),*> WasmReturnType for Result<($($tuple,)*), Trap>
+        impl<$($tuple),*> WasmResults for Result<($($tuple,)*), Trap>
         where
             $(
                 $tuple: WasmType
@@ -130,7 +130,7 @@ macro_rules! impl_wasm_return_type {
         {
             type Ok = ($($tuple,)*);
 
-            fn into_fallible(self) -> Result<<Self as WasmReturnType>::Ok, Trap> {
+            fn into_fallible(self) -> Result<<Self as WasmResults>::Ok, Trap> {
                 self
             }
         }

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -7,7 +7,6 @@ use crate::{
     Caller,
     SignatureEntity,
 };
-use alloc::sync::Arc;
 use core::array;
 use wasmi_core::{FromValue, Trap, Value, ValueType, F32, F64};
 
@@ -187,18 +186,6 @@ where
             },
         );
         (signature, trampoline)
-    }
-}
-
-impl<T> HostFuncTrampoline<T> {
-    pub fn new<F>(trampoline: F) -> Self
-    where
-        F: Fn(Caller<T>, FuncParams) -> Result<FuncResults, Trap>,
-        F: Send + Sync + 'static,
-    {
-        Self {
-            closure: Arc::new(trampoline),
-        }
     }
 }
 

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -265,9 +265,21 @@ impl WasmType for F64 {
     }
 }
 
+/// A list of [`WasmType`] types.
+///
+/// # Note
+///
+/// This is a convenience trait that allows to:
+///
+/// - Read host function parameters from a region of the value stack.
+/// - Write host function results into a region of the value stack.
+/// - Iterate over the value types of the Wasm type sequence
+///     - This is useful to construct host function signatures.
 pub trait WasmTypeList: ReadParams + WriteResults {
+    /// The [`ValueType`] sequence iterator type.
     type Iter: IntoIterator<Item = ValueType> + ExactSizeIterator + DoubleEndedIterator;
 
+    /// Returns an iterator over the [`ValueType`] sequence representing `Self`.
     fn value_types() -> Self::Iter;
 }
 
@@ -485,7 +497,19 @@ where
     }
 }
 
+/// Tuple types that can be applied to a function taking matching parameters.
+///
+/// # Note
+///
+/// This is a convenience type to clean up some generic code.
 pub trait ApplyFunc<F, R> {
+    /// Applies `f` given `self` as parameters.
+    ///
+    /// # Note
+    ///
+    /// `Self` usually is a tuple type `(T1, T2, ..)` and `f` is
+    /// a function that takes parameters of the same order and structure
+    /// as `Self`.
     fn apply_ref(self, f: F) -> R;
 }
 

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -136,40 +136,24 @@ pub trait WasmType: FromValue + Into<Value> + InternalWasmType {
     fn value_type() -> ValueType;
 }
 
-impl WasmType for u32 {
-    fn value_type() -> ValueType {
-        ValueType::I32
-    }
+macro_rules! impl_wasm_type {
+    ( $( type $rust_type:ty = $wasmi_type:ident );* $(;)? ) => {
+        $(
+            impl WasmType for $rust_type {
+                fn value_type() -> ValueType {
+                    ValueType::$wasmi_type
+                }
+            }
+        )*
+    };
 }
-
-impl WasmType for u64 {
-    fn value_type() -> ValueType {
-        ValueType::I64
-    }
-}
-
-impl WasmType for i32 {
-    fn value_type() -> ValueType {
-        ValueType::I32
-    }
-}
-
-impl WasmType for i64 {
-    fn value_type() -> ValueType {
-        ValueType::I64
-    }
-}
-
-impl WasmType for F32 {
-    fn value_type() -> ValueType {
-        ValueType::F32
-    }
-}
-
-impl WasmType for F64 {
-    fn value_type() -> ValueType {
-        ValueType::F64
-    }
+impl_wasm_type! {
+    type u32 = I32;
+    type u64 = I64;
+    type i32 = I32;
+    type i64 = I64;
+    type F32 = F32;
+    type F64 = F64;
 }
 
 /// A list of [`WasmType`] types.

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -136,6 +136,18 @@ pub trait WasmType: FromValue + Into<Value> + InternalWasmType {
     fn value_type() -> ValueType;
 }
 
+impl WasmType for u32 {
+    fn value_type() -> ValueType {
+        ValueType::I32
+    }
+}
+
+impl WasmType for u64 {
+    fn value_type() -> ValueType {
+        ValueType::I64
+    }
+}
+
 impl WasmType for i32 {
     fn value_type() -> ValueType {
         ValueType::I32

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -89,17 +89,6 @@ pub trait WasmReturnType {
     fn into_fallible(self) -> Result<<Self as WasmReturnType>::Ok, Trap>;
 }
 
-impl<T1> WasmReturnType for T1
-where
-    T1: WasmType,
-{
-    type Ok = T1;
-
-    fn into_fallible(self) -> Result<Self::Ok, Trap> {
-        Ok(self)
-    }
-}
-
 macro_rules! impl_wasm_return_type {
     ( $n:literal $( $tuple:ident )* ) => {
         impl<$($tuple),*> WasmReturnType for ($($tuple,)*)
@@ -172,17 +161,6 @@ pub trait WasmTypeList: ReadParams + WriteResults {
 
     /// Returns an iterator over the [`ValueType`] sequence representing `Self`.
     fn value_types() -> Self::Iter;
-}
-
-impl<T1> WasmTypeList for T1
-where
-    T1: WasmType,
-{
-    type Iter = array::IntoIter<ValueType, 1>;
-
-    fn value_types() -> Self::Iter {
-        [<T1 as WasmType>::value_type()].into_iter()
-    }
 }
 
 macro_rules! impl_wasm_type_list {

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -11,12 +11,16 @@ use crate::{
 use core::array;
 use wasmi_core::{FromValue, Trap, Value, ValueType, F32, F64};
 
+/// Closures and functions that can be used as host functions.
 pub trait IntoFunc<T, Params, Results>: Send + Sync + 'static {
+    /// The parameters of the host function.
     #[doc(hidden)]
     type Params: WasmTypeList;
+    /// The results of the host function.
     #[doc(hidden)]
     type Results: WasmTypeList;
 
+    /// Converts the function into its `wasmi` signature and its trampoline.
     #[doc(hidden)]
     fn into_func(self) -> (SignatureEntity, HostFuncTrampoline<T>);
 }
@@ -83,9 +87,12 @@ macro_rules! impl_into_func {
 }
 for_each_tuple!(impl_into_func);
 
+/// Types and type sequences that can be used as return values of host functions.
 pub trait WasmReturnType {
+    #[doc(hidden)]
     type Ok: WasmTypeList;
 
+    #[doc(hidden)]
     fn into_fallible(self) -> Result<<Self as WasmReturnType>::Ok, Trap>;
 }
 
@@ -131,6 +138,7 @@ macro_rules! impl_wasm_return_type {
 }
 for_each_tuple!(impl_wasm_return_type);
 
+/// Types that can be used as parameters or results of host functions.
 pub trait WasmType: FromValue + Into<Value> + InternalWasmType {
     /// Returns the value type of the Wasm type.
     fn value_type() -> ValueType;

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::{
     engine::{ReadParams, WriteResults},
+    foreach_tuple::for_each_tuple,
     Caller,
     SignatureEntity,
 };

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -208,35 +208,3 @@ macro_rules! impl_wasm_type_list {
     };
 }
 for_each_tuple!(impl_wasm_type_list);
-
-/// Tuple types that can be applied to a function taking matching parameters.
-///
-/// # Note
-///
-/// This is a convenience type to clean up some generic code.
-pub trait ApplyFunc<F, R> {
-    /// Applies `f` given `self` as parameters.
-    ///
-    /// # Note
-    ///
-    /// `Self` usually is a tuple type `(T1, T2, ..)` and `f` is
-    /// a function that takes parameters of the same order and structure
-    /// as `Self`.
-    fn apply_ref(self, f: F) -> R;
-}
-
-macro_rules! impl_apply_func {
-    ( $n:literal $( $tuple:ident )* ) => {
-        impl<F, R, $($tuple),*> ApplyFunc<F, R> for ($($tuple,)*)
-        where
-            F: Fn($($tuple),*) -> R,
-        {
-            #[allow(non_snake_case)]
-            fn apply_ref(self, f: F) -> R {
-                let ($($tuple,)*) = self;
-                f($($tuple),*)
-            }
-        }
-    };
-}
-for_each_tuple!(impl_apply_func);

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -12,7 +12,9 @@ use core::array;
 use wasmi_core::{FromValue, Trap, Value, ValueType, F32, F64};
 
 pub trait IntoFunc<T, Params, Results>: Send + Sync + 'static {
+    #[doc(hidden)]
     type Params: WasmTypeList;
+    #[doc(hidden)]
     type Results: WasmTypeList;
 
     #[doc(hidden)]

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -89,6 +89,17 @@ pub trait WasmReturnType {
     fn into_fallible(self) -> Result<<Self as WasmReturnType>::Ok, Trap>;
 }
 
+impl<T1> WasmReturnType for T1
+where
+    T1: WasmType,
+{
+    type Ok = T1;
+
+    fn into_fallible(self) -> Result<Self::Ok, Trap> {
+        Ok(self)
+    }
+}
+
 macro_rules! impl_wasm_return_type {
     ( $n:literal $( $tuple:ident )* ) => {
         impl<$($tuple),*> WasmReturnType for ($($tuple,)*)
@@ -161,6 +172,17 @@ pub trait WasmTypeList: ReadParams + WriteResults {
 
     /// Returns an iterator over the [`ValueType`] sequence representing `Self`.
     fn value_types() -> Self::Iter;
+}
+
+impl<T1> WasmTypeList for T1
+where
+    T1: WasmType,
+{
+    type Iter = array::IntoIter<ValueType, 1>;
+
+    fn value_types() -> Self::Iter {
+        [<T1 as WasmType>::value_type()].into_iter()
+    }
 }
 
 macro_rules! impl_wasm_type_list {

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -214,13 +214,13 @@ macro_rules! for_each_tuple {
         $mac!( 7 T1 T2 T3 T4 T5 T6 T7);
         $mac!( 8 T1 T2 T3 T4 T5 T6 T7 T8);
         $mac!( 9 T1 T2 T3 T4 T5 T6 T7 T8 T9);
-        // $mac!(10 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10);
-        // $mac!(11 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11);
-        // $mac!(12 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12);
-        // $mac!(13 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13);
-        // $mac!(14 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14);
-        // $mac!(15 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
-        // $mac!(16 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16);
+        $mac!(10 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10);
+        $mac!(11 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11);
+        $mac!(12 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12);
+        $mac!(13 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13);
+        $mac!(14 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14);
+        $mac!(15 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
+        $mac!(16 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16);
     }
 }
 

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -202,28 +202,6 @@ impl<T> HostFuncTrampoline<T> {
     }
 }
 
-macro_rules! for_each_tuple {
-    ($mac:ident) => {
-        $mac!( 0 );
-        $mac!( 1 T1);
-        $mac!( 2 T1 T2);
-        $mac!( 3 T1 T2 T3);
-        $mac!( 4 T1 T2 T3 T4);
-        $mac!( 5 T1 T2 T3 T4 T5);
-        $mac!( 6 T1 T2 T3 T4 T5 T6);
-        $mac!( 7 T1 T2 T3 T4 T5 T6 T7);
-        $mac!( 8 T1 T2 T3 T4 T5 T6 T7 T8);
-        $mac!( 9 T1 T2 T3 T4 T5 T6 T7 T8 T9);
-        $mac!(10 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10);
-        $mac!(11 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11);
-        $mac!(12 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12);
-        $mac!(13 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13);
-        $mac!(14 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14);
-        $mac!(15 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15);
-        $mac!(16 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16);
-    }
-}
-
 pub trait WasmReturnType {
     type Ok: WasmTypeList;
 

--- a/wasmi_v1/src/func/mod.rs
+++ b/wasmi_v1/src/func/mod.rs
@@ -160,6 +160,19 @@ pub struct HostFuncTrampoline<T> {
     closure: Arc<HostFuncTrampolineFn<T>>,
 }
 
+impl<T> HostFuncTrampoline<T> {
+    /// Creates a new [`HostFuncTrampoline`] from the given trampoline function.
+    pub fn new<F>(trampoline: F) -> Self
+    where
+        F: Fn(Caller<T>, FuncParams) -> Result<FuncResults, Trap>,
+        F: Send + Sync + 'static,
+    {
+        Self {
+            closure: Arc::new(trampoline),
+        }
+    }
+}
+
 impl<T> Clone for HostFuncTrampoline<T> {
     fn clone(&self) -> Self {
         Self {

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -10,6 +10,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
+#[macro_use]
+mod foreach_tuple;
+
 mod arena;
 mod engine;
 mod error;


### PR DESCRIPTION
This PR optimizes marshalling of function parameters and return values when calling host functions from Wasm execution.
This basically tries to go the optimal path where the host function parameters are read out directly from the value stack and the host function directly writes results back into the value stack.
The benchmarks show improvements between 10-15%:

# Note

- Host calls when executed from the host side now use the `v1` interpreter engine, too.
- The optimized marshalling mainly got improved for the common case where Wasm calls into the host.
- This PR implementation allows for an efficient `TypedFunc` implementation. (https://github.com/paritytech/wasmi/issues/303)
- There no longer is the need for the artificial `scratch` buffer for the `v1` engine type so this PR removes it again.

# ToDo

- [x] Use more declarative macros instead of hand coding some generic trait implementations.
- [x] Write some unit tests to guard some edge cases for host calls.
    - [ ] Fix failing tests.

# Benchmarks

## Before

```
execute/host_calls/v0   time:   [75.558 us 75.773 us 76.006 us]                                  
                        change: [-1.0263% -0.2417% +0.5489%] (p = 0.54 > 0.05)
execute/host_calls/v1   time:   [59.512 us 60.099 us 61.050 us]                                  
                        change: [-4.4018% -3.6043% -2.7357%] (p = 0.00 < 0.05)
```

## After

```
execute/host_calls/v0   time:   [73.723 us 75.298 us 77.553 us]                                  
                        change: [-2.7991% -1.3959% +0.2272%] (p = 0.06 > 0.05)
execute/host_calls/v1   time:   [52.763 us 52.959 us 53.169 us]                                  
                        change: [-2.8487% -1.7205% -0.7480%] (p = 0.00 < 0.05)
```