### PR TITLE
Optimize recursive calls

### DIFF
--- a/wasmi_v1/src/engine/call_stack.rs
+++ b/wasmi_v1/src/engine/call_stack.rs
@@ -222,18 +222,6 @@ impl CallStack {
         Ok(())
     }
 
-    pub fn push_pair(
-        &mut self,
-        first: FunctionFrame,
-        second: FunctionFrame,
-    ) -> Result<(), TrapCode> {
-        if self.len() + 1 >= self.recursion_limit {
-            return Err(TrapCode::StackOverflow);
-        }
-        self.frames.extend([first, second]);
-        Ok(())
-    }
-
     /// Pops the last [`FunctionFrame`] from the [`CallStack`] if any.
     pub fn pop(&mut self) -> Option<FunctionFrame> {
         self.frames.pop()

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -78,7 +78,7 @@ impl<'engine, 'func> ExecutionContext<'engine, 'func> {
     /// calls into another function or the function returns to its caller.
     #[inline(always)]
     pub fn execute_frame(
-        &mut self,
+        self,
         mut ctx: impl AsContextMut,
     ) -> Result<FunctionExecutionOutcome, Trap> {
         'outer: loop {


### PR DESCRIPTION
While trying to figure out https://github.com/paritytech/wasmi/issues/339 I discovered some optimization potential for recursive calls and host calls which led to a fantastic speed up.

This basically reuses the local variable `function_frame` inside a hot loop instead of hot swapping the most recent function frame using the call stack. This behavior was inherited by the old `wasmi` engine (so we could implement an improvement there as well potentially).

# Benchmarks

## Before

```
execute/tiny_keccak/v1         time: [982.21 us 985.14 us 988.71 us]
execute/rev_complement/v1      time: [1.2141 ms 1.2168 ms 1.2200 ms]
execute/regex_redux/v1         time: [1.3259 ms 1.3288 ms 1.3322 ms]
execute/count_until/v1         time: [1.7190 ms 1.7231 ms 1.7274 ms]
execute/factorial_recursive/v1 time: [1.4232 us 1.4269 us 1.4311 us]
execute/factorial_optimized/v1 time: [725.67 ns 727.49 ns 729.57 ns]
execute/recursive_ok/v1        time: [376.72 us 378.03 us 379.50 us]
execute/recursive_trap/v1      time: [39.879 us 39.987 us 40.108 us]
execute/host_calls/v1          time: [54.598 us 54.743 us 54.898 us]
```

## After

```
execute/tiny_keccak/v1         time:   [988.81 us 991.87 us 995.41 us]
execute/rev_complement/v1      time:   [1.2125 ms 1.2150 ms 1.2179 ms]
execute/regex_redux/v1         time:   [1.2941 ms 1.2978 ms 1.3026 ms]
execute/count_until/v1         time:   [1.7007 ms 1.7133 ms 1.7367 ms]
execute/factorial_recursive/v1 time:   [1.2394 us 1.2433 us 1.2479 us]
execute/factorial_optimized/v1 time:   [723.59 ns 727.05 ns 732.14 ns]
execute/recursive_ok/v1        time:   [316.64 us 320.51 us 325.65 us]
execute/recursive_trap/v1      time:   [30.679 us 30.745 us 30.816 us]
execute/host_calls/v1          time:   [47.431 us 47.576 us 47.747 us]
```

## Summary

We see improvements in

- `factorial_recursive`: `1.4269 us` down to `1.2433 us` -> 13% faster
- `recursive_ok`: `378.03 us` down to `320.51 us` -> 16% faster
- `recursive_trap`: `39.987 us` down to `30.745 us` -> 23% faster
- `host_calls`: `54.743 us` down to `47.576 us` -> 13% faster