### PR TITLE
Separate wasmi wasmi_v1 crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --features v1
+          args: --workspace
       - name: Build (all features)
         uses: actions-rs/cargo@v1
         with:
@@ -32,12 +32,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --features v1 --no-default-features
+          args: --workspace --no-default-features
       - name: Build (wasm32)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --features v1 --no-default-features --target wasm32-unknown-unknown
+          args: --workspace --no-default-features --target wasm32-unknown-unknown
 
   test:
     name: Test
@@ -72,7 +72,7 @@ jobs:
           RUSTFLAGS: '--cfg debug_assertions'
         with:
           command: test
-          args: --workspace --release --features v1
+          args: --workspace --release
       - name: Test (all features)
         uses: actions-rs/cargo@v1
         env:
@@ -146,7 +146,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --features v1 -- -D warnings
+          args: --workspace -- -D warnings
       - name: Clippy (all features)
         uses: actions-rs/cargo@v1
         with:
@@ -156,7 +156,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --features v1 --no-default-features -- -D warnings
+          args: --workspace --no-default-features -- -D warnings
 
   coverage:
     name: Coverage
@@ -177,7 +177,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.0'
-          args: --workspace --features v1
+          args: --workspace
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
 wasmi_core = { version = "0.1", path = "core", default-features = false }
-wasmi_v1 = { version = "0.11", path = "wasmi_v1", default-features = false, optional = true }
 validation = { package = "wasmi-validation", version = "0.4", path = "validation", default-features = false }
 parity-wasm = { version = "0.42.0", default-features = false }
 
@@ -35,8 +34,6 @@ std = [
     "parity-wasm/std",
     "validation/std",
 ]
-# Enables the `wasmi_v1` interpreter implementation.
-v1 = ["wasmi_v1"]
 # Enables OS supported virtual memory.
 #
 # Note

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -13,7 +13,7 @@ use assert_matches::assert_matches;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::slice;
 use wasmi as v0;
-use wasmi::{Trap, RuntimeValue as Value};
+use wasmi::{RuntimeValue as Value, Trap};
 use wasmi_v1 as v1;
 
 const WASM_KERNEL: &str =

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -13,7 +13,7 @@ use assert_matches::assert_matches;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::slice;
 use wasmi as v0;
-use wasmi::{Trap, Value};
+use wasmi::{Trap, RuntimeValue as Value};
 use wasmi_v1 as v1;
 
 const WASM_KERNEL: &str =

--- a/examples/interpret.rs
+++ b/examples/interpret.rs
@@ -3,7 +3,7 @@
 extern crate wasmi;
 
 use std::{env::args, fs::File};
