### PR TITLE
Clean up wasmi_v1 codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,5 @@ name = "benches"
 harness = false
 
 [profile.bench]
-debug = true
 lto = "fat"
 codegen-units = 1

--- a/wasmi_v1/src/engine/call_stack.rs
+++ b/wasmi_v1/src/engine/call_stack.rs
@@ -244,12 +244,6 @@ impl CallStack {
         self.frames.len()
     }
 
-    /// Returns `true` if the [`CallStack`] is empty.
-    #[allow(dead_code)] // TODO: decide how to remove this
-    pub fn is_empty(&self) -> bool {
-        self.frames.is_empty()
-    }
-
     /// Clears the [`CallStack`] entirely.
     ///
     /// # Note

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -352,14 +352,14 @@ impl EngineInner {
         // we are required to extend the value stack.
         let len_inputs = input_types.len();
         let len_outputs = output_types.len();
-        let len_inout = cmp::max(len_inputs, len_outputs);
-        self.value_stack.reserve(len_inout)?;
+        let max_inout = cmp::max(len_inputs, len_outputs);
+        self.value_stack.reserve(max_inout)?;
         if len_outputs > len_inputs {
             let delta = len_outputs - len_inputs;
             self.value_stack.extend_zeros(delta)?;
         }
         let params_results = FuncParams::new(
-            self.value_stack.peek_as_slice_mut(len_inout),
+            self.value_stack.peek_as_slice_mut(max_inout),
             len_inputs,
             len_outputs,
         );

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -235,9 +235,10 @@ impl EngineInner {
                 signature
             }
             FuncEntityInternal::Host(host_func) => {
+                let signature = host_func.signature();
                 let host_func = host_func.clone();
-                self.execute_host_func(&mut ctx, host_func.clone(), None)?;
-                host_func.signature()
+                self.execute_host_func(&mut ctx, host_func, None)?;
+                signature
             }
         };
         let result_types = signature.outputs(&ctx);

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -24,7 +24,7 @@ use self::{
     value_stack::{FromStackEntry, StackEntry, ValueStack},
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func};
-use crate::{func::HostFuncEntity, Instance, Trap, TrapCode, ValueType};
+use crate::{func::HostFuncEntity, Instance, Trap, ValueType};
 use alloc::sync::Arc;
 use core::cmp;
 use spin::mutex::Mutex;

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -347,8 +347,7 @@ impl EngineInner {
     {
         // The host function signature is required for properly
         // adjusting, inspecting and manipulating the value stack.
-        let signature = host_func.signature();
-        let (input_types, output_types) = signature.inputs_outputs(ctx.as_context());
+        let (input_types, output_types) = host_func.signature().inputs_outputs(ctx.as_context());
         // In case the host function returns more values than it takes
         // we are required to extend the value stack.
         let len_inputs = input_types.len();

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -386,10 +386,6 @@ impl EngineInner {
     {
         self.value_stack.clear();
         self.call_stack.clear();
-        assert!(
-            self.value_stack.is_empty(),
-            "encountered non-empty value stack upon function execution initialization",
-        );
         for param in params.feed_params() {
             self.value_stack.push(param);
         }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -259,9 +259,7 @@ impl EngineInner {
     /// - When encountering a Wasm trap during the execution of `func`.
     fn execute_wasm_func(&mut self, mut ctx: impl AsContextMut, func: Func) -> Result<(), Trap> {
         let frame = FunctionFrame::new(ctx.as_context(), func);
-        self.call_stack
-            .push(frame)
-            .map_err(|_error| TrapCode::StackOverflow)?;
+        self.call_stack.push(frame)?;
         self.execute_until_done(ctx.as_context_mut())?;
         Ok(())
     }

--- a/wasmi_v1/src/engine/value_stack.rs
+++ b/wasmi_v1/src/engine/value_stack.rs
@@ -373,11 +373,6 @@ impl ValueStack {
         self.stack_ptr
     }
 
-    /// Returns `true` if the [`ValueStack`] is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     /// Reserves enough space for `additional` entries in the [`ValueStack`].
     ///
     /// # Note

--- a/wasmi_v1/src/module/compile/mod.rs
+++ b/wasmi_v1/src/module/compile/mod.rs
@@ -104,32 +104,6 @@ impl<'engine> FuncBodyTranslator<'engine> {
         }
     }
 
-    /// Translates the instructions forming a Wasm function body into `wasmi` bytecode.
-    ///
-    /// Returns a [`FuncBody`] reference to the translated `wasmi` bytecode.
-    pub fn translate<'a, I: 'a>(
-        &mut self,
-        validator: &mut FunctionValidationContext,
-        instructions: I,
-    ) -> Result<FuncBody, Error>
-    where
-        I: IntoIterator<Item = &'a pwasm::Instruction>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        for instruction in instructions {
-            self.translate_instruction(validator, instruction)?;
-        }
-        // We need to call this function yet another time at the end
-        // of the instruction sequence because with future Wasm `multivalue`
-        // proposal it could be that the last instruction pushes a lot
-        // of values to the stack.
-        self.pin_max_stack_height(validator);
-        let func_body =
-            self.inst_builder
-                .finish(self.engine, self.len_locals, self.max_stack_height);
-        Ok(func_body)
-    }
-
     /// Updates the maximum stack height of the function.
     ///
     /// # Note

--- a/wasmi_v1/src/module/instantiate.rs
+++ b/wasmi_v1/src/module/instantiate.rs
@@ -172,11 +172,6 @@ pub struct InstancePre<'a> {
 }
 
 impl<'a> InstancePre<'a> {
-    /// Returns `true` if the [`Module`] has a `start` function.
-    fn has_start_fn(&self) -> bool {
-        self.start_fn().is_some()
-    }
-
     /// Returns the index of the `start` function if any.
     ///
     /// Returns `None` if the [`Module`] does not have a `start` function.

--- a/wasmi_v1/src/module/mod.rs
+++ b/wasmi_v1/src/module/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO: remove
-
 mod compile;
 mod error;
 mod instantiate;


### PR DESCRIPTION
- Removes superflous `clone`
- Removes plenty of dead code
- Cleans up some engine specific code
- Removes useless assert