### PR TITLE
Add #[inline] annotations to small functions in wasmi_core crate

### DIFF
--- a/core/src/nan_preserving_float.rs
+++ b/core/src/nan_preserving_float.rs
@@ -11,6 +11,7 @@ macro_rules! impl_binop {
         impl<T: Into<$for>> $op<T> for $for {
             type Output = Self;
 
+            #[inline]
             fn $func_name(self, other: T) -> Self {
                 $for(
                     $op::$func_name($is::from_bits(self.0), $is::from_bits(other.into().0))
@@ -41,54 +42,65 @@ macro_rules! float {
         impl_binop!($for, $is, Rem, rem);
 
         impl $for {
+            #[inline]
             pub fn from_bits(other: $rep) -> Self {
                 $for(other)
             }
 
+            #[inline]
             pub fn to_bits(self) -> $rep {
                 self.0
             }
 
+            #[inline]
             pub fn from_float(fl: $is) -> Self {
                 fl.into()
             }
 
+            #[inline]
             pub fn to_float(self) -> $is {
                 self.into()
             }
 
+            #[inline]
             pub fn is_nan(self) -> bool {
                 self.to_float().is_nan()
             }
 
             #[must_use]
+            #[inline]
             pub fn abs(self) -> Self {
                 $for(self.0 & !$sign_bit)
             }
 
             #[must_use]
+            #[inline]
             pub fn fract(self) -> Self {
                 FloatCore::fract(self.to_float()).into()
             }
 
             #[must_use]
+            #[inline]
             pub fn min(self, other: Self) -> Self {
                 Self::from(self.to_float().min(other.to_float()))
             }
 
             #[must_use]
+            #[inline]
             pub fn max(self, other: Self) -> Self {
                 Self::from(self.to_float().max(other.to_float()))
             }
         }
 
         impl From<$is> for $for {
+            #[inline]
             fn from(other: $is) -> $for {
                 $for(other.to_bits())
             }
         }
 
         impl From<$for> for $is {
+            #[inline]
             fn from(other: $for) -> $is {
                 <$is>::from_bits(other.0)
             }
@@ -97,6 +109,7 @@ macro_rules! float {
         impl Neg for $for {
             type Output = Self;
 
+            #[inline]
             fn neg(self) -> Self {
                 $for(self.0 ^ $sign_bit)
             }
@@ -105,12 +118,14 @@ macro_rules! float {
         // clippy suggestion would fail some tests
         #[allow(clippy::cmp_owned)]
         impl<T: Into<$for> + Copy> PartialEq<T> for $for {
+            #[inline]
             fn eq(&self, other: &T) -> bool {
                 $is::from(*self) == $is::from((*other).into())
             }
         }
 
         impl<T: Into<$for> + Copy> PartialOrd<T> for $for {
+            #[inline]
             fn partial_cmp(&self, other: &T) -> Option<Ordering> {
                 $is::from(*self).partial_cmp(&$is::from((*other).into()))
             }
@@ -128,24 +143,28 @@ float!(F32, u32, f32);
 float!(F64, u64, f64);
 
 impl From<u32> for F32 {
+    #[inline]
     fn from(other: u32) -> Self {
         Self::from_bits(other)
     }
 }
 
 impl From<F32> for u32 {
+    #[inline]
     fn from(other: F32) -> Self {
         other.to_bits()
     }
 }
 
 impl From<u64> for F64 {
+    #[inline]
     fn from(other: u64) -> Self {
         Self::from_bits(other)
     }
 }
 
 impl From<F64> for u64 {
+    #[inline]
     fn from(other: F64) -> Self {
         other.to_bits()
     }

--- a/core/src/trap.rs
+++ b/core/src/trap.rs
@@ -19,6 +19,7 @@ pub enum Trap {
 
 impl Trap {
     /// Wraps the host error in a [`Trap`].
+    #[inline]
     pub fn host<U>(host_error: U) -> Self
     where
         U: HostError + Sized,
@@ -27,11 +28,13 @@ impl Trap {
     }
 
     /// Returns `true` if `self` trap originating from host code.
+    #[inline]
     pub fn is_host(&self) -> bool {
         matches!(self, Self::Host(_))
     }
 
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
+    #[inline]
     pub fn code(&self) -> Option<TrapCode> {
         if let Self::Code(trap_code) = self {
             return Some(*trap_code);
@@ -41,6 +44,7 @@ impl Trap {
 }
 
 impl From<TrapCode> for Trap {
+    #[inline]
     fn from(error: TrapCode) -> Self {
         Self::Code(error)
     }
@@ -50,6 +54,7 @@ impl<U> From<U> for Trap
 where
     U: HostError + Sized,
 {
+    #[inline]
     fn from(e: U) -> Self {
         Trap::host(e)
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -35,6 +35,7 @@ impl Display for ValueType {
 
 impl ValueType {
     /// Converts into [`ValueType`] from [`pwasm::ValueType`].
+    #[inline]
     pub fn from_elements(value_type: pwasm::ValueType) -> Self {
         match value_type {
             pwasm::ValueType::I32 => Self::I32,
@@ -45,6 +46,7 @@ impl ValueType {
     }
 
     /// Converts from [`ValueType`] into [`pwasm::ValueType`].
+    #[inline]
     pub fn into_elements(self) -> pwasm::ValueType {
         match self {
             Self::I32 => pwasm::ValueType::I32,
@@ -138,10 +140,12 @@ macro_rules! impl_little_endian_convert_primitive {
             impl LittleEndianConvert for $primitive {
                 type Bytes = [::core::primitive::u8; ::core::mem::size_of::<$primitive>()];
 
+                #[inline]
                 fn into_le_bytes(self) -> Self::Bytes {
                     <$primitive>::to_le_bytes(self)
                 }
 
+                #[inline]
                 fn from_le_bytes(bytes: Self::Bytes) -> Self {
                     <$primitive>::from_le_bytes(bytes)
                 }
@@ -157,10 +161,12 @@ macro_rules! impl_little_endian_convert_float {
             impl LittleEndianConvert for $float_ty {
                 type Bytes = <$uint_ty as LittleEndianConvert>::Bytes;
 
+                #[inline]
                 fn into_le_bytes(self) -> Self::Bytes {
                     <$uint_ty>::into_le_bytes(self.to_bits())
                 }
 
+                #[inline]
                 fn from_le_bytes(bytes: Self::Bytes) -> Self {
                     Self::from_bits(<$uint_ty>::from_le_bytes(bytes))
                 }
@@ -233,6 +239,7 @@ pub trait Float<T>: ArithmeticOps<T> {
 
 impl Value {
     /// Creates new default value of given type.
+    #[inline]
     pub fn default(value_type: ValueType) -> Self {
         match value_type {
             ValueType::I32 => Value::I32(0),
@@ -255,6 +262,7 @@ impl Value {
     }
 
     /// Get variable type for this value.
+    #[inline]
     pub fn value_type(&self) -> ValueType {
         match *self {
             Value::I32(_) => ValueType::I32,
@@ -271,66 +279,77 @@ impl Value {
     ///
     /// [`FromValue`]: trait.FromValue.html
     /// [`Value`]: enum.Value.html
+    #[inline]
     pub fn try_into<T: FromValue>(self) -> Option<T> {
         FromValue::from_value(self)
     }
 }
 
 impl From<i8> for Value {
+    #[inline]
     fn from(val: i8) -> Self {
         Value::I32(val as i32)
     }
 }
 
 impl From<i16> for Value {
+    #[inline]
     fn from(val: i16) -> Self {
         Value::I32(val as i32)
     }
 }
 
 impl From<i32> for Value {
+    #[inline]
     fn from(val: i32) -> Self {
         Value::I32(val)
     }
 }
 
 impl From<i64> for Value {
+    #[inline]
     fn from(val: i64) -> Self {
         Value::I64(val)
     }
 }
 
 impl From<u8> for Value {
+    #[inline]
     fn from(val: u8) -> Self {
         Value::I32(val as i32)
     }
 }
 
 impl From<u16> for Value {
+    #[inline]
     fn from(val: u16) -> Self {
         Value::I32(val as i32)
     }
 }
 
 impl From<u32> for Value {
+    #[inline]
     fn from(val: u32) -> Self {
         Value::I32(val.transmute_into())
     }
 }
 
 impl From<u64> for Value {
+    #[inline]
     fn from(val: u64) -> Self {
         Value::I64(val.transmute_into())
     }
 }
 
 impl From<F32> for Value {
+    #[inline]
     fn from(val: F32) -> Self {
         Value::F32(val)
     }
 }
 
 impl From<F64> for Value {
+    #[inline]
     fn from(val: F64) -> Self {
         Value::F64(val)
     }
@@ -339,6 +358,7 @@ impl From<F64> for Value {
 macro_rules! impl_from_value {
     ($expected_rt_ty: ident, $into: ty) => {
         impl FromValue for $into {
+            #[inline]
             fn from_value(val: Value) -> Option<Self> {
                 match val {
                     Value::$expected_rt_ty(val) => Some(val.transmute_into()),
@@ -354,6 +374,7 @@ macro_rules! impl_from_value {
 ///
 /// [`I32`]: enum.Value.html#variant.I32
 impl FromValue for bool {
+    #[inline]
     fn from_value(val: Value) -> Option<Self> {
         match val {
             Value::I32(val) => Some(val != 0),
@@ -366,6 +387,7 @@ impl FromValue for bool {
 ///
 /// [`I32`]: enum.Value.html#variant.I32
 impl FromValue for i8 {
+    #[inline]
     fn from_value(val: Value) -> Option<Self> {
         let min = i8::min_value() as i32;
         let max = i8::max_value() as i32;
@@ -380,6 +402,7 @@ impl FromValue for i8 {
 ///
 /// [`I32`]: enum.Value.html#variant.I32
 impl FromValue for i16 {
+    #[inline]
     fn from_value(val: Value) -> Option<Self> {
         let min = i16::min_value() as i32;
         let max = i16::max_value() as i32;
@@ -394,6 +417,7 @@ impl FromValue for i16 {
 ///
 /// [`I32`]: enum.Value.html#variant.I32
 impl FromValue for u8 {
+    #[inline]
     fn from_value(val: Value) -> Option<Self> {
         let min = u8::min_value() as i32;
         let max = u8::max_value() as i32;
@@ -408,6 +432,7 @@ impl FromValue for u8 {
 ///
 /// [`I32`]: enum.Value.html#variant.I32
 impl FromValue for u16 {
+    #[inline]
     fn from_value(val: Value) -> Option<Self> {
         let min = u16::min_value() as i32;
         let max = u16::max_value() as i32;
@@ -428,6 +453,7 @@ impl_from_value!(I64, u64);
 macro_rules! impl_wrap_into {
     ($from:ident, $into:ident) => {
         impl WrapInto<$into> for $from {
+            #[inline]
             fn wrap_into(self) -> $into {
                 self as $into
             }
@@ -435,6 +461,7 @@ macro_rules! impl_wrap_into {
     };
     ($from:ident, $intermediate:ident, $into:ident) => {
         impl WrapInto<$into> for $from {
+            #[inline]
             fn wrap_into(self) -> $into {
                 $into::from(self as $intermediate)
             }
@@ -455,6 +482,7 @@ impl_wrap_into!(u64, f32, F32);
 impl_wrap_into!(f64, f32);
 
 impl WrapInto<F32> for F64 {
+    #[inline]
     fn wrap_into(self) -> F32 {
         (f64::from(self) as f32).into()
     }
@@ -463,6 +491,7 @@ impl WrapInto<F32> for F64 {
 macro_rules! impl_try_truncate_into {
     (@primitive $from: ident, $into: ident, $to_primitive:path) => {
         impl TryTruncateInto<$into, TrapCode> for $from {
+            #[inline]
             fn try_truncate_into(self) -> Result<$into, TrapCode> {
                 // Casting from a float to an integer will round the float towards zero
                 if self.is_nan() {
@@ -477,6 +506,7 @@ macro_rules! impl_try_truncate_into {
     };
     (@wrapped $from:ident, $intermediate:ident, $into:ident) => {
         impl TryTruncateInto<$into, TrapCode> for $from {
+            #[inline]
             fn try_truncate_into(self) -> Result<$into, TrapCode> {
                 $intermediate::from(self).try_truncate_into()
             }
@@ -504,6 +534,7 @@ impl_try_truncate_into!(@wrapped F64, f64, u64);
 macro_rules! impl_extend_into {
     ($from:ident, $into:ident) => {
         impl ExtendInto<$into> for $from {
+            #[inline]
             fn extend_into(self) -> $into {
                 self as $into
             }
@@ -511,6 +542,7 @@ macro_rules! impl_extend_into {
     };
     ($from:ident, $intermediate:ident, $into:ident) => {
         impl ExtendInto<$into> for $from {
+            #[inline]
             fn extend_into(self) -> $into {
                 $into::from(self as $intermediate)
             }
@@ -546,6 +578,7 @@ impl_extend_into!(u64, f64, F64);
 impl_extend_into!(f32, f64, F64);
 
 impl ExtendInto<F64> for F32 {
+    #[inline]
     fn extend_into(self) -> F64 {
         (f32::from(self) as f64).into()
     }
@@ -554,6 +587,7 @@ impl ExtendInto<F64> for F32 {
 macro_rules! impl_transmute_into_self {
     ($type: ident) => {
         impl TransmuteInto<$type> for $type {
+            #[inline]
             fn transmute_into(self) -> $type {
                 self
             }
@@ -571,6 +605,7 @@ impl_transmute_into_self!(F64);
 macro_rules! impl_transmute_into_as {
     ($from: ident, $into: ident) => {
         impl TransmuteInto<$into> for $from {
+            #[inline]
             fn transmute_into(self) -> $into {
                 self as $into
             }
@@ -585,36 +620,42 @@ impl_transmute_into_as!(i64, u64);
 macro_rules! impl_transmute_into_npf {
     ($npf:ident, $float:ident, $signed:ident, $unsigned:ident) => {
         impl TransmuteInto<$float> for $npf {
+            #[inline]
             fn transmute_into(self) -> $float {
                 self.into()
             }
         }
 
         impl TransmuteInto<$npf> for $float {
+            #[inline]
             fn transmute_into(self) -> $npf {
                 self.into()
             }
         }
 
         impl TransmuteInto<$signed> for $npf {
+            #[inline]
             fn transmute_into(self) -> $signed {
                 self.to_bits() as _
             }
         }
 
         impl TransmuteInto<$unsigned> for $npf {
+            #[inline]
             fn transmute_into(self) -> $unsigned {
                 self.to_bits()
             }
         }
 
         impl TransmuteInto<$npf> for $signed {
+            #[inline]
             fn transmute_into(self) -> $npf {
                 $npf::from_bits(self as _)
             }
         }
 
         impl TransmuteInto<$npf> for $unsigned {
+            #[inline]
             fn transmute_into(self) -> $npf {
                 $npf::from_bits(self)
             }
@@ -626,36 +667,42 @@ impl_transmute_into_npf!(F32, f32, i32, u32);
 impl_transmute_into_npf!(F64, f64, i64, u64);
 
 impl TransmuteInto<i32> for f32 {
+    #[inline]
     fn transmute_into(self) -> i32 {
         self.to_bits() as i32
     }
 }
 
 impl TransmuteInto<i64> for f64 {
+    #[inline]
     fn transmute_into(self) -> i64 {
         self.to_bits() as i64
     }
 }
 
 impl TransmuteInto<f32> for i32 {
+    #[inline]
     fn transmute_into(self) -> f32 {
         f32::from_bits(self as u32)
     }
 }
 
 impl TransmuteInto<f64> for i64 {
+    #[inline]
     fn transmute_into(self) -> f64 {
         f64::from_bits(self as u64)
     }
 }
 
 impl TransmuteInto<i32> for u32 {
+    #[inline]
     fn transmute_into(self) -> i32 {
         self as _
     }
 }
 
 impl TransmuteInto<i64> for u64 {
+    #[inline]
     fn transmute_into(self) -> i64 {
         self as _
     }
@@ -664,15 +711,19 @@ impl TransmuteInto<i64> for u64 {
 macro_rules! impl_integer_arithmetic_ops {
     ($type: ident) => {
         impl ArithmeticOps<$type> for $type {
+            #[inline]
             fn add(self, other: $type) -> $type {
                 self.wrapping_add(other)
             }
+            #[inline]
             fn sub(self, other: $type) -> $type {
                 self.wrapping_sub(other)
             }
+            #[inline]
             fn mul(self, other: $type) -> $type {
                 self.wrapping_mul(other)
             }
+            #[inline]
             fn div(self, other: $type) -> Result<$type, TrapCode> {
                 if other == 0 {
                     Err(TrapCode::DivisionByZero)
@@ -697,15 +748,19 @@ impl_integer_arithmetic_ops!(u64);
 macro_rules! impl_float_arithmetic_ops {
     ($type: ident) => {
         impl ArithmeticOps<$type> for $type {
+            #[inline]
             fn add(self, other: $type) -> $type {
                 self + other
             }
+            #[inline]
             fn sub(self, other: $type) -> $type {
                 self - other
             }
+            #[inline]
             fn mul(self, other: $type) -> $type {
                 self * other
             }
+            #[inline]
             fn div(self, other: $type) -> Result<$type, TrapCode> {
                 Ok(self / other)
             }
@@ -721,21 +776,27 @@ impl_float_arithmetic_ops!(F64);
 macro_rules! impl_integer {
     ($type: ident) => {
         impl Integer<$type> for $type {
+            #[inline]
             fn leading_zeros(self) -> $type {
                 self.leading_zeros() as $type
             }
+            #[inline]
             fn trailing_zeros(self) -> $type {
                 self.trailing_zeros() as $type
             }
+            #[inline]
             fn count_ones(self) -> $type {
                 self.count_ones() as $type
             }
+            #[inline]
             fn rotl(self, other: $type) -> $type {
                 self.rotate_left(other as u32)
             }
+            #[inline]
             fn rotr(self, other: $type) -> $type {
                 self.rotate_right(other as u32)
             }
+            #[inline]
             fn rem(self, other: $type) -> Result<$type, TrapCode> {
                 if other == 0 {
                     Err(TrapCode::DivisionByZero)
@@ -771,21 +832,27 @@ macro_rules! impl_float {
         // In this particular instance we want to directly compare floating point numbers.
         #[allow(clippy::float_cmp)]
         impl Float<$type> for $type {
+            #[inline]
             fn abs(self) -> $type {
                 fmath::$fXX::abs($fXX::from(self)).into()
             }
+            #[inline]
             fn floor(self) -> $type {
                 fmath::$fXX::floor($fXX::from(self)).into()
             }
+            #[inline]
             fn ceil(self) -> $type {
                 fmath::$fXX::ceil($fXX::from(self)).into()
             }
+            #[inline]
             fn trunc(self) -> $type {
                 fmath::$fXX::trunc($fXX::from(self)).into()
             }
+            #[inline]
             fn round(self) -> $type {
                 fmath::$fXX::round($fXX::from(self)).into()
             }
+            #[inline]
             fn nearest(self) -> $type {
                 let round = self.round();
                 if fmath::$fXX::fract($fXX::from(self)).abs() != 0.5 {
@@ -801,15 +868,19 @@ macro_rules! impl_float {
                     round
                 }
             }
+            #[inline]
             fn sqrt(self) -> $type {
                 fmath::$fXX::sqrt($fXX::from(self)).into()
             }
+            #[inline]
             fn is_sign_positive(self) -> bool {
                 $fXX::is_sign_positive($fXX::from(self)).into()
             }
+            #[inline]
             fn is_sign_negative(self) -> bool {
                 $fXX::is_sign_negative($fXX::from(self)).into()
             }
+            #[inline]
             fn min(self, other: $type) -> $type {
                 // The implementation strictly adheres to the mandated behavior for the Wasm specification.
                 // Note: In other contexts this API is also known as: `nan_min`.
@@ -825,6 +896,7 @@ macro_rules! impl_float {
                     }
                 }
             }
+            #[inline]
             fn max(self, other: $type) -> $type {
                 // The implementation strictly adheres to the mandated behavior for the Wasm specification.
                 // Note: In other contexts this API is also known as: `nan_max`.
@@ -840,6 +912,7 @@ macro_rules! impl_float {
                     }
                 }
             }
+            #[inline]
             fn copysign(self, other: $type) -> $type {
                 use core::mem::size_of;
                 let sign_mask: $iXX = 1 << ((size_of::<$iXX>() << 3) - 1);
@@ -904,60 +977,74 @@ fn copysign_regression_works() {
 #[cfg(not(feature = "std"))]
 mod libm_adapters {
     pub mod f32 {
+        #[inline]
         pub fn abs(v: f32) -> f32 {
             libm::fabsf(v)
         }
 
+        #[inline]
         pub fn floor(v: f32) -> f32 {
             libm::floorf(v)
         }
 
+        #[inline]
         pub fn ceil(v: f32) -> f32 {
             libm::ceilf(v)
         }
 
+        #[inline]
         pub fn trunc(v: f32) -> f32 {
             libm::truncf(v)
         }
 
+        #[inline]
         pub fn round(v: f32) -> f32 {
             libm::roundf(v)
         }
 
+        #[inline]
         pub fn fract(v: f32) -> f32 {
             v - trunc(v)
         }
 
+        #[inline]
         pub fn sqrt(v: f32) -> f32 {
             libm::sqrtf(v)
         }
     }
 
     pub mod f64 {
+        #[inline]
         pub fn abs(v: f64) -> f64 {
             libm::fabs(v)
         }
 
+        #[inline]
         pub fn floor(v: f64) -> f64 {
             libm::floor(v)
         }
 
+        #[inline]
         pub fn ceil(v: f64) -> f64 {
             libm::ceil(v)
         }
 
+        #[inline]
         pub fn trunc(v: f64) -> f64 {
             libm::trunc(v)
         }
 
+        #[inline]
         pub fn round(v: f64) -> f64 {
             libm::round(v)
         }
 
+        #[inline]
         pub fn fract(v: f64) -> f64 {
             v - trunc(v)
         }
 
+        #[inline]
         pub fn sqrt(v: f64) -> f64 {
             libm::sqrt(v)
         }

--- a/core/src/vmem.rs
+++ b/core/src/vmem.rs
@@ -20,6 +20,7 @@ pub enum VirtualMemoryError {
 }
 
 impl From<region::Error> for VirtualMemoryError {
+    #[inline]
     fn from(error: region::Error) -> Self {
         Self::Region(error)
     }
@@ -77,6 +78,7 @@ impl VirtualMemory {
     }
 
     /// Returns a shared slice over the bytes of the virtual memory allocation.
+    #[inline]
     pub fn data(&self) -> &[u8] {
         // # SAFETY
         //
@@ -89,6 +91,7 @@ impl VirtualMemory {
     }
 
     /// Returns an exclusive slice over the bytes of the virtual memory allocation.
+    #[inline]
     pub fn data_mut(&mut self) -> &mut [u8] {
         // # SAFETY
         //


### PR DESCRIPTION
This PR is a refinement of [this PR](https://github.com/paritytech/wasmi/pull/347).
The main difference between this PR and the former is that I only annotated relevant functions in the `wasmi_core` crate.

I verified with benchmarks that the best case performance is not regressed.
In fact benchmarks show some neat wins in performance even in the current best case profile settings.
```toml
[profile.release]
lto = "fat"
codegen-units = 1
```

<details>

```
compile_and_validate/v0 time:   [6.8221 ms 6.8453 ms 6.8721 ms]                                    
                        change: [-2.0524% -1.5869% -1.1425%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

compile_and_validate/v1 time:   [6.7297 ms 6.7463 ms 6.7650 ms]                                    
                        change: [-2.6581% -2.2644% -1.8682%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

instantiate/v0          time:   [460.08 us 461.96 us 464.18 us]                           
                        change: [+0.2618% +2.3480% +4.2720%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

instantiate/v1          time:   [54.018 us 54.107 us 54.208 us]                           
                        change: [-4.6674% -4.1457% -3.5764%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking execute/tiny_keccak/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.4s, enable flat sampling, or reduce sample count to 60.
execute/tiny_keccak/v0  time:   [1.2702 ms 1.2727 ms 1.2752 ms]                                    
                        change: [+0.5417% +1.2087% +1.8752%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe

execute/tiny_keccak/v1  time:   [961.91 us 963.43 us 965.09 us]                                   
                        change: [-2.0734% -1.7034% -1.3231%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking execute/rev_complement/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.9s, enable flat sampling, or reduce sample count to 50.
execute/rev_complement/v0                                                                             
                        time:   [1.5623 ms 1.5643 ms 1.5664 ms]
                        change: [+0.6921% +1.2161% +1.7325%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe

Benchmarking execute/rev_complement/v1: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.7s, enable flat sampling, or reduce sample count to 60.
execute/rev_complement/v1                                                                             
                        time:   [1.1290 ms 1.1311 ms 1.1333 ms]
                        change: [-2.6785% -1.9878% -1.2998%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe

Benchmarking execute/regex_redux/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
execute/regex_redux/v0  time:   [1.6770 ms 1.6812 ms 1.6857 ms]                                    
                        change: [+1.3202% +1.8556% +2.3431%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

Benchmarking execute/regex_redux/v1: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.0s, enable flat sampling, or reduce sample count to 60.
execute/regex_redux/v1  time:   [1.1888 ms 1.1910 ms 1.1934 ms]                                    
                        change: [-1.2959% -0.7429% -0.1354%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

Benchmarking execute/count_until/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.5s, enable flat sampling, or reduce sample count to 50.
execute/count_until/v0  time:   [1.8797 ms 1.8817 ms 1.8838 ms]                                    
                        change: [+1.5764% +2.0140% +2.4777%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

Benchmarking execute/count_until/v1: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.7s, enable flat sampling, or reduce sample count to 50.
execute/count_until/v1  time:   [1.7268 ms 1.7289 ms 1.7312 ms]                                    
                        change: [-4.8373% -4.3642% -3.9103%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe

execute/factorial_recursive/v0                                                                             
                        time:   [25.391 us 25.457 us 25.530 us]
                        change: [+10.521% +11.035% +11.545%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

execute/factorial_recursive/v1                                                                             
                        time:   [1.1499 us 1.1519 us 1.1543 us]
                        change: [-5.7141% -5.2811% -4.8554%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe

execute/factorial_optimized/v0                                                                             
                        time:   [24.226 us 24.291 us 24.364 us]
                        change: [+9.9294% +10.795% +11.618%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

execute/factorial_optimized/v1                                                                             
                        time:   [734.22 ns 735.52 ns 736.90 ns]
                        change: [-0.7316% -0.3179% +0.0833%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

execute/recursive_ok/v0 time:   [518.42 us 519.49 us 520.76 us]                                    
                        change: [+6.4530% +7.1026% +7.8196%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

execute/recursive_ok/v1 time:   [301.69 us 302.45 us 303.27 us]                                    
                        change: [-6.0900% -5.6249% -5.1553%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

execute/recursive_trap/v0                                                                            
                        time:   [71.429 us 71.619 us 71.832 us]
                        change: [+2.5093% +3.0868% +3.6646%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

execute/recursive_trap/v1                                                                             
                        time:   [28.415 us 28.458 us 28.503 us]
                        change: [-6.2794% -5.8939% -5.5115%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

execute/host_calls/v0   time:   [75.813 us 75.955 us 76.109 us]                                  
                        change: [+3.0887% +3.6202% +4.1416%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) low mild
  6 (6.00%) high mild
  6 (6.00%) high severe

execute/host_calls/v1   time:   [46.744 us 46.836 us 46.933 us]                                   
                        change: [+2.6132% +3.0292% +3.4293%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe
```

</details>

Compared to the original PR there are fewer gains on the default release profile:
```toml
[profile.release]
lto = false
codegen-units = 16
```

<details>

```
compile_and_validate/v0 time:   [8.8091 ms 8.8399 ms 8.8740 ms]                                    
                        change: [-3.4497% -2.8317% -2.2452%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

compile_and_validate/v1 time:   [9.1008 ms 9.1259 ms 9.1530 ms]                                    
                        change: [-3.1303% -2.6654% -2.2118%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

instantiate/v0          time:   [516.68 us 519.71 us 523.97 us]                           
                        change: [-1.9549% -0.1458% +1.7433%] (p = 0.89 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

instantiate/v1          time:   [75.096 us 75.261 us 75.447 us]                           
                        change: [-4.7806% -3.9669% -3.1288%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe

Benchmarking execute/tiny_keccak/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.7s, enable flat sampling, or reduce sample count to 60.
execute/tiny_keccak/v0  time:   [1.3225 ms 1.3257 ms 1.3296 ms]                                    
                        change: [-15.715% -15.047% -14.214%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

execute/tiny_keccak/v1  time:   [4.4582 ms 4.5235 ms 4.5867 ms]                                    
                        change: [-1.7800% -0.2564% +1.1385%] (p = 0.73 > 0.05)
                        No change in performance detected.

Benchmarking execute/rev_complement/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.4s, enable flat sampling, or reduce sample count to 50.
execute/rev_complement/v0                                                                             
                        time:   [1.6442 ms 1.6473 ms 1.6504 ms]
                        change: [-24.252% -23.870% -23.474%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe

execute/rev_complement/v1                                                                             
                        time:   [5.5133 ms 5.5247 ms 5.5369 ms]
                        change: [-11.425% -11.086% -10.744%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking execute/regex_redux/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, enable flat sampling, or reduce sample count to 50.
execute/regex_redux/v0  time:   [1.8321 ms 1.8355 ms 1.8392 ms]                                    
                        change: [-11.425% -10.620% -9.9913%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe

execute/regex_redux/v1  time:   [5.2250 ms 5.2395 ms 5.2563 ms]                                    
                        change: [-10.833% -10.416% -10.005%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

Benchmarking execute/count_until/v0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
execute/count_until/v0  time:   [1.7288 ms 1.7322 ms 1.7359 ms]                                    
                        change: [-16.428% -16.072% -15.691%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

execute/count_until/v1  time:   [5.2632 ms 5.2786 ms 5.2973 ms]                                    
                        change: [-12.046% -11.713% -11.328%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

execute/factorial_recursive/v0                                                                             
                        time:   [23.622 us 23.680 us 23.745 us]
                        change: [-13.596% -13.063% -12.521%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

execute/factorial_recursive/v1                                                                             
                        time:   [3.3644 us 3.3738 us 3.3838 us]
                        change: [-2.9039% -2.3538% -1.7840%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

execute/factorial_optimized/v0                                                                             
                        time:   [22.001 us 22.059 us 22.118 us]
                        change: [-14.925% -14.352% -13.786%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

execute/factorial_optimized/v1                                                                             
                        time:   [2.1976 us 2.2023 us 2.2075 us]
                        change: [-26.559% -26.166% -25.777%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  7 (7.00%) high severe

execute/recursive_ok/v0 time:   [576.76 us 578.01 us 579.46 us]                                    
                        change: [-6.8714% -6.1659% -5.4949%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low mild
  7 (7.00%) high mild
  4 (4.00%) high severe

execute/recursive_ok/v1 time:   [828.75 us 830.57 us 832.48 us]                                    
                        change: [-7.4671% -6.9124% -6.3596%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe

execute/recursive_trap/v0                                                                            
                        time:   [76.037 us 76.206 us 76.384 us]
                        change: [-10.528% -9.6716% -8.9099%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

execute/recursive_trap/v1                                                                            
                        time:   [76.506 us 76.787 us 77.122 us]
                        change: [-9.6152% -7.9603% -6.4676%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

execute/host_calls/v0   time:   [96.371 us 96.596 us 96.845 us]                                  
                        change: [-14.304% -13.825% -13.346%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe

execute/host_calls/v1   time:   [117.97 us 118.26 us 118.60 us]                                  
                        change: [-3.5932% -2.9390% -2.3392%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe
```

</details>