### PR TITLE
Update wasmparser: 0.82 -> 0.83

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The new `wasmi_v1` engine supports a variety of WebAssembly proposals and will s
 
 | Wasm Proposal | Status | Comment |
 |:--|:--:|:--|
-| [`mutable-global`] | ❌ | Planned but not yet implemented. High priority. |
+| [`mutable-global`] | ✅ | |
 | [`saturating-float-to-int`] | ✅ | |
 | [`sign-extension`] | ✅ | |
 | [`multi-value`] | ✅ | |

--- a/tests/spec/local/missing-features/mutable-global-disabled.wast
+++ b/tests/spec/local/missing-features/mutable-global-disabled.wast
@@ -1,0 +1,14 @@
+(assert_invalid
+  (module
+    (import "m0" "g0" (global (mut i32)))
+  )
+  "mutable global support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (global $g0 (mut i32) (i32.const 0))
+    (export "g0" (global $g0))
+  )
+  "mutable global support is not enabled"
+)

--- a/tests/spec/local/missing-features/saturating-float-to-int-disabled.wast
+++ b/tests/spec/local/missing-features/saturating-float-to-int-disabled.wast
@@ -1,0 +1,79 @@
+(assert_invalid
+  (module
+    (func (param f32) (result i32)
+      local.get 0
+      i32.trunc_sat_f32_s
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f32) (result i32)
+      local.get 0
+      i32.trunc_sat_f32_u
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f64) (result i32)
+      local.get 0
+      i32.trunc_sat_f64_s
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f64) (result i32)
+      local.get 0
+      i32.trunc_sat_f64_u
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f32) (result i64)
+      local.get 0
+      i64.trunc_sat_f32_s
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f32) (result i64)
+      local.get 0
+      i64.trunc_sat_f32_u
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f64) (result i64)
+      local.get 0
+      i64.trunc_sat_f64_s
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param f64) (result i64)
+      local.get 0
+      i64.trunc_sat_f64_u
+    )
+  )
+  "saturating float to int conversions support is not enabled"
+)

--- a/tests/spec/local/missing-features/sign-extension-disabled.wast
+++ b/tests/spec/local/missing-features/sign-extension-disabled.wast
@@ -1,0 +1,49 @@
+(assert_invalid
+  (module
+    (func (param i32) (result i32)
+      local.get 0
+      i32.extend8_s
+    )
+  )
+  "sign extension operations support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param i32) (result i32)
+      local.get 0
+      i32.extend16_s
+    )
+  )
+  "sign extension operations support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param i64) (result i64)
+      local.get 0
+      i64.extend8_s
+    )
+  )
+  "sign extension operations support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param i64) (result i64)
+      local.get 0
+      i64.extend16_s
+    )
+  )
+  "sign extension operations support is not enabled"
+)
+
+(assert_invalid
+  (module
+    (func (param i64) (result i64)
+      local.get 0
+      i64.extend32_s
+    )
+  )
+  "sign extension operations support is not enabled"
+)

