### PR TITLE
Add GlobalType

### DIFF
--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -51,7 +51,7 @@ impl Display for GlobalError {
 }
 
 /// The mutability of a global variable.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Mutability {
     /// The value of the global variable is a constant.
     Const,
@@ -60,7 +60,7 @@ pub enum Mutability {
 }
 
 /// The type of a global variable.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct GlobalType {
     /// The value type of the global variable.
     value_type: ValueType,

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -62,15 +62,22 @@ pub enum Mutability {
 #[derive(Debug, Copy, Clone)]
 pub struct GlobalType {
     /// The value type of the global variable.
-    ty: ValueType,
+    value_type: ValueType,
     /// The mutability of the global variable.
     mutability: Mutability,
 }
 
 impl GlobalType {
+    pub fn new(value_type: ValueType, mutability: Mutability) -> Self {
+        Self {
+            value_type,
+            mutability,
+        }
+    }
+
     /// Returns the [`ValueType`] of the global variable.
     pub fn value_type(&self) -> ValueType {
-        self.ty
+        self.value_type
     }
 
     /// Returns the [`Mutability`] of the global variable.
@@ -109,10 +116,7 @@ impl GlobalEntity {
 
     /// Returns the [`GlobalType`] of the global variable.
     pub fn global_type(&self) -> GlobalType {
-        GlobalType {
-            ty: self.value_type(),
-            mutability: self.mutability,
-        }
+        GlobalType::new(self.value_type(), self.mutability)
     }
 
     /// Sets a new value to the global variable.

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -58,10 +58,33 @@ pub enum Mutability {
     Mutable,
 }
 
+/// The type of a global variable.
+#[derive(Debug, Copy, Clone)]
+pub struct GlobalType {
+    /// The value type of the global variable.
+    ty: ValueType,
+    /// The mutability of the global variable.
+    mutability: Mutability,
+}
+
+impl GlobalType {
+    /// Returns the [`ValueType`] of the global variable.
+    pub fn value_type(&self) -> ValueType {
+        self.ty
+    }
+
+    /// Returns the [`Mutability`] of the global variable.
+    pub fn mutability(&self) -> Mutability {
+        self.mutability
+    }
+}
+
 /// A global variable entitiy.
 #[derive(Debug)]
 pub struct GlobalEntity {
+    /// The current value of the global variable.
     value: Value,
+    /// The mutability of the global variable.
     mutability: Mutability,
 }
 
@@ -82,6 +105,14 @@ impl GlobalEntity {
     /// Returns the type of the global variable value.
     pub fn value_type(&self) -> ValueType {
         self.value.value_type()
+    }
+
+    /// Returns the [`GlobalType`] of the global variable.
+    pub fn global_type(&self) -> GlobalType {
+        GlobalType {
+            ty: self.value_type(),
+            mutability: self.mutability,
+        }
     }
 
     /// Sets a new value to the global variable.
@@ -155,6 +186,11 @@ impl Global {
     /// Panics if `ctx` does not own this [`Global`].
     pub fn value_type(&self, ctx: impl AsContext) -> ValueType {
         ctx.as_context().store.resolve_global(*self).value_type()
+    }
+
+    /// Returns the [`GlobalType`] of the global variable.
+    pub fn global_type(&self, ctx: impl AsContext) -> GlobalType {
+        ctx.as_context().store.resolve_global(*self).global_type()
     }
 
     /// Sets a new value to the global variable.

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -1,6 +1,7 @@
 use super::{AsContext, AsContextMut, Index, Stored};
 use crate::{Value, ValueType};
 use core::{fmt, fmt::Display};
+use parity_wasm::elements as pwasm;
 
 /// A raw index to a global variable entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -73,6 +74,17 @@ impl GlobalType {
             value_type,
             mutability,
         }
+    }
+
+    /// Converts into [`GlobalType`] from [`pwasm::GlobalType`].
+    pub fn from_elements(global_type: pwasm::GlobalType) -> Self {
+        let value_type = ValueType::from_elements(global_type.content_type());
+        let mutability = if global_type.is_mutable() {
+            Mutability::Mutable
+        } else {
+            Mutability::Const
+        };
+        Self::new(value_type, mutability)
     }
 
     /// Returns the [`ValueType`] of the global variable.

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -57,7 +57,7 @@ pub use self::{
     external::Extern,
     func::{Caller, Func, TypedFunc, WasmParams, WasmResults},
     func_type::FuncType,
-    global::{Global, Mutability},
+    global::{Global, GlobalType, Mutability},
     instance::{ExportsIter, Instance},
     linker::Linker,
     memory::{Memory, MemoryType},

--- a/wasmi_v1/src/module/instantiate.rs
+++ b/wasmi_v1/src/module/instantiate.rs
@@ -104,14 +104,10 @@ impl Display for InstantiationError {
                     expected, actual
                 )
             }
-            Self::GlobalTypeMismatch {
-                expected,
-                actual,
-            } => write!(
+            Self::GlobalTypeMismatch { expected, actual } => write!(
                 f,
                 "expected {:?} global type but found {:?} value type",
-                expected,
-                actual,
+                expected, actual,
             ),
             Self::ElementSegmentDoesNotFit {
                 table,
@@ -385,10 +381,7 @@ impl Module {
                     let expected = GlobalType::from_elements(*global_type);
                     let actual = global.global_type(&context);
                     if expected != actual {
-                        return Err(InstantiationError::GlobalTypeMismatch {
-                            expected,
-                            actual,
-                        });
+                        return Err(InstantiationError::GlobalTypeMismatch { expected, actual });
                     }
                     builder.push_global(global);
                 }

--- a/wasmi_v1/src/module/instantiate.rs
+++ b/wasmi_v1/src/module/instantiate.rs
@@ -29,7 +29,7 @@ use super::{
     },
     Module,
 };
-use crate::{Value, ValueType, F32, F64};
+use crate::{GlobalType, Value, ValueType, F32, F64};
 use core::{fmt, fmt::Display};
 use parity_wasm::elements as pwasm;
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
@@ -62,17 +62,9 @@ pub enum InstantiationError {
     /// Caused when a global variable has a mismatching global variable type and mutability.
     GlobalTypeMismatch {
         /// The expected global type for the global variable import.
-        ///
-        /// # Note
-        ///
-        /// The global type is required to match value type and mutability.
-        expected: pwasm::GlobalType,
-        /// The actual value type of the global variable import.
-        actual_type: ValueType,
-        /// The actual mutability of the global variable import.
-        ///
-        /// This is `true` if the global variable is mutable.
-        actual_mutability: bool,
+        expected: GlobalType,
+        /// The actual global type found for the global variable import.
+        actual: GlobalType,
     },
     /// Caused when an element segment does not fit into the specified table instance.
     ElementSegmentDoesNotFit {
@@ -114,18 +106,12 @@ impl Display for InstantiationError {
             }
             Self::GlobalTypeMismatch {
                 expected,
-                actual_type,
-                actual_mutability,
+                actual,
             } => write!(
                 f,
-                "expected {:?} global type but found {} {:?} value type",
+                "expected {:?} global type but found {:?} value type",
                 expected,
-                if *actual_mutability {
-                    "mutable"
-                } else {
-                    "immutable"
-                },
-                actual_type
+                actual,
             ),
             Self::ElementSegmentDoesNotFit {
                 table,
@@ -396,16 +382,12 @@ impl Module {
                     builder.push_memory(memory);
                 }
                 (pwasm::External::Global(global_type), Extern::Global(global)) => {
-                    let expected = *global_type;
-                    let expected_type = ValueType::from_elements(expected.content_type());
-                    let expected_mutability = expected.is_mutable();
-                    let actual_type = global.value_type(context.as_context());
-                    let actual_mutability = global.is_mutable(context.as_context());
-                    if expected_type != actual_type || expected_mutability != actual_mutability {
+                    let expected = GlobalType::from_elements(*global_type);
+                    let actual = global.global_type(&context);
+                    if expected != actual {
                         return Err(InstantiationError::GlobalTypeMismatch {
                             expected,
-                            actual_type,
-                            actual_mutability,
+                            actual,
                         });
                     }
                     builder.push_global(global);


### PR DESCRIPTION
This add `GlobalType` to the `wasmi_v1` crate so that now all instance types (`Func`, `Table`, `Memory` and `Global`) do have some associated `XType`.
- `Func` -> `FuncType`
- `Table` -> `TableType`
- `Memory` -> `MemoryType`
- `Global` -> `GlobalType`

With this PR we also cleaned up the `InstantiationError` that was especially ugly due to the missing `GlobalType`.