### PR TITLE
Implement multi-value Wasm proposal

### DIFF
--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use wasmi::nan_preserving_float::{F32, F64};
 use wasmi_core::Value;
 use wasmi_v1::{
+    Config,
     Engine,
     Extern,
     Func,
@@ -47,8 +48,8 @@ pub struct TestContext<'a> {
 
 impl<'a> TestContext<'a> {
     /// Creates a new [`TestContext`] with the given [`TestDescriptor`].
-    pub fn new(descriptor: &'a TestDescriptor) -> Self {
-        let engine = Engine::default();
+    pub fn new(descriptor: &'a TestDescriptor, config: Config) -> Self {
+        let engine = Engine::new(&config);
         let mut linker = Linker::default();
         let mut store = Store::new(&engine, ());
         let default_memory = Memory::new(&mut store, MemoryType::new(1, Some(2))).unwrap();

--- a/tests/spec/v1/mod.rs
+++ b/tests/spec/v1/mod.rs
@@ -10,6 +10,12 @@ use self::{
     error::TestError,
     profile::TestProfile,
 };
+use wasmi_v1::Config;
+
+/// Run Wasm spec test suite using default `wasmi` configuration.
+fn run_wasm_spec_test(file_name: &str) {
+    self::run::run_wasm_spec_test(file_name, Config::default())
+}
 
 macro_rules! define_tests {
     ( $( $(#[$attr:meta])* fn $test_name:ident($file_name:expr); )* ) => {
@@ -17,11 +23,34 @@ macro_rules! define_tests {
             #[test]
             $( #[$attr] )*
             fn $test_name() {
-                self::run::run_wasm_spec_test($file_name)
+                run_wasm_spec_test($file_name)
             }
         )*
     };
 }
+
+mod multi_value {
+    use super::*;
+
+    /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
+    fn run_wasm_spec_test(file_name: &str) {
+        self::run::run_wasm_spec_test(file_name, Config::default().enable_multi_value())
+    }
+
+    define_tests! {
+        fn wasm_binary("proposals/multi-value/binary");
+        fn wasm_block("proposals/multi-value/block");
+        fn wasm_br("proposals/multi-value/br");
+        fn wasm_call("proposals/multi-value/call");
+        fn wasm_call_indirect("proposals/multi-value/call_indirect");
+        fn wasm_fac("proposals/multi-value/fac");
+        fn wasm_func("proposals/multi-value/func");
+        fn wasm_if("proposals/multi-value/if");
+        fn wasm_loop("proposals/multi-value/loop");
+        fn wasm_type("proposals/multi-value/type");
+    }
+}
+
 define_tests! {
     fn wasm_address("address");
     fn wasm_align("align");

--- a/tests/spec/v1/run.rs
+++ b/tests/spec/v1/run.rs
@@ -1,7 +1,7 @@
 use super::{error::TestError, TestContext, TestDescriptor};
 use anyhow::Result;
 use wasmi_core::{Trap, Value, F32, F64};
-use wasmi_v1::Error as WasmiError;
+use wasmi_v1::{Config, Error as WasmiError};
 use wast::{
     lexer::Lexer,
     parser::ParseBuffer,
@@ -16,9 +16,9 @@ use wast::{
 };
 
 /// Runs the Wasm test spec identified by the given name.
-pub fn run_wasm_spec_test(name: &str) {
+pub fn run_wasm_spec_test(name: &str, config: Config) {
     let test = TestDescriptor::new(name);
-    let mut context = TestContext::new(&test);
+    let mut context = TestContext::new(&test, config);
 
     let mut lexer = Lexer::new(test.file());
     lexer.allow_confusing_unicode(true);

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -57,7 +57,7 @@ impl<'engine> ModuleParser<'engine> {
     fn new(engine: &'engine Engine) -> Self {
         let builder = ModuleBuilder::new(engine);
         let mut validator = Validator::default();
-        validator.wasm_features(Self::features());
+        validator.wasm_features(Self::features(engine));
         let parser = WasmParser::new(0);
         Self {
             builder,
@@ -68,10 +68,10 @@ impl<'engine> ModuleParser<'engine> {
     }
 
     /// Returns the Wasm features supported by `wasmi`.
-    fn features() -> WasmFeatures {
+    fn features(engine: &Engine) -> WasmFeatures {
         WasmFeatures {
             reference_types: false,
-            multi_value: false,
+            multi_value: engine.config().multi_value(),
             bulk_memory: false,
             module_linking: false,
             simd: false,


### PR DESCRIPTION
Note that this PR does no real implementation as it turned out that multi-value is already pretty much supported. So the only thing that this PR does is to allow to enable multi-value Wasm proposal support via the wasmi_v1::Config type. Also this PR integrates the Wasm spec testsuite tests for the multi-value Wasm proposal.