--- a/tests/spec/v1/descriptor.rs
+++ b/tests/spec/v1/descriptor.rs
@@ -19,7 +19,7 @@ impl TestDescriptor {
     ///
     /// If the corresponding Wasm test spec file cannot properly be read.
     pub fn new(name: &str) -> Self {
-        let path = format!("tests/spec/testsuite-v1/{}.wast", name);
+        let path = format!("tests/spec/{}.wast", name);
         let file = fs::read_to_string(&path).unwrap_or_else(|error| {
             panic!("{}, failed to read `.wast` test file: {}", path, error)
         });

--- a/tests/spec/v1/mod.rs
+++ b/tests/spec/v1/mod.rs
@@ -12,9 +12,14 @@ use self::{
 };
 use wasmi_v1::Config;
 
-/// Run Wasm spec test suite using default `wasmi` configuration.
+/// Run Wasm spec test suite using MVP `wasmi` configuration.
+///
+/// # Note
+///
+/// The Wasm MVP has no Wasm proposals enabled.
 fn run_wasm_spec_test(file_name: &str) {
-    self::run::run_wasm_spec_test(file_name, Config::default())
+    let config = Config::mvp().enable_mutable_global(true);
+    self::run::run_wasm_spec_test(file_name, config)
 }
 
 macro_rules! define_tests {
@@ -30,7 +35,13 @@ macro_rules! define_tests {
 }
 
 mod saturating_float_to_int {
-    use super::run_wasm_spec_test;
+    use super::Config;
+
+    /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
+    fn run_wasm_spec_test(file_name: &str) {
+        let config = Config::mvp().enable_saturating_float_to_int(true);
+        super::run::run_wasm_spec_test(file_name, config)
+    }
 
     define_tests! {
         fn wasm_conversions("proposals/nontrapping-float-to-int-conversions/conversions");
@@ -38,7 +49,13 @@ mod saturating_float_to_int {
 }
 
 mod sign_extension_ops {
-    use super::run_wasm_spec_test;
+    use super::Config;
+
+    /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
+    fn run_wasm_spec_test(file_name: &str) {
+        let config = Config::mvp().enable_sign_extension(true);
+        super::run::run_wasm_spec_test(file_name, config)
+    }
 
     define_tests! {
         fn wasm_i32("proposals/sign-extension-ops/i32");
@@ -51,7 +68,8 @@ mod multi_value {
 
     /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
     fn run_wasm_spec_test(file_name: &str) {
-        super::run::run_wasm_spec_test(file_name, Config::default().enable_multi_value())
+        let config = Config::mvp().enable_multi_value(true);
+        super::run::run_wasm_spec_test(file_name, config)
     }
 
     define_tests! {

--- a/tests/spec/v1/mod.rs
+++ b/tests/spec/v1/mod.rs
@@ -22,13 +22,40 @@ fn run_wasm_spec_test(file_name: &str) {
     self::run::run_wasm_spec_test(file_name, config)
 }
 
-macro_rules! define_tests {
+macro_rules! define_local_tests {
     ( $( $(#[$attr:meta])* fn $test_name:ident($file_name:expr); )* ) => {
         $(
             #[test]
             $( #[$attr] )*
             fn $test_name() {
-                run_wasm_spec_test($file_name)
+                run_wasm_spec_test(&format!("local/{}", $file_name))
+            }
+        )*
+    };
+}
+
+mod missing_features {
+    use super::Config;
+
+    /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
+    fn run_wasm_spec_test(file_name: &str) {
+        super::run::run_wasm_spec_test(file_name, Config::mvp())
+    }
+
+    define_local_tests! {
+        fn wasm_mutable_global("missing-features/mutable-global-disabled");
+        fn wasm_sign_extension("missing-features/sign-extension-disabled");
+        fn wasm_saturating_float_to_int("missing-features/saturating-float-to-int-disabled");
+    }
+}
+
+macro_rules! define_spec_tests {
+    ( $( $(#[$attr:meta])* fn $test_name:ident($file_name:expr); )* ) => {
+        $(
+            #[test]
+            $( #[$attr] )*
+            fn $test_name() {
+                run_wasm_spec_test(&format!("testsuite-v1/{}", $file_name))
             }
         )*
     };
@@ -43,7 +70,7 @@ mod saturating_float_to_int {
         super::run::run_wasm_spec_test(file_name, config)
     }
 
-    define_tests! {
+    define_spec_tests! {
         fn wasm_conversions("proposals/nontrapping-float-to-int-conversions/conversions");
     }
 }
@@ -57,7 +84,7 @@ mod sign_extension_ops {
         super::run::run_wasm_spec_test(file_name, config)
     }
 
-    define_tests! {
+    define_spec_tests! {
         fn wasm_i32("proposals/sign-extension-ops/i32");
         fn wasm_i64("proposals/sign-extension-ops/i64");
     }
@@ -72,7 +99,7 @@ mod multi_value {
         super::run::run_wasm_spec_test(file_name, config)
     }
 
-    define_tests! {
+    define_spec_tests! {
         fn wasm_binary("proposals/multi-value/binary");
         fn wasm_block("proposals/multi-value/block");
         fn wasm_br("proposals/multi-value/br");
@@ -86,7 +113,7 @@ mod multi_value {
     }
 }
 
-define_tests! {
+define_spec_tests! {
     fn wasm_address("address");
     fn wasm_align("align");
     fn wasm_binary("binary");

--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -11,7 +11,7 @@ description = "WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 
 [dependencies]
-wasmparser = { version = "0.82", package = "wasmparser-nostd", default-features = false }
+wasmparser = { version = "0.83", package = "wasmparser-nostd", default-features = false }
 wasmi_core = { version = "0.1", path = "../core", default-features = false }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -169,7 +169,7 @@ impl Config {
     /// # Note
     ///
     /// The Wasm MVP has no Wasm proposals enabled by default.
-    pub fn mvp() -> Self {
+    pub const fn mvp() -> Self {
         Self {
             value_stack_limit: DEFAULT_VALUE_STACK_LIMIT,
             call_stack_limit: DEFAULT_CALL_STACK_LIMIT,
@@ -181,46 +181,46 @@ impl Config {
     }
 
     /// Enables the `mutable-global` Wasm proposal.
-    pub fn enable_mutable_global(mut self, enable: bool) -> Self {
+    pub const fn enable_mutable_global(mut self, enable: bool) -> Self {
         self.mutable_global = enable;
         self
     }
 
     /// Returns `true` if the `mutable-global` Wasm proposal is enabled.
-    pub fn mutable_global(&self) -> bool {
+    pub const fn mutable_global(&self) -> bool {
         self.mutable_global
     }
 
     /// Enables the `sign-extension` Wasm proposal.
-    pub fn enable_sign_extension(mut self, enable: bool) -> Self {
+    pub const fn enable_sign_extension(mut self, enable: bool) -> Self {
         self.sign_extension = enable;
         self
     }
 
     /// Returns `true` if the `sign-extension` Wasm proposal is enabled.
-    pub fn sign_extension(&self) -> bool {
+    pub const fn sign_extension(&self) -> bool {
         self.sign_extension
     }
 
     /// Enables the `saturating-float-to-int` Wasm proposal.
-    pub fn enable_saturating_float_to_int(mut self, enable: bool) -> Self {
+    pub const fn enable_saturating_float_to_int(mut self, enable: bool) -> Self {
         self.saturating_float_to_int = enable;
         self
     }
 
     /// Returns `true` if the `saturating-float-to-int` Wasm proposal is enabled.
-    pub fn saturating_float_to_int(&self) -> bool {
+    pub const fn saturating_float_to_int(&self) -> bool {
         self.saturating_float_to_int
     }
 
     /// Enables the `multi-value` Wasm proposal.
-    pub fn enable_multi_value(mut self, enable: bool) -> Self {
+    pub const fn enable_multi_value(mut self, enable: bool) -> Self {
         self.multi_value = enable;
         self
     }
 
     /// Returns `true` if the `multi-value` Wasm proposal is enabled.
-    pub fn multi_value(&self) -> bool {
+    pub const fn multi_value(&self) -> bool {
         self.multi_value
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -116,7 +116,37 @@ pub struct Config {
     /// Reaching this limit during execution of a Wasm function will
     /// cause a stack overflow trap.
     call_stack_limit: usize,
-    /// Is `true` if the `multi-value` Wasm proposal is enabled.
+    /// Is `true` if the [`mutable-global`] Wasm proposal is enabled.
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`mutable-global`]: https://github.com/WebAssembly/mutable-global
+    mutable_global: bool,
+    /// Is `true` if the [`sign-extension`] Wasm proposal is enabled.
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`sign-extension`]: https://github.com/WebAssembly/sign-extension-ops
+    sign_extension: bool,
+    /// Is `true` if the [`saturating-float-to-int`] Wasm proposal is enabled.
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`saturating-float-to-int`]: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
+    saturating_float_to_int: bool,
+    /// Is `true` if the [`multi-value`] Wasm proposal is enabled.
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`multi-value`]: https://github.com/WebAssembly/multi-value
     multi_value: bool,
 }
 
@@ -125,15 +155,67 @@ impl Default for Config {
         Self {
             value_stack_limit: DEFAULT_VALUE_STACK_LIMIT,
             call_stack_limit: DEFAULT_CALL_STACK_LIMIT,
-            multi_value: false,
+            mutable_global: true,
+            sign_extension: true,
+            saturating_float_to_int: true,
+            multi_value: true,
         }
     }
 }
 
 impl Config {
+    /// Creates the [`Config`] for the Wasm MVP (minimum viable product).
+    ///
+    /// # Note
+    ///
+    /// The Wasm MVP has no Wasm proposals enabled by default.
+    pub fn mvp() -> Self {
+        Self {
+            value_stack_limit: DEFAULT_VALUE_STACK_LIMIT,
+            call_stack_limit: DEFAULT_CALL_STACK_LIMIT,
+            mutable_global: false,
+            sign_extension: false,
+            saturating_float_to_int: false,
+            multi_value: false,
+        }
+    }
+
+    /// Enables the `mutable-global` Wasm proposal.
+    pub fn enable_mutable_global(mut self, enable: bool) -> Self {
+        self.mutable_global = enable;
+        self
+    }
+
+    /// Returns `true` if the `mutable-global` Wasm proposal is enabled.
+    pub fn mutable_global(&self) -> bool {
+        self.mutable_global
+    }
+
+    /// Enables the `sign-extension` Wasm proposal.
+    pub fn enable_sign_extension(mut self, enable: bool) -> Self {
+        self.sign_extension = enable;
+        self
+    }
+
+    /// Returns `true` if the `sign-extension` Wasm proposal is enabled.
+    pub fn sign_extension(&self) -> bool {
+        self.sign_extension
+    }
+
+    /// Enables the `saturating-float-to-int` Wasm proposal.
+    pub fn enable_saturating_float_to_int(mut self, enable: bool) -> Self {
+        self.saturating_float_to_int = enable;
+        self
+    }
+
+    /// Returns `true` if the `saturating-float-to-int` Wasm proposal is enabled.
+    pub fn saturating_float_to_int(&self) -> bool {
+        self.saturating_float_to_int
+    }
+
     /// Enables the `multi-value` Wasm proposal.
-    pub fn enable_multi_value(mut self) -> Self {
-        self.multi_value = true;
+    pub fn enable_multi_value(mut self, enable: bool) -> Self {
+        self.multi_value = enable;
         self
     }
 

--- a/wasmi_v1/src/module/compile/mod.rs
+++ b/wasmi_v1/src/module/compile/mod.rs
@@ -630,23 +630,23 @@ impl<'engine, 'parser> FunctionTranslator<'engine, 'parser> {
             | Operator::F64x2ConvertLowI32x4U
             | Operator::F32x4DemoteF64x2Zero
             | Operator::F64x2PromoteLowF32x4
-            | Operator::I8x16SwizzleRelaxed
-            | Operator::I32x4TruncSatF32x4SRelaxed
-            | Operator::I32x4TruncSatF32x4URelaxed
-            | Operator::I32x4TruncSatF64x2SZeroRelaxed
-            | Operator::I32x4TruncSatF64x2UZeroRelaxed
-            | Operator::F32x4FmaRelaxed
-            | Operator::F32x4FmsRelaxed
-            | Operator::F64x2FmaRelaxed
-            | Operator::F64x2FmsRelaxed
+            | Operator::I8x16RelaxedSwizzle
+            | Operator::I32x4RelaxedTruncSatF32x4S
+            | Operator::I32x4RelaxedTruncSatF32x4U
+            | Operator::I32x4RelaxedTruncSatF64x2SZero
+            | Operator::I32x4RelaxedTruncSatF64x2UZero
+            | Operator::F32x4Fma
+            | Operator::F32x4Fms
+            | Operator::F64x2Fma
+            | Operator::F64x2Fms
             | Operator::I8x16LaneSelect
             | Operator::I16x8LaneSelect
             | Operator::I32x4LaneSelect
             | Operator::I64x2LaneSelect
-            | Operator::F32x4MinRelaxed
-            | Operator::F32x4MaxRelaxed
-            | Operator::F64x2MinRelaxed
-            | Operator::F64x2MaxRelaxed => unsupported_error(),
+            | Operator::F32x4RelaxedMin
+            | Operator::F32x4RelaxedMax
+            | Operator::F64x2RelaxedMin
+            | Operator::F64x2RelaxedMax => unsupported_error(),
         }
     }
 }

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -83,6 +83,9 @@ impl<'engine> ModuleParser<'engine> {
             exceptions: false,
             memory64: false,
             extended_const: false,
+            mutable_global: engine.config().mutable_global(),
+            saturating_float_to_int: engine.config().saturating_float_to_int(),
+            sign_extension: engine.config().sign_extension(),
         }
     }
 


### PR DESCRIPTION
This allows us to properly support the `mutable-globals`, `sign-extension-ops` and `saturating-float-to-int` Wasm proposals.