-use wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, Value};
+use wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, RuntimeValue};
 
 fn load_from_file(filename: &str) -> Module {
     use std::io::prelude::*;
@@ -41,6 +41,6 @@ fn main() {
     // "_call" export of function to be executed with an i32 argument and prints the result of execution
     println!(
         "Result: {:?}",
-        main.invoke_export("_call", &[Value::I32(argument)], &mut NopExternals)
+        main.invoke_export("_call", &[RuntimeValue::I32(argument)], &mut NopExternals)
     );
 }

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -4,7 +4,7 @@ extern crate wasmi;
 use std::env::args;
 
 use parity_wasm::elements::{External, FunctionType, Internal, Module, Type, ValueType};
-use wasmi::{ImportsBuilder, ModuleInstance, NopExternals, Value};
+use wasmi::{ImportsBuilder, ModuleInstance, NopExternals, RuntimeValue};
 
 fn main() {
     let args: Vec<_> = args().collect();
@@ -72,30 +72,30 @@ fn main() {
             .iter()
             .enumerate()
             .map(|(i, value)| match value {
-                ValueType::I32 => Value::I32(
+                ValueType::I32 => RuntimeValue::I32(
                     program_args[i]
                         .parse::<i32>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as i32", program_args[i])),
                 ),
-                ValueType::I64 => Value::I64(
+                ValueType::I64 => RuntimeValue::I64(
                     program_args[i]
                         .parse::<i64>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as i64", program_args[i])),
                 ),
-                ValueType::F32 => Value::F32(
+                ValueType::F32 => RuntimeValue::F32(
                     program_args[i]
                         .parse::<f32>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as f32", program_args[i]))
                         .into(),
                 ),
-                ValueType::F64 => Value::F64(
+                ValueType::F64 => RuntimeValue::F64(
                     program_args[i]
                         .parse::<f64>()
                         .unwrap_or_else(|_| panic!("Can't parse arg #{} as f64", program_args[i]))
                         .into(),
                 ),
             })
-            .collect::<Vec<Value>>()
+            .collect::<Vec<RuntimeValue>>()
     };
 
     let loaded_module = wasmi::Module::from_parity_wasm_module(module).expect("Module to be valid");

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -15,9 +15,9 @@ use wasmi::{
     ModuleInstance,
     ModuleRef,
     RuntimeArgs,
+    RuntimeValue,
     Signature,
     Trap,
-    RuntimeValue,
     ValueType,
 };
 
@@ -152,7 +152,11 @@ const SET_FUNC_INDEX: usize = 0;
 const GET_FUNC_INDEX: usize = 1;
 
 impl<'a> Externals for Runtime<'a> {
-    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
+    fn invoke_index(
+        &mut self,
+        index: usize,
+        args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             SET_FUNC_INDEX => {
                 let idx: i32 = args.nth(0);

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -17,7 +17,7 @@ use wasmi::{
     RuntimeArgs,
     Signature,
     Trap,
-    Value,
+    RuntimeValue,
     ValueType,
 };
 
@@ -152,7 +152,7 @@ const SET_FUNC_INDEX: usize = 0;
 const GET_FUNC_INDEX: usize = 1;
 
 impl<'a> Externals for Runtime<'a> {
-    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             SET_FUNC_INDEX => {
                 let idx: i32 = args.nth(0);

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -20,11 +20,11 @@ use wasmi::{
     ModuleImportResolver,
     ModuleInstance,
     NopExternals,
+    RuntimeValue,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
-    RuntimeValue,
 };
 
 fn load_from_file(filename: &str) -> Module {

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -24,7 +24,7 @@ use wasmi::{
     TableDescriptor,
     TableInstance,
     TableRef,
-    Value,
+    RuntimeValue,
 };
 
 fn load_from_file(filename: &str) -> Module {
@@ -48,7 +48,7 @@ impl ModuleImportResolver for ResolveAll {
         global_type: &GlobalDescriptor,
     ) -> Result<GlobalRef, Error> {
         Ok(GlobalInstance::alloc(
-            Value::default(global_type.value_type()),
+            RuntimeValue::default(global_type.value_type()),
             global_type.is_mutable(),
         ))
     }

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,4 +1,4 @@
-use crate::{value::Value, Error, ValueType};
+use crate::{Error, RuntimeValue, ValueType};
 use alloc::rc::Rc;
 use core::cell::Cell;
 use parity_wasm::elements::ValueType as EValueType;
@@ -31,7 +31,7 @@ impl ::core::ops::Deref for GlobalRef {
 /// [`I64`]: enum.Value.html#variant.I64
 #[derive(Debug)]
 pub struct GlobalInstance {
-    val: Cell<Value>,
+    val: Cell<RuntimeValue>,
     mutable: bool,
 }
 
@@ -40,7 +40,7 @@ impl GlobalInstance {
     ///
     /// Since it is possible to export only immutable globals,
     /// users likely want to set `mutable` to `false`.
-    pub fn alloc(val: Value, mutable: bool) -> GlobalRef {
+    pub fn alloc(val: RuntimeValue, mutable: bool) -> GlobalRef {
         GlobalRef(Rc::new(GlobalInstance {
             val: Cell::new(val),
             mutable,
@@ -53,7 +53,7 @@ impl GlobalInstance {
     ///
     /// Returns `Err` if this global isn't mutable or if
     /// type of `val` doesn't match global's type.
-    pub fn set(&self, val: Value) -> Result<(), Error> {
+    pub fn set(&self, val: RuntimeValue) -> Result<(), Error> {
         if !self.mutable {
             return Err(Error::Global(
                 "Attempt to change an immutable variable".into(),
@@ -67,7 +67,7 @@ impl GlobalInstance {
     }
 
     /// Get the value of this global variable.
-    pub fn get(&self) -> Value {
+    pub fn get(&self) -> RuntimeValue {
         self.val.get()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@ use core::fmt;
 use std::error;
 
 #[doc(inline)]
-#[deprecated(note = "use `Value` instead")]
 pub use wasmi_core::Value as RuntimeValue;
 
 /// Internal interpreter error.
@@ -292,12 +291,12 @@ pub use wasmi_core::{
     LittleEndianConvert,
     Trap,
     TrapCode,
-    Value,
     ValueType,
 };
 
 #[cfg(feature = "v1")]
 pub use wasmi_v1 as v1;
+use wasmi_core::Value;
 
 /// Mirrors the old value module.
 pub mod value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! extern crate wasmi;
 //! extern crate wabt;
 //!
-//! use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, Value};
+//! use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
 //!
 //! fn main() {
 //!     // Parse WAT (WebAssembly Text format) into wasm bytecode.
@@ -89,7 +89,7 @@
 //!             &[],
 //!             &mut NopExternals,
 //!         ).expect("failed to execute export"),
-//!         Some(Value::I32(1337)),
+//!         Some(RuntimeValue::I32(1337)),
 //!     );
 //! }
 //! ```
@@ -113,9 +113,6 @@ use alloc::{
 use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
-
-#[doc(inline)]
-pub use wasmi_core::Value as RuntimeValue;
 
 /// Internal interpreter error.
 #[derive(Debug)]
@@ -284,7 +281,8 @@ pub use self::{
     table::{TableInstance, TableRef},
     types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor},
 };
-use wasmi_core::Value;
+#[doc(inline)]
+pub use wasmi_core::Value as RuntimeValue;
 pub use wasmi_core::{
     memory_units,
     FromValue,
@@ -296,7 +294,7 @@ pub use wasmi_core::{
 };
 
 /// Mirrors the old value module.
-pub mod value {
+pub(crate) mod value {
     pub use wasmi_core::{
         ArithmeticOps,
         ExtendInto,
@@ -306,7 +304,7 @@ pub mod value {
         LittleEndianConvert,
         TransmuteInto,
         TryTruncateInto,
-        Value,
+        Value as RuntimeValue,
         ValueType,
         WrapInto,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,6 @@ pub use wasmi_core::{
     TrapCode,
     ValueType,
 };
-
-#[cfg(feature = "v1")]
-pub use wasmi_v1 as v1;
 use wasmi_core::Value;
 
 /// Mirrors the old value module.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ pub use self::{
     table::{TableInstance, TableRef},
     types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor},
 };
+use wasmi_core::Value;
 pub use wasmi_core::{
     memory_units,
     FromValue,
@@ -293,7 +294,6 @@ pub use wasmi_core::{
     TrapCode,
     ValueType,
 };
-use wasmi_core::Value;
 
 /// Mirrors the old value module.
 pub mod value {

--- a/src/module.rs
+++ b/src/module.rs
@@ -12,10 +12,10 @@ use crate::{
     Error,
     MemoryInstance,
     Module,
+    RuntimeValue,
     Signature,
     TableInstance,
     Trap,
-    Value,
 };
 use alloc::{
     borrow::ToOwned,
@@ -431,7 +431,7 @@ impl ModuleInstance {
                 .as_ref()
                 .expect("passive segments are rejected due to validation");
             let offset_val = match eval_init_expr(offset, &module_ref) {
-                Value::I32(v) => v as u32,
+                RuntimeValue::I32(v) => v as u32,
                 _ => panic!("Due to validation elem segment offset should evaluate to i32"),
             };
 
@@ -464,7 +464,7 @@ impl ModuleInstance {
                 .as_ref()
                 .expect("passive segments are rejected due to validation");
             let offset_val = match eval_init_expr(offset, &module_ref) {
-                Value::I32(v) => v as u32,
+                RuntimeValue::I32(v) => v as u32,
                 _ => panic!("Due to validation data segment offset should evaluate to i32"),
             };
 
@@ -605,7 +605,7 @@ impl ModuleInstance {
     /// ```rust
     /// # extern crate wasmi;
     /// # extern crate wabt;
-    /// # use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, Value};
+    /// # use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
     /// # fn main() {
     /// # let wasm_binary: Vec<u8> = wabt::wat2wasm(
     /// #   r#"
@@ -626,19 +626,19 @@ impl ModuleInstance {
     /// assert_eq!(
     ///     instance.invoke_export(
     ///         "add",
-    ///         &[Value::I32(5), Value::I32(3)],
+    ///         &[RuntimeValue::I32(5), RuntimeValue::I32(3)],
     ///         &mut NopExternals,
     ///     ).expect("failed to execute export"),
-    ///     Some(Value::I32(8)),
+    ///     Some(RuntimeValue::I32(8)),
     /// );
     /// # }
     /// ```
     pub fn invoke_export<E: Externals>(
         &self,
         func_name: &str,
-        args: &[Value],
+        args: &[RuntimeValue],
         externals: &mut E,
-    ) -> Result<Option<Value>, Error> {
+    ) -> Result<Option<RuntimeValue>, Error> {
         let func_instance = self.func_by_name(func_name)?;
 
         FuncInstance::invoke(&func_instance, args, externals).map_err(Error::Trap)
@@ -654,10 +654,10 @@ impl ModuleInstance {
     pub fn invoke_export_with_stack<E: Externals>(
         &self,
         func_name: &str,
-        args: &[Value],
+        args: &[RuntimeValue],
         externals: &mut E,
         stack_recycler: &mut StackRecycler,
-    ) -> Result<Option<Value>, Error> {
+    ) -> Result<Option<RuntimeValue>, Error> {
         let func_instance = self.func_by_name(func_name)?;
 
         FuncInstance::invoke_with_stack(&func_instance, args, externals, stack_recycler)
@@ -780,7 +780,7 @@ impl<'a> NotStartedModuleRef<'a> {
     }
 }
 
-fn eval_init_expr(init_expr: &InitExpr, module: &ModuleInstance) -> Value {
+fn eval_init_expr(init_expr: &InitExpr, module: &ModuleInstance) -> RuntimeValue {
     let code = init_expr.code();
     debug_assert!(
         code.len() == 2,

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,6 +1,4 @@
 //! End-to-end tests for `wasmi`.
 
 mod v0;
-
-#[cfg(feature = "v1")]
 mod v1;

--- a/tests/e2e/v0/host.rs
+++ b/tests/e2e/v0/host.rs
@@ -25,7 +25,7 @@ use wasmi::{
     TableRef,
     Trap,
     TrapCode,
-    Value,
+    RuntimeValue,
     ValueType,
 };
 
@@ -55,7 +55,7 @@ struct TestHost {
     memory: Option<MemoryRef>,
     instance: Option<ModuleRef>,
 
-    trap_sub_result: Option<Value>,
+    trap_sub_result: Option<RuntimeValue>,
 }
 
 impl TestHost {
@@ -107,13 +107,13 @@ const RECURSE_FUNC_INDEX: usize = 4;
 const TRAP_SUB_FUNC_INDEX: usize = 5;
 
 impl Externals for TestHost {
-    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             SUB_FUNC_INDEX => {
                 let a: i32 = args.nth(0);
                 let b: i32 = args.nth(1);
 
-                let result: Value = (a - b).into();
+                let result: RuntimeValue = (a - b).into();
 
                 Ok(Some(result))
             }
@@ -146,7 +146,7 @@ impl Externals for TestHost {
                 let mut buf = [0u8; 1];
                 memory.get_into(ptr, &mut buf).unwrap();
 
-                Ok(Some(Value::I32(buf[0] as i32)))
+                Ok(Some(RuntimeValue::I32(buf[0] as i32)))
             }
             RECURSE_FUNC_INDEX => {
                 let val = args
@@ -172,7 +172,7 @@ impl Externals for TestHost {
                 let a: i32 = args.nth(0);
                 let b: i32 = args.nth(1);
 
-                let result: Value = (a - b).into();
+                let result: RuntimeValue = (a - b).into();
                 self.trap_sub_result = Some(result);
                 Err(Trap::host(HostErrorWithCode { error_code: 301 }))
             }
@@ -271,7 +271,7 @@ fn call_host_func() {
         instance
             .invoke_export("test", &[], &mut env)
             .expect("Failed to invoke 'test' function",),
-        Some(Value::I32(-2))
+        Some(RuntimeValue::I32(-2))
     );
 }
 
@@ -314,13 +314,13 @@ fn resume_call_host_func() {
         invocation
             .resume_execution(trap_sub_result, &mut env)
             .expect("Failed to invoke 'test' function",),
-        Some(Value::I32(-2))
+        Some(RuntimeValue::I32(-2))
     );
 }
 
 #[test]
 fn resume_call_host_func_type_mismatch() {
-    fn resume_with_val(val: Option<Value>) {
+    fn resume_with_val(val: Option<RuntimeValue>) {
         let module = parse_wat(
             r#"
             (module
@@ -489,7 +489,7 @@ fn pull_internal_mem_from_module() {
 
     assert_eq!(
         instance.invoke_export("test", &[], &mut env).unwrap(),
-        Some(Value::I32(1))
+        Some(RuntimeValue::I32(1))
     );
 }
 
@@ -537,7 +537,7 @@ fn recursion() {
             .invoke_export("test", &[], &mut env)
             .expect("Failed to invoke 'test' function",),
         // 363 = 321 + 42
-        Some(Value::I64(363))
+        Some(RuntimeValue::I64(363))
     );
 }
 
@@ -594,7 +594,7 @@ fn defer_providing_externals() {
     }
 
     impl<'a> Externals for HostExternals<'a> {
-        fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
+        fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
             match index {
                 INC_FUNC_INDEX => {
                     let a = args.nth::<u32>(0);
@@ -660,7 +660,7 @@ fn two_envs_one_externals() {
             &mut self,
             index: usize,
             _args: RuntimeArgs,
-        ) -> Result<Option<Value>, Trap> {
+        ) -> Result<Option<RuntimeValue>, Trap> {
             match index {
                 PRIVILEGED_FUNC_INDEX => {
                     println!("privileged!");
@@ -776,7 +776,7 @@ fn dynamically_add_host_func() {
             &mut self,
             index: usize,
             _args: RuntimeArgs,
-        ) -> Result<Option<Value>, Trap> {
+        ) -> Result<Option<RuntimeValue>, Trap> {
             match index {
                 ADD_FUNC_FUNC_INDEX => {
                     // Allocate indicies for the new function.
@@ -793,9 +793,9 @@ fn dynamically_add_host_func() {
                         .set(table_index, Some(added_func))
                         .map_err(|_| TrapCode::TableAccessOutOfBounds)?;
 
-                    Ok(Some(Value::I32(table_index as i32)))
+                    Ok(Some(RuntimeValue::I32(table_index as i32)))
                 }
-                index if index as u32 <= self.added_funcs => Ok(Some(Value::I32(index as i32))),
+                index if index as u32 <= self.added_funcs => Ok(Some(RuntimeValue::I32(index as i32))),
                 _ => panic!("'env' module doesn't provide function at index {}", index),
             }
         }
@@ -866,6 +866,6 @@ fn dynamically_add_host_func() {
         instance
             .invoke_export("test", &[], &mut host_externals)
             .expect("Failed to invoke 'test' function"),
-        Some(Value::I32(2))
+        Some(RuntimeValue::I32(2))
     );
 }

--- a/tests/e2e/v0/host.rs
+++ b/tests/e2e/v0/host.rs
@@ -19,13 +19,13 @@ use wasmi::{
     ModuleRef,
     ResumableError,
     RuntimeArgs,
+    RuntimeValue,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
     Trap,
     TrapCode,
-    RuntimeValue,
     ValueType,
 };
 
@@ -107,7 +107,11 @@ const RECURSE_FUNC_INDEX: usize = 4;
 const TRAP_SUB_FUNC_INDEX: usize = 5;
 
 impl Externals for TestHost {
-    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
+    fn invoke_index(
+        &mut self,
+        index: usize,
+        args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             SUB_FUNC_INDEX => {
                 let a: i32 = args.nth(0);
@@ -594,7 +598,11 @@ fn defer_providing_externals() {
     }
 
     impl<'a> Externals for HostExternals<'a> {
-        fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
+        fn invoke_index(
+            &mut self,
+            index: usize,
+            args: RuntimeArgs,
+        ) -> Result<Option<RuntimeValue>, Trap> {
             match index {
                 INC_FUNC_INDEX => {
                     let a = args.nth::<u32>(0);
@@ -795,7 +803,9 @@ fn dynamically_add_host_func() {
 
                     Ok(Some(RuntimeValue::I32(table_index as i32)))
                 }
-                index if index as u32 <= self.added_funcs => Ok(Some(RuntimeValue::I32(index as i32))),
+                index if index as u32 <= self.added_funcs => {
+                    Ok(Some(RuntimeValue::I32(index as i32)))
+                }
                 _ => panic!("'env' module doesn't provide function at index {}", index),
             }
         }

--- a/tests/e2e/v0/mod.rs
+++ b/tests/e2e/v0/mod.rs
@@ -23,17 +23,17 @@ fn assert_error_properties() {
 /// to a Value and back works as expected and the number remains unchanged.
 #[test]
 fn unsigned_to_value() {
-    use wasmi::Value;
+    use wasmi::RuntimeValue;
 
     let overflow_i32: u32 = ::core::i32::MAX as u32 + 1;
     assert_eq!(
-        Value::from(overflow_i32).try_into::<u32>().unwrap(),
+        RuntimeValue::from(overflow_i32).try_into::<u32>().unwrap(),
         overflow_i32
     );
 
     let overflow_i64: u64 = ::core::i64::MAX as u64 + 1;
     assert_eq!(
-        Value::from(overflow_i64).try_into::<u64>().unwrap(),
+        RuntimeValue::from(overflow_i64).try_into::<u64>().unwrap(),
         overflow_i64
     );
 }

--- a/tests/e2e/v0/wasm.rs
+++ b/tests/e2e/v0/wasm.rs
@@ -17,11 +17,11 @@ use wasmi::{
     ModuleImportResolver,
     ModuleInstance,
     NopExternals,
+    RuntimeValue,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
-    RuntimeValue,
 };
 
 struct Env {
@@ -152,7 +152,10 @@ fn interpreter_accumulate_u8() {
     let _ = env_memory.set(offset, BUF);
 
     // Set up the function argument list and invoke the function
-    let args = &[RuntimeValue::I32(BUF.len() as i32), RuntimeValue::I32(offset as i32)];
+    let args = &[
+        RuntimeValue::I32(BUF.len() as i32),
+        RuntimeValue::I32(offset as i32),
+    ];
     let retval = instance
         .invoke_export(FUNCTION_NAME, args, &mut NopExternals)
         .expect("Failed to execute function");

--- a/tests/e2e/v0/wasm.rs
+++ b/tests/e2e/v0/wasm.rs
@@ -21,7 +21,7 @@ use wasmi::{
     TableDescriptor,
     TableInstance,
     TableRef,
-    Value,
+    RuntimeValue,
 };
 
 struct Env {
@@ -34,8 +34,8 @@ struct Env {
 impl Env {
     fn new() -> Env {
         Env {
-            table_base: GlobalInstance::alloc(Value::I32(0), false),
-            memory_base: GlobalInstance::alloc(Value::I32(0), false),
+            table_base: GlobalInstance::alloc(RuntimeValue::I32(0), false),
+            memory_base: GlobalInstance::alloc(RuntimeValue::I32(0), false),
             memory: MemoryInstance::alloc(Pages(256), None).unwrap(),
             table: TableInstance::alloc(64, None).unwrap(),
         }
@@ -119,8 +119,8 @@ fn interpreter_inc_i32() {
 
     let i32_val = 42;
     // the functions expects a single i32 parameter
-    let args = &[Value::I32(i32_val)];
-    let exp_retval = Some(Value::I32(i32_val + 1));
+    let args = &[RuntimeValue::I32(i32_val)];
+    let exp_retval = Some(RuntimeValue::I32(i32_val + 1));
 
     let retval = instance
         .invoke_export(FUNCTION_NAME, args, &mut NopExternals)
@@ -152,14 +152,14 @@ fn interpreter_accumulate_u8() {
     let _ = env_memory.set(offset, BUF);
 
     // Set up the function argument list and invoke the function
-    let args = &[Value::I32(BUF.len() as i32), Value::I32(offset as i32)];
+    let args = &[RuntimeValue::I32(BUF.len() as i32), RuntimeValue::I32(offset as i32)];
     let retval = instance
         .invoke_export(FUNCTION_NAME, args, &mut NopExternals)
         .expect("Failed to execute function");
 
     // For verification, repeat accumulation using native code
     let accu = BUF.iter().fold(0_i32, |a, b| a + *b as i32);
-    let exp_retval: Option<Value> = Some(Value::I32(accu));
+    let exp_retval: Option<RuntimeValue> = Some(RuntimeValue::I32(accu));
 
     // Verify calculation from WebAssembly runtime is identical to expected result
     assert_eq!(exp_retval, retval);

--- a/tests/e2e/v1/func.rs
+++ b/tests/e2e/v1/func.rs
@@ -1,9 +1,8 @@
 //! Tests for the `Func` type in `wasmi_v1`.
 
 use assert_matches::assert_matches;
-use wasmi_v1::{Engine, Func, Store};
-use wasmi_core::{F32, F64, Value};
-use wasmi_v1::{errors::FuncError, Error};
+use wasmi_core::{Value, F32, F64};
+use wasmi_v1::{errors::FuncError, Engine, Error, Func, Store};
 
 fn test_setup() -> Store<()> {
     let engine = Engine::default();

--- a/tests/e2e/v1/func.rs
+++ b/tests/e2e/v1/func.rs
@@ -1,11 +1,8 @@
 //! Tests for the `Func` type in `wasmi_v1`.
 
 use assert_matches::assert_matches;
-use wasmi::{
-    v1::{Engine, Func, Store},
-    Value,
-};
-use wasmi_core::{F32, F64};
+use wasmi_v1::{Engine, Func, Store};
+use wasmi_core::{F32, F64, Value};
 use wasmi_v1::{errors::FuncError, Error};
 
 fn test_setup() -> Store<()> {

--- a/tests/spec/mod.rs
+++ b/tests/spec/mod.rs
@@ -1,4 +1,2 @@
 mod v0;
-
-#[cfg(feature = "v1")]
 mod v1;

--- a/tests/spec/v0/run.rs
+++ b/tests/spec/v0/run.rs
@@ -22,12 +22,12 @@ use wasmi::{
     ModuleInstance,
     ModuleRef,
     RuntimeArgs,
+    RuntimeValue,
     Signature,
     TableDescriptor,
     TableInstance,
     TableRef,
     Trap,
-    RuntimeValue,
 };
 
 fn spec_to_value(val: WabtValue<u32, u64>) -> RuntimeValue {
@@ -83,7 +83,11 @@ impl SpecModule {
 const PRINT_FUNC_INDEX: usize = 0;
 
 impl Externals for SpecModule {
-    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
+    fn invoke_index(
+        &mut self,
+        index: usize,
+        args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             PRINT_FUNC_INDEX => {
                 println!("print: {:?}", args);

--- a/tests/spec/v0/run.rs
+++ b/tests/spec/v0/run.rs
@@ -27,15 +27,15 @@ use wasmi::{
     TableInstance,
     TableRef,
     Trap,
-    Value,
+    RuntimeValue,
 };
 
-fn spec_to_value(val: WabtValue<u32, u64>) -> Value {
+fn spec_to_value(val: WabtValue<u32, u64>) -> RuntimeValue {
     match val {
-        WabtValue::I32(v) => Value::I32(v),
-        WabtValue::I64(v) => Value::I64(v),
-        WabtValue::F32(v) => Value::F32(v.into()),
-        WabtValue::F64(v) => Value::F64(v.into()),
+        WabtValue::I32(v) => RuntimeValue::I32(v),
+        WabtValue::I64(v) => RuntimeValue::I64(v),
+        WabtValue::F32(v) => RuntimeValue::F32(v.into()),
+        WabtValue::F64(v) => RuntimeValue::F64(v.into()),
         WabtValue::V128(_) => panic!("v128 is not supported"),
     }
 }
@@ -73,9 +73,9 @@ impl SpecModule {
         SpecModule {
             table: TableInstance::alloc(10, Some(20)).unwrap(),
             memory: MemoryInstance::alloc(Pages(1), Some(Pages(2))).unwrap(),
-            global_i32: GlobalInstance::alloc(Value::I32(666), false),
-            global_f32: GlobalInstance::alloc(Value::F32(666.0.into()), false),
-            global_f64: GlobalInstance::alloc(Value::F64(666.0.into()), false),
+            global_i32: GlobalInstance::alloc(RuntimeValue::I32(666), false),
+            global_f32: GlobalInstance::alloc(RuntimeValue::F32(666.0.into()), false),
+            global_f64: GlobalInstance::alloc(RuntimeValue::F64(666.0.into()), false),
         }
     }
 }
@@ -83,7 +83,7 @@ impl SpecModule {
 const PRINT_FUNC_INDEX: usize = 0;
 
 impl Externals for SpecModule {
-    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<Value>, Trap> {
+    fn invoke_index(&mut self, index: usize, args: RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             PRINT_FUNC_INDEX => {
                 println!("print: {:?}", args);
@@ -306,7 +306,7 @@ fn load_module(
 fn run_action(
     program: &mut SpecDriver,
     action: &Action<u32, u64>,
-) -> Result<Option<Value>, InterpreterError> {
+) -> Result<Option<RuntimeValue>, InterpreterError> {
     match *action {
         Action::Invoke {
             ref module,
@@ -395,19 +395,19 @@ fn try_spec(name: &str) -> Result<(), Error> {
                             .cloned()
                             .map(spec_to_value)
                             .collect::<Vec<_>>();
-                        let actual_result = result.into_iter().collect::<Vec<Value>>();
+                        let actual_result = result.into_iter().collect::<Vec<RuntimeValue>>();
                         for (actual_result, spec_expected) in
                             actual_result.iter().zip(spec_expected.iter())
                         {
                             assert_eq!(actual_result.value_type(), spec_expected.value_type());
                             // f32::NAN != f32::NAN
                             match spec_expected {
-                                Value::F32(val) if val.is_nan() => match actual_result {
-                                    Value::F32(val) => assert!(val.is_nan()),
+                                RuntimeValue::F32(val) if val.is_nan() => match actual_result {
+                                    RuntimeValue::F32(val) => assert!(val.is_nan()),
                                     _ => unreachable!(), // checked above that types are same
                                 },
-                                Value::F64(val) if val.is_nan() => match actual_result {
-                                    Value::F64(val) => assert!(val.is_nan()),
+                                RuntimeValue::F64(val) if val.is_nan() => match actual_result {
+                                    RuntimeValue::F64(val) => assert!(val.is_nan()),
                                     _ => unreachable!(), // checked above that types are same
                                 },
                                 spec_expected => assert_eq!(actual_result, spec_expected),
@@ -424,14 +424,14 @@ fn try_spec(name: &str) -> Result<(), Error> {
                 let result = run_action(&mut spec_driver, &action);
                 match result {
                     Ok(result) => {
-                        for actual_result in result.into_iter().collect::<Vec<Value>>() {
+                        for actual_result in result.into_iter().collect::<Vec<RuntimeValue>>() {
                             match actual_result {
-                                Value::F32(val) => {
+                                RuntimeValue::F32(val) => {
                                     if !val.is_nan() {
                                         panic!("Expected nan value, got {:?}", val)
                                     }
                                 }
-                                Value::F64(val) => {
+                                RuntimeValue::F64(val) => {
                                     if !val.is_nan() {
                                         panic!("Expected nan value, got {:?}", val)
                                     }

--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -1,24 +1,22 @@
 use super::{TestDescriptor, TestError, TestProfile, TestSpan};
 use anyhow::Result;
 use std::collections::HashMap;
-use wasmi::{
-    nan_preserving_float::{F32, F64},
-    v1::{
-        Engine,
-        Extern,
-        Func,
-        Global,
-        Instance,
-        Linker,
-        Memory,
-        MemoryType,
-        Module,
-        Mutability,
-        Store,
-        Table,
-        TableType,
-    },
-    Value,
+use wasmi_core::Value;
+use wasmi::nan_preserving_float::{F32, F64};
+use wasmi_v1::{
+    Engine,
+    Extern,
+    Func,
+    Global,
+    Instance,
+    Linker,
+    Memory,
+    MemoryType,
+    Module,
+    Mutability,
+    Store,
+    Table,
+    TableType,
 };
 use wast::Id;
 

--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -1,8 +1,8 @@
 use super::{TestDescriptor, TestError, TestProfile, TestSpan};
 use anyhow::Result;
 use std::collections::HashMap;
-use wasmi_core::Value;
 use wasmi::nan_preserving_float::{F32, F64};
+use wasmi_core::Value;
 use wasmi_v1::{
     Engine,
     Extern,

--- a/tests/spec/v1/error.rs
+++ b/tests/spec/v1/error.rs
@@ -1,5 +1,5 @@
 use std::{error::Error, fmt, fmt::Display};
-use wasmi::v1::Error as WasmiError;
+use wasmi_v1::Error as WasmiError;
 
 /// Errors that may occur upon Wasm spec test suite execution.
 #[derive(Debug)]

--- a/tests/spec/v1/run.rs
+++ b/tests/spec/v1/run.rs
@@ -1,11 +1,7 @@
 use super::{error::TestError, TestContext, TestDescriptor};
 use anyhow::Result;
-use wasmi::{
-    nan_preserving_float::{F32, F64},
-    v1::Error as WasmiError,
-    Trap,
-    Value,
-};
+use wasmi_core::{Trap, Value, F32, F64};
+use wasmi_v1::Error as WasmiError;
 use wast::{
     lexer::Lexer,
     parser::ParseBuffer,
@@ -355,5 +351,4 @@ fn execute_wast_invoke(
     context
         .invoke(module_name, field_name, &args)
         .map(|results| results.to_vec())
-    // .map_err(Into::into)
 }


### PR DESCRIPTION
This PR entirely separates `wasmi` and `wasmi_v1` crates.
This removes the `v1` crate feature from `wasmi` again which also has the effect that our CI is simpler again.
Tests and benchmarks now operate without crate feature flags always on both `wasmi` and `wasmi_v1` crates.