### PR TITLE
Use wat instead of wabt crate where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ parity-wasm = { version = "0.42.0", default-features = false }
 [dev-dependencies]
 assert_matches = "1.5"
 wabt = "0.9"
+wat = "1"
 wast = "39.0"
 anyhow = "1.0"
 criterion = "0.3.5"

--- a/benches/bench/mod.rs
+++ b/benches/bench/mod.rs
@@ -98,6 +98,11 @@ pub fn load_instance_from_file_v1(file_name: &str) -> (v1::Store<()>, v1::Instan
     (store, instance)
 }
 
+/// Converts the `.wat` encoded `bytes` into `.wasm` encoded bytes.
+pub fn wat2wasm(bytes: &[u8]) -> Vec<u8> {
+    wat::parse_bytes(bytes).unwrap().into_owned()
+}
+
 /// Parses the Wasm source from the given `.wat` bytes into a `wasmi` `v0` module.
 ///
 /// # Note
@@ -108,7 +113,7 @@ pub fn load_instance_from_file_v1(file_name: &str) -> (v1::Store<()>, v1::Instan
 ///
 /// If the benchmark Wasm file could not be opened, read or parsed.
 pub fn load_instance_from_wat_v0(wat_bytes: &[u8]) -> v0::ModuleRef {
-    let wasm = wabt::wat2wasm(wat_bytes).unwrap();
+    let wasm = wat2wasm(wat_bytes);
     let module = v0::Module::from_buffer(&wasm).unwrap();
     v0::ModuleInstance::new(&module, &v0::ImportsBuilder::default())
         .expect("failed to instantiate wasm module")
@@ -126,7 +131,7 @@ pub fn load_instance_from_wat_v0(wat_bytes: &[u8]) -> v0::ModuleRef {
 ///
 /// If the benchmark Wasm file could not be opened, read or parsed.
 pub fn load_instance_from_wat_v1(wat_bytes: &[u8]) -> (v1::Store<()>, v1::Instance) {
-    let wasm = wabt::wat2wasm(wat_bytes).unwrap();
+    let wasm = wat2wasm(wat_bytes);
     let engine = v1::Engine::default();
     let module = v1::Module::new(&engine, &wasm).unwrap();
     let mut linker = <v1::Linker<()>>::default();

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -8,6 +8,7 @@ use self::bench::{
     load_module_from_file_v0,
     load_module_from_file_v1,
     load_wasm_from_file,
+    wat2wasm,
 };
 use assert_matches::assert_matches;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -520,7 +521,7 @@ fn bench_execute_recursive_trap_v1(c: &mut Criterion) {
 const HOST_CALLS_REPETITIONS: i64 = 1000;
 
 fn bench_execute_host_calls_v0(c: &mut Criterion) {
-    let wasm = wabt::wat2wasm(include_bytes!("wat/host_calls.wat")).unwrap();
+    let wasm = wat2wasm(include_bytes!("wat/host_calls.wat"));
     let module = v0::Module::from_buffer(&wasm).unwrap();
     let instance = v0::ModuleInstance::new(&module, &BenchExternals)
         .expect("failed to instantiate wasm module")
@@ -619,7 +620,7 @@ fn bench_execute_host_calls_v0(c: &mut Criterion) {
 }
 
 fn bench_execute_host_calls_v1(c: &mut Criterion) {
-    let wasm = wabt::wat2wasm(include_bytes!("wat/host_calls.wat")).unwrap();
+    let wasm = wat2wasm(include_bytes!("wat/host_calls.wat"));
     let engine = v1::Engine::default();
     let module = v1::Module::new(&engine, &wasm).unwrap();
     let mut linker = <v1::Linker<()>>::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,14 +49,14 @@
 //!
 //! ```rust
 //! extern crate wasmi;
-//! extern crate wabt;
+//! extern crate wat;
 //!
 //! use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
 //!
 //! fn main() {
 //!     // Parse WAT (WebAssembly Text format) into wasm bytecode.
 //!     let wasm_binary: Vec<u8> =
-//!         wabt::wat2wasm(
+//!         wat::parse_str(
 //!             r#"
 //!             (module
 //!                 (func (export "test") (result i32)
@@ -370,10 +370,10 @@ impl Module {
     ///
     /// ```rust
     /// # extern crate wasmi;
-    /// # extern crate wabt;
+    /// # extern crate wat;
     ///
     /// let wasm_binary: Vec<u8> =
-    ///     wabt::wat2wasm(
+    ///     wat::parse_str(
     ///         r#"
     ///         (module
     ///          (func $add (param $lhs i32) (param $rhs i32) (result i32)
@@ -389,7 +389,7 @@ impl Module {
     /// assert!(module.deny_floating_point().is_ok());
     ///
     /// let wasm_binary: Vec<u8> =
-    ///     wabt::wat2wasm(
+    ///     wat::parse_str(
     ///         r#"
     ///         (module
     ///          (func $add (param $lhs f32) (param $rhs f32) (result f32)
@@ -404,7 +404,7 @@ impl Module {
     /// assert!(module.deny_floating_point().is_err());
     ///
     /// let wasm_binary: Vec<u8> =
-    ///     wabt::wat2wasm(
+    ///     wat::parse_str(
     ///         r#"
     ///         (module
     ///          (func $add (param $lhs f32) (param $rhs f32) (result f32)

--- a/src/module.rs
+++ b/src/module.rs
@@ -604,10 +604,10 @@ impl ModuleInstance {
     ///
     /// ```rust
     /// # extern crate wasmi;
-    /// # extern crate wabt;
+    /// # extern crate wat;
     /// # use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
     /// # fn main() {
-    /// # let wasm_binary: Vec<u8> = wabt::wat2wasm(
+    /// # let wasm_binary: Vec<u8> = wat::parse_str(
     /// #   r#"
     /// #   (module
     /// #       (func (export "add") (param i32 i32) (result i32)
@@ -845,7 +845,7 @@ mod tests {
     use crate::{func::FuncInstance, imports::ImportsBuilder, types::Signature, Module, ValueType};
 
     fn parse_wat(source: &str) -> Module {
-        let wasm_binary = wabt::wat2wasm(source).expect("Failed to parse wat source");
+        let wasm_binary = wat::parse_str(source).expect("Failed to parse wat source");
         Module::from_buffer(wasm_binary).expect("Failed to load parsed module")
     }
 

--- a/src/prepare/tests.rs
+++ b/src/prepare/tests.rs
@@ -9,7 +9,7 @@ use crate::isa;
 use parity_wasm::{deserialize_buffer, elements::Module};
 
 fn validate(wat: &str) -> CompiledModule {
-    let wasm = wabt::wat2wasm(wat).unwrap();
+    let wasm = wat::parse_str(wat).unwrap();
     let module = deserialize_buffer::<Module>(&wasm).unwrap();
     compile_module(module).unwrap()
 }

--- a/tests/e2e/v0/mod.rs
+++ b/tests/e2e/v0/mod.rs
@@ -39,6 +39,6 @@ fn unsigned_to_value() {
 }
 
 pub fn parse_wat(source: &str) -> Module {
-    let wasm_binary = wabt::wat2wasm(source).expect("Failed to parse wat source");
+    let wasm_binary = wat::parse_str(source).expect("Failed to parse wat source");
     Module::from_buffer(wasm_binary).expect("Failed to load parsed module")
 }

--- a/tests/e2e/v0/wasm.rs
+++ b/tests/e2e/v0/wasm.rs
@@ -98,7 +98,7 @@ fn load_from_file(filename: &str) -> Module {
     let mut file = File::open(filename).unwrap();
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).unwrap();
-    let wasm_buf = ::wabt::wat2wasm(&buf).unwrap();
+    let wasm_buf = ::wat::parse_bytes(&buf).unwrap().into_owned();
     Module::from_buffer(wasm_buf).unwrap()
 }
 

--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -17,7 +17,7 @@ parity-wasm = { version = "0.42.0", default-features = false }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]
-wabt = "0.9"
+wat = "1"
 
 [features]
 default = ["std"]

--- a/wasmi_v1/src/module/tests.rs
+++ b/wasmi_v1/src/module/tests.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 fn wat2wasm(wat: &str) -> Vec<u8> {
-    wabt::wat2wasm(wat).unwrap()
+    wat::parse_str(wat).unwrap()
 }
 
 fn compile(bytes: impl AsRef<[u8]>) -> (Engine, Vec<FuncBody>) {


### PR DESCRIPTION
This will further improve Wasm spec compliance once https://github.com/paritytech/wasmi/pull/346 lands.
The `wat` crate is authored by the BytecodeAlliance and in a much better shape than the `wabt` crate.
Also it is stlil maintained and updated for new Wasm proposals and fixes.

Remaining wabt users are:

- The two outdated fuzz systems.
- The outdated v0 Wasm testsuite.