### PR TITLE
Implement UntypedValue in wasmi_core

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::{
     host_error::HostError,
     nan_preserving_float::{F32, F64},
     trap::{Trap, TrapCode},
-    untyped::UntypedValue,
+    untyped::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedError, UntypedValue},
     value::{
         ArithmeticOps,
         ExtendInto,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 mod host_error;
 mod nan_preserving_float;
 mod trap;
+mod untyped;
 mod value;
 
 #[cfg(feature = "virtual_memory")]
@@ -24,6 +25,7 @@ pub use self::{
     host_error::HostError,
     nan_preserving_float::{F32, F64},
     trap::{Trap, TrapCode},
+    untyped::UntypedValue,
     value::{
         ArithmeticOps,
         ExtendInto,

--- a/core/src/untyped.rs
+++ b/core/src/untyped.rs
@@ -1,0 +1,811 @@
+use crate::{
+    ArithmeticOps,
+    ExtendInto,
+    Float,
+    Integer,
+    SignExtendFrom,
+    TrapCode,
+    TruncateSaturateInto,
+    TryTruncateInto,
+    Value,
+    ValueType,
+    WrapInto,
+    F32,
+    F64,
+};
+use core::ops::{Neg, Shl, Shr};
+
+/// An untyped [`Value`].
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UntypedValue {
+    /// This inner value is required to have enough bits to represent
+    /// all fundamental WebAssembly types `i32`, `i64`, `f32` and `f64`.
+    bits: u64,
+}
+
+impl UntypedValue {
+    /// Returns the underlying bits of the [`UntypedValue`].
+    pub fn to_bits(self) -> u64 {
+        self.bits
+    }
+
+    /// Converts the [`UntypedValue`] into a [`Value`].
+    pub fn with_type(self, value_type: ValueType) -> Value {
+        match value_type {
+            ValueType::I32 => Value::I32(<_>::from(self)),
+            ValueType::I64 => Value::I64(<_>::from(self)),
+            ValueType::F32 => Value::F32(<_>::from(self)),
+            ValueType::F64 => Value::F64(<_>::from(self)),
+        }
+    }
+}
+
+macro_rules! impl_from_untyped_for_int {
+    ( $( $int:ty ),* $(,)? ) => {
+        $(
+            impl From<UntypedValue> for $int {
+                fn from(untyped: UntypedValue) -> Self {
+                    untyped.to_bits() as _
+                }
+            }
+        )*
+    };
+}
+impl_from_untyped_for_int!(i32, i64, u32, u64);
+
+macro_rules! impl_from_untyped_for_float {
+    ( $( $float:ty ),* $(,)? ) => {
+        $(
+            impl From<UntypedValue> for $float {
+                fn from(untyped: UntypedValue) -> Self {
+                    Self::from_bits(untyped.to_bits() as _)
+                }
+            }
+        )*
+    };
+}
+impl_from_untyped_for_float!(f32, f64, F32, F64);
+
+impl From<Value> for UntypedValue {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::I32(value) => value.into(),
+            Value::I64(value) => value.into(),
+            Value::F32(value) => value.into(),
+            Value::F64(value) => value.into(),
+        }
+    }
+}
+
+macro_rules! impl_from_prim {
+    ( $( $prim:ty ),* $(,)? ) => {
+        $(
+            impl From<$prim> for UntypedValue {
+                fn from(value: $prim) -> Self {
+                    Self { bits: value as u64 }
+                }
+            }
+        )*
+    };
+}
+#[rustfmt::skip]
+impl_from_prim!(
+    bool,
+    i8, i16, i32, i64,
+    u8, u16, u32, u64,
+    f32, f64,
+);
+
+impl From<F32> for UntypedValue {
+    fn from(value: F32) -> Self {
+        Self {
+            bits: value.to_bits() as u64,
+        }
+    }
+}
+
+impl From<F64> for UntypedValue {
+    fn from(value: F64) -> Self {
+        Self {
+            bits: value.to_bits() as u64,
+        }
+    }
+}
+
+macro_rules! op {
+    ( $operator:tt ) => {{
+        |lhs, rhs| lhs $operator rhs
+    }};
+}
+
+impl UntypedValue {
+    /// Execute an infallible generic operation on `T` that returns an `R`.
+    fn execute_unary<T, R>(self, op: fn(T) -> R) -> Self
+    where
+        T: From<Self>,
+        R: Into<Self>,
+    {
+        op(T::from(self)).into()
+    }
+
+    /// Execute an infallible generic operation on `T` that returns an `R`.
+    fn try_execute_unary<T, R>(self, op: fn(T) -> Result<R, TrapCode>) -> Result<Self, TrapCode>
+    where
+        T: From<Self>,
+        R: Into<Self>,
+    {
+        op(T::from(self)).map(Into::into)
+    }
+
+    /// Execute an infallible generic operation on `T` that returns an `R`.
+    fn execute_binary<T, R>(self, rhs: Self, op: fn(T, T) -> R) -> Self
+    where
+        T: From<Self>,
+        R: Into<Self>,
+    {
+        op(T::from(self), T::from(rhs)).into()
+    }
+
+    /// Execute a fallible generic operation on `T` that returns an `R`.
+    fn try_execute_binary<T, R>(
+        self,
+        rhs: Self,
+        op: fn(T, T) -> Result<R, TrapCode>,
+    ) -> Result<Self, TrapCode>
+    where
+        T: From<Self>,
+        R: Into<Self>,
+    {
+        op(T::from(self), T::from(rhs)).map(Into::into)
+    }
+
+    /// Execute `i32.add` Wasm operation.
+    pub fn i32_add(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i32 as ArithmeticOps<i32>>::add)
+    }
+
+    /// Execute `i64.add` Wasm operation.
+    pub fn i64_add(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i64 as ArithmeticOps<i64>>::add)
+    }
+
+    /// Execute `i32.sub` Wasm operation.
+    pub fn i32_sub(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i32 as ArithmeticOps<i32>>::sub)
+    }
+
+    /// Execute `i64.sub` Wasm operation.
+    pub fn i64_sub(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i64 as ArithmeticOps<i64>>::sub)
+    }
+
+    /// Execute `i32.mul` Wasm operation.
+    pub fn i32_mul(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i32 as ArithmeticOps<i32>>::mul)
+    }
+
+    /// Execute `i64.mul` Wasm operation.
+    pub fn i64_mul(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i64 as ArithmeticOps<i64>>::mul)
+    }
+
+    /// Execute `i32.div_s` Wasm operation.
+    pub fn i32_div_s(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <i32 as ArithmeticOps<i32>>::div)
+    }
+
+    /// Execute `i64.div_s` Wasm operation.
+    pub fn i64_div_s(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <i64 as ArithmeticOps<i64>>::div)
+    }
+
+    /// Execute `i32.div_u` Wasm operation.
+    pub fn i32_div_u(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <u32 as ArithmeticOps<u32>>::div)
+    }
+
+    /// Execute `i64.div_u` Wasm operation.
+    pub fn i64_div_u(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <u64 as ArithmeticOps<u64>>::div)
+    }
+
+    /// Execute `i32.rem_s` Wasm operation.
+    pub fn i32_rem_s(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <i32 as Integer<i32>>::rem)
+    }
+
+    /// Execute `i64.rem_s` Wasm operation.
+    pub fn i64_rem_s(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <i64 as Integer<i64>>::rem)
+    }
+
+    /// Execute `i32.rem_u` Wasm operation.
+    pub fn i32_rem_u(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <u32 as Integer<u32>>::rem)
+    }
+
+    /// Execute `i64.rem_u` Wasm operation.
+    pub fn i64_rem_u(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <u64 as Integer<u64>>::rem)
+    }
+
+    /// Execute `i32.and` Wasm operation.
+    pub fn i32_and(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, _>(rhs, op!(&))
+    }
+
+    /// Execute `i64.and` Wasm operation.
+    pub fn i64_and(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, _>(rhs, op!(&))
+    }
+
+    /// Execute `i32.or` Wasm operation.
+    pub fn i32_or(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, _>(rhs, op!(|))
+    }
+
+    /// Execute `i64.or` Wasm operation.
+    pub fn i64_or(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, _>(rhs, op!(|))
+    }
+
+    /// Execute `i32.xor` Wasm operation.
+    pub fn i32_xor(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, _>(rhs, op!(^))
+    }
+
+    /// Execute `i64.xor` Wasm operation.
+    pub fn i64_xor(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, _>(rhs, op!(^))
+    }
+
+    /// Execute `i32.shl` Wasm operation.
+    pub fn i32_shl(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, _>(rhs, |lhs, rhs| lhs.shl(rhs & 0x1F))
+    }
+
+    /// Execute `i64.shl` Wasm operation.
+    pub fn i64_shl(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, _>(rhs, |lhs, rhs| lhs.shl(rhs & 0x3F))
+    }
+
+    /// Execute `i32.shr_s` Wasm operation.
+    pub fn i32_shr_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, _>(rhs, |lhs, rhs| lhs.shr(rhs & 0x1F))
+    }
+
+    /// Execute `i64.shr_s` Wasm operation.
+    pub fn i64_shr_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, _>(rhs, |lhs, rhs| lhs.shr(rhs & 0x3F))
+    }
+
+    /// Execute `i32.shr_u` Wasm operation.
+    pub fn i32_shr_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u32, _>(rhs, |lhs, rhs| lhs.shr(rhs & 0x1F))
+    }
+
+    /// Execute `i64.shr_u` Wasm operation.
+    pub fn i64_shr_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u64, _>(rhs, |lhs, rhs| lhs.shr(rhs & 0x3F))
+    }
+
+    /// Execute `i32.clz` Wasm operation.
+    pub fn i32_clz(self) -> Self {
+        self.execute_unary(<i32 as Integer<i32>>::leading_zeros)
+    }
+
+    /// Execute `i64.clz` Wasm operation.
+    pub fn i64_clz(self) -> Self {
+        self.execute_unary(<i64 as Integer<i64>>::leading_zeros)
+    }
+
+    /// Execute `i32.ctz` Wasm operation.
+    pub fn i32_ctz(self) -> Self {
+        self.execute_unary(<i32 as Integer<i32>>::trailing_zeros)
+    }
+
+    /// Execute `i64.ctz` Wasm operation.
+    pub fn i64_ctz(self) -> Self {
+        self.execute_unary(<i64 as Integer<i64>>::trailing_zeros)
+    }
+
+    /// Execute `i32.popcnt` Wasm operation.
+    pub fn i32_popcnt(self) -> Self {
+        self.execute_unary(<i32 as Integer<i32>>::count_ones)
+    }
+
+    /// Execute `i64.popcnt` Wasm operation.
+    pub fn i64_popcnt(self) -> Self {
+        self.execute_unary(<i64 as Integer<i64>>::count_ones)
+    }
+
+    /// Execute `i32.rotl` Wasm operation.
+    pub fn i32_rotl(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i32 as Integer<i32>>::rotl)
+    }
+
+    /// Execute `i64.rotl` Wasm operation.
+    pub fn i64_rotl(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i64 as Integer<i64>>::rotl)
+    }
+
+    /// Execute `i32.rotr` Wasm operation.
+    pub fn i32_rotr(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i32 as Integer<i32>>::rotr)
+    }
+
+    /// Execute `i64.rotr` Wasm operation.
+    pub fn i64_rotr(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <i64 as Integer<i64>>::rotr)
+    }
+
+    /// Execute `i32.eq` Wasm operation.
+    pub fn i32_eq(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, bool>(rhs, op!(==))
+    }
+
+    /// Execute `i64.eq` Wasm operation.
+    pub fn i64_eq(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, bool>(rhs, op!(==))
+    }
+
+    /// Execute `f32.eq` Wasm operation.
+    pub fn f32_eq(self, rhs: Self) -> Self {
+        self.execute_binary::<F32, bool>(rhs, op!(==))
+    }
+
+    /// Execute `f64.eq` Wasm operation.
+    pub fn f64_eq(self, rhs: Self) -> Self {
+        self.execute_binary::<F64, bool>(rhs, op!(==))
+    }
+
+    /// Execute `i32.ne` Wasm operation.
+    pub fn i32_ne(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, bool>(rhs, op!(!=))
+    }
+
+    /// Execute `i64.ne` Wasm operation.
+    pub fn i64_ne(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, bool>(rhs, op!(!=))
+    }
+
+    /// Execute `f32.ne` Wasm operation.
+    pub fn f32_ne(self, rhs: Self) -> Self {
+        self.execute_binary::<F32, bool>(rhs, op!(!=))
+    }
+
+    /// Execute `f64.ne` Wasm operation.
+    pub fn f64_ne(self, rhs: Self) -> Self {
+        self.execute_binary::<F64, bool>(rhs, op!(!=))
+    }
+
+    /// Execute `i32.lt_s` Wasm operation.
+    pub fn i32_lt_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, bool>(rhs, op!(<))
+    }
+
+    /// Execute `i64.lt_s` Wasm operation.
+    pub fn i64_lt_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, bool>(rhs, op!(<))
+    }
+
+    /// Execute `i32.lt_u` Wasm operation.
+    pub fn i32_lt_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u32, bool>(rhs, op!(<))
+    }
+
+    /// Execute `i64.lt_u` Wasm operation.
+    pub fn i64_lt_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u64, bool>(rhs, op!(<))
+    }
+
+    /// Execute `f32.lt` Wasm operation.
+    pub fn f32_lt(self, rhs: Self) -> Self {
+        self.execute_binary::<F32, bool>(rhs, op!(<))
+    }
+
+    /// Execute `f64.lt` Wasm operation.
+    pub fn f64_lt(self, rhs: Self) -> Self {
+        self.execute_binary::<F64, bool>(rhs, op!(<))
+    }
+
+    /// Execute `i32.le_s` Wasm operation.
+    pub fn i32_le_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, bool>(rhs, op!(<=))
+    }
+
+    /// Execute `i64.le_s` Wasm operation.
+    pub fn i64_le_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, bool>(rhs, op!(<=))
+    }
+
+    /// Execute `i32.le_u` Wasm operation.
+    pub fn i32_le_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u32, bool>(rhs, op!(<=))
+    }
+
+    /// Execute `i64.le_u` Wasm operation.
+    pub fn i64_le_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u64, bool>(rhs, op!(<=))
+    }
+
+    /// Execute `f32.le` Wasm operation.
+    pub fn f32_le(self, rhs: Self) -> Self {
+        self.execute_binary::<F32, bool>(rhs, op!(<=))
+    }
+
+    /// Execute `f64.le` Wasm operation.
+    pub fn f64_le(self, rhs: Self) -> Self {
+        self.execute_binary::<F64, bool>(rhs, op!(<=))
+    }
+
+    /// Execute `i32.gt_s` Wasm operation.
+    pub fn i32_gt_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, bool>(rhs, op!(>))
+    }
+
+    /// Execute `i64.gt_s` Wasm operation.
+    pub fn i64_gt_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, bool>(rhs, op!(>))
+    }
+
+    /// Execute `i32.gt_u` Wasm operation.
+    pub fn i32_gt_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u32, bool>(rhs, op!(>))
+    }
+
+    /// Execute `i64.gt_u` Wasm operation.
+    pub fn i64_gt_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u64, bool>(rhs, op!(>))
+    }
+
+    /// Execute `f32.gt` Wasm operation.
+    pub fn f32_gt(self, rhs: Self) -> Self {
+        self.execute_binary::<F32, bool>(rhs, op!(>))
+    }
+
+    /// Execute `f64.gt` Wasm operation.
+    pub fn f64_gt(self, rhs: Self) -> Self {
+        self.execute_binary::<F64, bool>(rhs, op!(>))
+    }
+
+    /// Execute `i32.ge_s` Wasm operation.
+    pub fn i32_ge_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i32, bool>(rhs, op!(>=))
+    }
+
+    /// Execute `i64.ge_s` Wasm operation.
+    pub fn i64_ge_s(self, rhs: Self) -> Self {
+        self.execute_binary::<i64, bool>(rhs, op!(>=))
+    }
+
+    /// Execute `i32.ge_u` Wasm operation.
+    pub fn i32_ge_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u32, bool>(rhs, op!(>=))
+    }
+
+    /// Execute `i64.ge_u` Wasm operation.
+    pub fn i64_ge_u(self, rhs: Self) -> Self {
+        self.execute_binary::<u64, bool>(rhs, op!(>=))
+    }
+
+    /// Execute `f32.ge` Wasm operation.
+    pub fn f32_ge(self, rhs: Self) -> Self {
+        self.execute_binary::<F32, bool>(rhs, op!(>=))
+    }
+
+    /// Execute `f64.ge` Wasm operation.
+    pub fn f64_ge(self, rhs: Self) -> Self {
+        self.execute_binary::<F64, bool>(rhs, op!(>=))
+    }
+
+    /// Execute `f32.abs` Wasm operation.
+    pub fn f32_abs(self) -> Self {
+        self.execute_unary(<F32 as Float<F32>>::abs)
+    }
+
+    /// Execute `f32.neg` Wasm operation.
+    pub fn f32_neg(self) -> Self {
+        self.execute_unary(<F32 as Neg>::neg)
+    }
+
+    /// Execute `f32.ceil` Wasm operation.
+    pub fn f32_ceil(self) -> Self {
+        self.execute_unary(<F32 as Float<F32>>::ceil)
+    }
+
+    /// Execute `f32.floor` Wasm operation.
+    pub fn f32_floor(self) -> Self {
+        self.execute_unary(<F32 as Float<F32>>::floor)
+    }
+
+    /// Execute `f32.trunc` Wasm operation.
+    pub fn f32_trunc(self) -> Self {
+        self.execute_unary(<F32 as Float<F32>>::trunc)
+    }
+
+    /// Execute `f32.nearest` Wasm operation.
+    pub fn f32_nearest(self) -> Self {
+        self.execute_unary(<F32 as Float<F32>>::nearest)
+    }
+
+    /// Execute `f32.sqrt` Wasm operation.
+    pub fn f32_sqrt(self) -> Self {
+        self.execute_unary(<F32 as Float<F32>>::sqrt)
+    }
+
+    /// Execute `f32.min` Wasm operation.
+    pub fn f32_min(self, other: Self) -> Self {
+        self.execute_binary(other, <F32 as Float<F32>>::min)
+    }
+
+    /// Execute `f32.max` Wasm operation.
+    pub fn f32_max(self, other: Self) -> Self {
+        self.execute_binary(other, <F32 as Float<F32>>::max)
+    }
+
+    /// Execute `f32.copysign` Wasm operation.
+    pub fn f32_copysign(self, other: Self) -> Self {
+        self.execute_binary(other, <F32 as Float<F32>>::copysign)
+    }
+
+    /// Execute `f64.abs` Wasm operation.
+    pub fn f64_abs(self) -> Self {
+        self.execute_unary(<F64 as Float<F64>>::abs)
+    }
+
+    /// Execute `f64.neg` Wasm operation.
+    pub fn f64_neg(self) -> Self {
+        self.execute_unary(<F64 as Neg>::neg)
+    }
+
+    /// Execute `f64.ceil` Wasm operation.
+    pub fn f64_ceil(self) -> Self {
+        self.execute_unary(<F64 as Float<F64>>::ceil)
+    }
+
+    /// Execute `f64.floor` Wasm operation.
+    pub fn f64_floor(self) -> Self {
+        self.execute_unary(<F64 as Float<F64>>::floor)
+    }
+
+    /// Execute `f64.trunc` Wasm operation.
+    pub fn f64_trunc(self) -> Self {
+        self.execute_unary(<F64 as Float<F64>>::trunc)
+    }
+
+    /// Execute `f64.nearest` Wasm operation.
+    pub fn f64_nearest(self) -> Self {
+        self.execute_unary(<F64 as Float<F64>>::nearest)
+    }
+
+    /// Execute `f64.sqrt` Wasm operation.
+    pub fn f64_sqrt(self) -> Self {
+        self.execute_unary(<F64 as Float<F64>>::sqrt)
+    }
+
+    /// Execute `f32.add` Wasm operation.
+    pub fn f32_add(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <F32 as ArithmeticOps<F32>>::add)
+    }
+
+    /// Execute `f64.add` Wasm operation.
+    pub fn f64_add(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <F64 as ArithmeticOps<F64>>::add)
+    }
+
+    /// Execute `f32.sub` Wasm operation.
+    pub fn f32_sub(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <F32 as ArithmeticOps<F32>>::sub)
+    }
+
+    /// Execute `f64.sub` Wasm operation.
+    pub fn f64_sub(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <F64 as ArithmeticOps<F64>>::sub)
+    }
+
+    /// Execute `f32.mul` Wasm operation.
+    pub fn f32_mul(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <F32 as ArithmeticOps<F32>>::mul)
+    }
+
+    /// Execute `f64.mul` Wasm operation.
+    pub fn f64_mul(self, rhs: Self) -> Self {
+        self.execute_binary(rhs, <F64 as ArithmeticOps<F64>>::mul)
+    }
+
+    /// Execute `f32.div` Wasm operation.
+    pub fn f32_div(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <F32 as ArithmeticOps<F32>>::div)
+    }
+
+    /// Execute `f64.div` Wasm operation.
+    pub fn f64_div(self, rhs: Self) -> Result<Self, TrapCode> {
+        self.try_execute_binary(rhs, <F64 as ArithmeticOps<F64>>::div)
+    }
+
+    /// Execute `f64.min` Wasm operation.
+    pub fn f64_min(self, other: Self) -> Self {
+        self.execute_binary(other, <F64 as Float<F64>>::min)
+    }
+
+    /// Execute `f64.max` Wasm operation.
+    pub fn f64_max(self, other: Self) -> Self {
+        self.execute_binary(other, <F64 as Float<F64>>::max)
+    }
+
+    /// Execute `f64.copysign` Wasm operation.
+    pub fn f64_copysign(self, other: Self) -> Self {
+        self.execute_binary(other, <F64 as Float<F64>>::copysign)
+    }
+
+    /// Execute `i32.wrap_i64` Wasm operation.
+    pub fn i32_wrap_i64(self) -> Self {
+        self.execute_unary(<i64 as WrapInto<i32>>::wrap_into)
+    }
+
+    /// Execute `i32.trunc_f32_s` Wasm operation.
+    pub fn i32_trunc_f32_s(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F32 as TryTruncateInto<i32, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i32.trunc_f32_u` Wasm operation.
+    pub fn i32_trunc_f32_u(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F32 as TryTruncateInto<u32, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i32.trunc_f64_s` Wasm operation.
+    pub fn i32_trunc_f64_s(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F64 as TryTruncateInto<i32, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i32.trunc_f64_u` Wasm operation.
+    pub fn i32_trunc_f64_u(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F64 as TryTruncateInto<u32, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i64.extend_i32_s` Wasm operation.
+    pub fn i64_extend_i32_s(self) -> Self {
+        self.execute_unary(<i32 as ExtendInto<i64>>::extend_into)
+    }
+
+    /// Execute `i64.extend_i32_u` Wasm operation.
+    pub fn i64_extend_i32_u(self) -> Self {
+        self.execute_unary(<u32 as ExtendInto<i64>>::extend_into)
+    }
+
+    /// Execute `i64.trunc_f32_s` Wasm operation.
+    pub fn i64_trunc_f32_s(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F32 as TryTruncateInto<i64, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i64.trunc_f32_u` Wasm operation.
+    pub fn i64_trunc_f32_u(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F32 as TryTruncateInto<u64, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i64.trunc_f64_s` Wasm operation.
+    pub fn i64_trunc_f64_s(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F64 as TryTruncateInto<i64, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `i64.trunc_f64_u` Wasm operation.
+    pub fn i64_trunc_f64_u(self) -> Result<Self, TrapCode> {
+        self.try_execute_unary(<F64 as TryTruncateInto<u64, TrapCode>>::try_truncate_into)
+    }
+
+    /// Execute `f32.convert_i32_s` Wasm operation.
+    pub fn f32_convert_i32_s(self) -> Self {
+        self.execute_unary(<i32 as ExtendInto<F32>>::extend_into)
+    }
+
+    /// Execute `f32.convert_i32_u` Wasm operation.
+    pub fn f32_convert_i32_u(self) -> Self {
+        self.execute_unary(<u32 as ExtendInto<F32>>::extend_into)
+    }
+
+    /// Execute `f32.convert_i64_s` Wasm operation.
+    pub fn f32_convert_i64_s(self) -> Self {
+        self.execute_unary(<i64 as WrapInto<F32>>::wrap_into)
+    }
+
+    /// Execute `f32.convert_i64_u` Wasm operation.
+    pub fn f32_convert_i64_u(self) -> Self {
+        self.execute_unary(<u64 as WrapInto<F32>>::wrap_into)
+    }
+
+    /// Execute `f32.demote_f64` Wasm operation.
+    pub fn f32_demote_f64(self) -> Self {
+        self.execute_unary(<F64 as WrapInto<F32>>::wrap_into)
+    }
+
+    /// Execute `f64.convert_i32_s` Wasm operation.
+    pub fn f64_convert_i32_s(self) -> Self {
+        self.execute_unary(<i32 as ExtendInto<F64>>::extend_into)
+    }
+
+    /// Execute `f64.convert_i32_u` Wasm operation.
+    pub fn f64_convert_i32_u(self) -> Self {
+        self.execute_unary(<u32 as ExtendInto<F64>>::extend_into)
+    }
+
+    /// Execute `f64.convert_i64_s` Wasm operation.
+    pub fn f64_convert_i64_s(self) -> Self {
+        self.execute_unary(<i64 as ExtendInto<F64>>::extend_into)
+    }
+
+    /// Execute `f64.convert_i64_u` Wasm operation.
+    pub fn f64_convert_i64_u(self) -> Self {
+        self.execute_unary(<u64 as ExtendInto<F64>>::extend_into)
+    }
+
+    /// Execute `f64.promote_f32` Wasm operation.
+    pub fn f64_promote_f32(self) -> Self {
+        self.execute_unary(<F32 as ExtendInto<F64>>::extend_into)
+    }
+
+    /// Execute `i32.extend8_s` Wasm operation.
+    pub fn i32_extend8_s(self) -> Self {
+        self.execute_unary(<i32 as SignExtendFrom<i8>>::sign_extend_from)
+    }
+
+    /// Execute `i32.extend16_s` Wasm operation.
+    pub fn i32_extend16_s(self) -> Self {
+        self.execute_unary(<i32 as SignExtendFrom<i16>>::sign_extend_from)
+    }
+
+    /// Execute `i64.extend8_s` Wasm operation.
+    pub fn i64_extend8_s(self) -> Self {
+        self.execute_unary(<i64 as SignExtendFrom<i8>>::sign_extend_from)
+    }
+
+    /// Execute `i64.extend16_s` Wasm operation.
+    pub fn i64_extend16_s(self) -> Self {
+        self.execute_unary(<i64 as SignExtendFrom<i16>>::sign_extend_from)
+    }
+
+    /// Execute `i64.extend32_s` Wasm operation.
+    pub fn i64_extend32_s(self) -> Self {
+        self.execute_unary(<i64 as SignExtendFrom<i32>>::sign_extend_from)
+    }
+
+    /// Execute `i32.trunc_sat_f32_s` Wasm operation.
+    pub fn i32_trunc_sat_f32_s(self) -> Self {
+        self.execute_unary(<F32 as TruncateSaturateInto<i32>>::truncate_saturate_into)
+    }
+
+    /// Execute `i32.trunc_sat_f32_u` Wasm operation.
+    pub fn i32_trunc_sat_f32_u(self) -> Self {
+        self.execute_unary(<F32 as TruncateSaturateInto<u32>>::truncate_saturate_into)
+    }
+
+    /// Execute `i32.trunc_sat_f64_s` Wasm operation.
+    pub fn i32_trunc_sat_f64_s(self) -> Self {
+        self.execute_unary(<F64 as TruncateSaturateInto<i32>>::truncate_saturate_into)
+    }
+
+    /// Execute `i32.trunc_sat_f64_u` Wasm operation.
+    pub fn i32_trunc_sat_f64_u(self) -> Self {
+        self.execute_unary(<F64 as TruncateSaturateInto<u32>>::truncate_saturate_into)
+    }
+
+    /// Execute `i64.trunc_sat_f32_s` Wasm operation.
+    pub fn i64_trunc_sat_f32_s(self) -> Self {
+        self.execute_unary(<F32 as TruncateSaturateInto<i64>>::truncate_saturate_into)
+    }
+
+    /// Execute `i64.trunc_sat_f32_u` Wasm operation.
+    pub fn i64_trunc_sat_f32_u(self) -> Self {
+        self.execute_unary(<F32 as TruncateSaturateInto<u64>>::truncate_saturate_into)
+    }
+
+    /// Execute `i64.trunc_sat_f64_s` Wasm operation.
+    pub fn i64_trunc_sat_f64_s(self) -> Self {
+        self.execute_unary(<F64 as TruncateSaturateInto<i64>>::truncate_saturate_into)
+    }
+
+    /// Execute `i64.trunc_sat_f64_u` Wasm operation.
+    pub fn i64_trunc_sat_f64_u(self) -> Self {
+        self.execute_unary(<F64 as TruncateSaturateInto<u64>>::truncate_saturate_into)
+    }
+}

--- a/core/src/untyped.rs
+++ b/core/src/untyped.rs
@@ -51,7 +51,7 @@ macro_rules! impl_from_untyped_for_int {
         )*
     };
 }
-impl_from_untyped_for_int!(i32, i64, u32, u64);
+impl_from_untyped_for_int!(i8, i16, i32, i64, u8, u16, u32, u64);
 
 macro_rules! impl_from_untyped_for_float {
     ( $( $float:ty ),* $(,)? ) => {
@@ -65,6 +65,12 @@ macro_rules! impl_from_untyped_for_float {
     };
 }
 impl_from_untyped_for_float!(f32, f64, F32, F64);
+
+impl From<UntypedValue> for bool {
+    fn from(untyped: UntypedValue) -> Self {
+        untyped.to_bits() != 0
+    }
+}
 
 impl From<Value> for UntypedValue {
     fn from(value: Value) -> Self {

--- a/core/src/untyped.rs
+++ b/core/src/untyped.rs
@@ -953,7 +953,7 @@ macro_rules! impl_decode_untyped_slice {
                             <$tuple as From<UntypedValue>>::from($tuple),
                         )*
                     )),
-                    unexpected => {
+                    _unexpected => {
                         Err(UntypedError::InvalidLen {
                             expected: $n,
                             found: results.len(),

--- a/core/src/untyped.rs
+++ b/core/src/untyped.rs
@@ -351,6 +351,16 @@ impl UntypedValue {
         self.execute_binary(rhs, <i64 as Integer<i64>>::rotr)
     }
 
+    /// Execute `i32.eqz` Wasm operation.
+    pub fn i32_eqz(self) -> Self {
+        self.execute_unary::<i32, bool>(|value| value == 0)
+    }
+
+    /// Execute `i64.eqz` Wasm operation.
+    pub fn i64_eqz(self) -> Self {
+        self.execute_unary::<i64, bool>(|value| value == 0)
+    }
+
     /// Execute `i32.eq` Wasm operation.
     pub fn i32_eq(self, rhs: Self) -> Self {
         self.execute_binary::<i32, bool>(rhs, op!(==))

--- a/wasmi_v1/src/engine/bytecode/mod.rs
+++ b/wasmi_v1/src/engine/bytecode/mod.rs
@@ -10,7 +10,7 @@ pub use self::{
     utils::{BrTable, DropKeep, FuncIdx, GlobalIdx, LocalIdx, Offset, SignatureIdx, Target},
     visitor::VisitInstruction,
 };
-use super::value_stack::StackEntry;
+use wasmi_core::UntypedValue;
 
 /// The internal `wasmi` bytecode that is stored for Wasm functions.
 ///
@@ -71,7 +71,7 @@ pub enum Instruction {
     I64Store32(Offset),
     CurrentMemory,
     GrowMemory,
-    Const(StackEntry),
+    Const(UntypedValue),
     I32Eqz,
     I32Eq,
     I32Ne,
@@ -251,7 +251,7 @@ impl Instruction {
     /// Creates a new `Const` instruction from the given value.
     pub fn constant<T>(value: T) -> Self
     where
-        T: Into<StackEntry>,
+        T: Into<UntypedValue>,
     {
         Self::Const(value.into())
     }

--- a/wasmi_v1/src/engine/bytecode/visitor.rs
+++ b/wasmi_v1/src/engine/bytecode/visitor.rs
@@ -1,5 +1,5 @@
 use super::{BrTable, DropKeep, FuncIdx, GlobalIdx, LocalIdx, Offset, SignatureIdx, Target};
-use crate::engine::value_stack::StackEntry;
+use wasmi_core::UntypedValue;
 
 pub trait VisitInstruction {
     type Outcome;
@@ -17,7 +17,7 @@ pub trait VisitInstruction {
     fn visit_set_global(&mut self, global_idx: GlobalIdx) -> Self::Outcome;
     fn visit_call(&mut self, func: FuncIdx) -> Self::Outcome;
     fn visit_call_indirect(&mut self, signature: SignatureIdx) -> Self::Outcome;
-    fn visit_const(&mut self, bytes: StackEntry) -> Self::Outcome;
+    fn visit_const(&mut self, bytes: UntypedValue) -> Self::Outcome;
     fn visit_unreachable(&mut self) -> Self::Outcome;
     fn visit_drop(&mut self) -> Self::Outcome;
     fn visit_select(&mut self) -> Self::Outcome;

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -15,13 +15,7 @@ use crate::{
     core::{Trap, TrapCode, F32, F64},
     Func,
 };
-use wasmi_core::{
-    memory_units::Pages,
-    ExtendInto,
-    LittleEndianConvert,
-    UntypedValue,
-    WrapInto,
-};
+use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedValue, WrapInto};
 
 /// The outcome of a `wasmi` instruction execution.
 ///

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -308,7 +308,7 @@ where
         Ok(ExecutionOutcome::Continue)
     }
 
-    fn execute_eqz(
+    fn execute_unary(
         &mut self,
         f: fn(UntypedValue) -> UntypedValue,
     ) -> Result<ExecutionOutcome, Trap> {
@@ -317,7 +317,7 @@ where
         Ok(ExecutionOutcome::Continue)
     }
 
-    fn execute_cmp(
+    fn execute_binary(
         &mut self,
         f: fn(UntypedValue, UntypedValue) -> UntypedValue,
     ) -> Result<ExecutionOutcome, Trap> {
@@ -891,139 +891,139 @@ where
     }
 
     fn visit_i32_eqz(&mut self) -> Self::Outcome {
-        self.execute_eqz(UntypedValue::i32_eqz)
+        self.execute_unary(UntypedValue::i32_eqz)
     }
 
     fn visit_i32_eq(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_eq)
+        self.execute_binary(UntypedValue::i32_eq)
     }
 
     fn visit_i32_ne(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_ne)
+        self.execute_binary(UntypedValue::i32_ne)
     }
 
     fn visit_i32_lt_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_lt_s)
+        self.execute_binary(UntypedValue::i32_lt_s)
     }
 
     fn visit_i32_lt_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_lt_u)
+        self.execute_binary(UntypedValue::i32_lt_u)
     }
 
     fn visit_i32_gt_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_gt_s)
+        self.execute_binary(UntypedValue::i32_gt_s)
     }
 
     fn visit_i32_gt_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_gt_u)
+        self.execute_binary(UntypedValue::i32_gt_u)
     }
 
     fn visit_i32_le_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_le_s)
+        self.execute_binary(UntypedValue::i32_le_s)
     }
 
     fn visit_i32_le_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_le_u)
+        self.execute_binary(UntypedValue::i32_le_u)
     }
 
     fn visit_i32_ge_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_ge_s)
+        self.execute_binary(UntypedValue::i32_ge_s)
     }
 
     fn visit_i32_ge_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i32_ge_u)
+        self.execute_binary(UntypedValue::i32_ge_u)
     }
 
     fn visit_i64_eqz(&mut self) -> Self::Outcome {
-        self.execute_eqz(UntypedValue::i64_eqz)
+        self.execute_unary(UntypedValue::i64_eqz)
     }
 
     fn visit_i64_eq(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_eq)
+        self.execute_binary(UntypedValue::i64_eq)
     }
 
     fn visit_i64_ne(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_ne)
+        self.execute_binary(UntypedValue::i64_ne)
     }
 
     fn visit_i64_lt_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_lt_s)
+        self.execute_binary(UntypedValue::i64_lt_s)
     }
 
     fn visit_i64_lt_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_lt_u)
+        self.execute_binary(UntypedValue::i64_lt_u)
     }
 
     fn visit_i64_gt_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_gt_s)
+        self.execute_binary(UntypedValue::i64_gt_s)
     }
 
     fn visit_i64_gt_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_gt_u)
+        self.execute_binary(UntypedValue::i64_gt_u)
     }
 
     fn visit_i64_le_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_le_s)
+        self.execute_binary(UntypedValue::i64_le_s)
     }
 
     fn visit_i64_le_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_le_u)
+        self.execute_binary(UntypedValue::i64_le_u)
     }
 
     fn visit_i64_ge_s(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_ge_s)
+        self.execute_binary(UntypedValue::i64_ge_s)
     }
 
     fn visit_i64_ge_u(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::i64_ge_u)
+        self.execute_binary(UntypedValue::i64_ge_u)
     }
 
     fn visit_f32_eq(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f32_eq)
+        self.execute_binary(UntypedValue::f32_eq)
     }
 
     fn visit_f32_ne(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f32_ne)
+        self.execute_binary(UntypedValue::f32_ne)
     }
 
     fn visit_f32_lt(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f32_lt)
+        self.execute_binary(UntypedValue::f32_lt)
     }
 
     fn visit_f32_gt(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f32_gt)
+        self.execute_binary(UntypedValue::f32_gt)
     }
 
     fn visit_f32_le(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f32_le)
+        self.execute_binary(UntypedValue::f32_le)
     }
 
     fn visit_f32_ge(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f32_ge)
+        self.execute_binary(UntypedValue::f32_ge)
     }
 
     fn visit_f64_eq(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f64_eq)
+        self.execute_binary(UntypedValue::f64_eq)
     }
 
     fn visit_f64_ne(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f64_ne)
+        self.execute_binary(UntypedValue::f64_ne)
     }
 
     fn visit_f64_lt(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f64_lt)
+        self.execute_binary(UntypedValue::f64_lt)
     }
 
     fn visit_f64_gt(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f64_gt)
+        self.execute_binary(UntypedValue::f64_gt)
     }
 
     fn visit_f64_le(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f64_le)
+        self.execute_binary(UntypedValue::f64_le)
     }
 
     fn visit_f64_ge(&mut self) -> Self::Outcome {
-        self.execute_cmp(UntypedValue::f64_ge)
+        self.execute_binary(UntypedValue::f64_ge)
     }
 
     fn visit_i32_clz(&mut self) -> Self::Outcome {

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -308,75 +308,24 @@ where
         Ok(ExecutionOutcome::Continue)
     }
 
-    fn execute_eqz<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue>,
-        T: PartialEq<T> + Default,
-    {
+    fn execute_eqz(
+        &mut self,
+        f: fn(UntypedValue) -> UntypedValue,
+    ) -> Result<ExecutionOutcome, Trap> {
         let entry = self.value_stack.last_mut();
-        let value = T::from(*entry);
-        let zero = Default::default();
-        let result = value == zero;
-        *entry = result.into();
+        *entry = f(*entry);
         Ok(ExecutionOutcome::Continue)
     }
 
-    /// Executes a relative operation given the top two stack values.
-    ///
-    /// After success the top of the stack will store the result.
-    fn execute_relop<T, F>(&mut self, f: F) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue>,
-        F: FnOnce(T, T) -> bool,
-    {
-        let right = self.value_stack.pop_as::<T>();
+    fn execute_cmp(
+        &mut self,
+        f: fn(UntypedValue, UntypedValue) -> UntypedValue,
+    ) -> Result<ExecutionOutcome, Trap> {
+        let right = self.value_stack.pop();
         let entry = self.value_stack.last_mut();
-        let left = T::from(*entry);
-        let result = f(left, right);
-        *entry = result.into();
+        let left = *entry;
+        *entry = f(left, right);
         Ok(ExecutionOutcome::Continue)
-    }
-
-    fn execute_eq<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue> + PartialEq,
-    {
-        self.execute_relop(|left: T, right: T| left == right)
-    }
-
-    fn execute_ne<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue> + PartialEq,
-    {
-        self.execute_relop(|left: T, right: T| left != right)
-    }
-
-    fn execute_lt<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue> + PartialOrd,
-    {
-        self.execute_relop(|left: T, right: T| left < right)
-    }
-
-    fn execute_le<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue> + PartialOrd,
-    {
-        self.execute_relop(|left: T, right: T| left <= right)
-    }
-
-    fn execute_gt<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue> + PartialOrd,
-    {
-        self.execute_relop(|left: T, right: T| left > right)
-    }
-
-    fn execute_ge<T>(&mut self) -> Result<ExecutionOutcome, Trap>
-    where
-        T: From<UntypedValue> + PartialOrd,
-    {
-        self.execute_relop(|left: T, right: T| left >= right)
     }
 
     fn execute_unop<T, U, F>(&mut self, f: F) -> Result<ExecutionOutcome, Trap>
@@ -942,139 +891,139 @@ where
     }
 
     fn visit_i32_eqz(&mut self) -> Self::Outcome {
-        self.execute_eqz::<i32>()
+        self.execute_eqz(UntypedValue::i32_eqz)
     }
 
     fn visit_i32_eq(&mut self) -> Self::Outcome {
-        self.execute_eq::<i32>()
+        self.execute_cmp(UntypedValue::i32_eq)
     }
 
     fn visit_i32_ne(&mut self) -> Self::Outcome {
-        self.execute_ne::<i32>()
+        self.execute_cmp(UntypedValue::i32_ne)
     }
 
     fn visit_i32_lt_s(&mut self) -> Self::Outcome {
-        self.execute_lt::<i32>()
+        self.execute_cmp(UntypedValue::i32_lt_s)
     }
 
     fn visit_i32_lt_u(&mut self) -> Self::Outcome {
-        self.execute_lt::<u32>()
+        self.execute_cmp(UntypedValue::i32_lt_u)
     }
 
     fn visit_i32_gt_s(&mut self) -> Self::Outcome {
-        self.execute_gt::<i32>()
+        self.execute_cmp(UntypedValue::i32_gt_s)
     }
 
     fn visit_i32_gt_u(&mut self) -> Self::Outcome {
-        self.execute_gt::<u32>()
+        self.execute_cmp(UntypedValue::i32_gt_u)
     }
 
     fn visit_i32_le_s(&mut self) -> Self::Outcome {
-        self.execute_le::<i32>()
+        self.execute_cmp(UntypedValue::i32_le_s)
     }
 
     fn visit_i32_le_u(&mut self) -> Self::Outcome {
-        self.execute_le::<u32>()
+        self.execute_cmp(UntypedValue::i32_le_u)
     }
 
     fn visit_i32_ge_s(&mut self) -> Self::Outcome {
-        self.execute_ge::<i32>()
+        self.execute_cmp(UntypedValue::i32_ge_s)
     }
 
     fn visit_i32_ge_u(&mut self) -> Self::Outcome {
-        self.execute_ge::<u32>()
+        self.execute_cmp(UntypedValue::i32_ge_u)
     }
 
     fn visit_i64_eqz(&mut self) -> Self::Outcome {
-        self.execute_eqz::<i64>()
+        self.execute_eqz(UntypedValue::i64_eqz)
     }
 
     fn visit_i64_eq(&mut self) -> Self::Outcome {
-        self.execute_eq::<i64>()
+        self.execute_cmp(UntypedValue::i64_eq)
     }
 
     fn visit_i64_ne(&mut self) -> Self::Outcome {
-        self.execute_ne::<i64>()
+        self.execute_cmp(UntypedValue::i64_ne)
     }
 
     fn visit_i64_lt_s(&mut self) -> Self::Outcome {
-        self.execute_lt::<i64>()
+        self.execute_cmp(UntypedValue::i64_lt_s)
     }
 
     fn visit_i64_lt_u(&mut self) -> Self::Outcome {
-        self.execute_lt::<u64>()
+        self.execute_cmp(UntypedValue::i64_lt_u)
     }
 
     fn visit_i64_gt_s(&mut self) -> Self::Outcome {
-        self.execute_gt::<i64>()
+        self.execute_cmp(UntypedValue::i64_gt_s)
     }
 
     fn visit_i64_gt_u(&mut self) -> Self::Outcome {
-        self.execute_gt::<u64>()
+        self.execute_cmp(UntypedValue::i64_gt_u)
     }
 
     fn visit_i64_le_s(&mut self) -> Self::Outcome {
-        self.execute_le::<i64>()
+        self.execute_cmp(UntypedValue::i64_le_s)
     }
 
     fn visit_i64_le_u(&mut self) -> Self::Outcome {
-        self.execute_le::<u64>()
+        self.execute_cmp(UntypedValue::i64_le_u)
     }
 
     fn visit_i64_ge_s(&mut self) -> Self::Outcome {
-        self.execute_ge::<i64>()
+        self.execute_cmp(UntypedValue::i64_ge_s)
     }
 
     fn visit_i64_ge_u(&mut self) -> Self::Outcome {
-        self.execute_ge::<u64>()
+        self.execute_cmp(UntypedValue::i64_ge_u)
     }
 
     fn visit_f32_eq(&mut self) -> Self::Outcome {
-        self.execute_eq::<F32>()
+        self.execute_cmp(UntypedValue::f32_eq)
     }
 
     fn visit_f32_ne(&mut self) -> Self::Outcome {
-        self.execute_ne::<F32>()
+        self.execute_cmp(UntypedValue::f32_ne)
     }
 
     fn visit_f32_lt(&mut self) -> Self::Outcome {
-        self.execute_lt::<F32>()
+        self.execute_cmp(UntypedValue::f32_lt)
     }
 
     fn visit_f32_gt(&mut self) -> Self::Outcome {
-        self.execute_gt::<F32>()
+        self.execute_cmp(UntypedValue::f32_gt)
     }
 
     fn visit_f32_le(&mut self) -> Self::Outcome {
-        self.execute_le::<F32>()
+        self.execute_cmp(UntypedValue::f32_le)
     }
 
     fn visit_f32_ge(&mut self) -> Self::Outcome {
-        self.execute_ge::<F32>()
+        self.execute_cmp(UntypedValue::f32_ge)
     }
 
     fn visit_f64_eq(&mut self) -> Self::Outcome {
-        self.execute_eq::<F64>()
+        self.execute_cmp(UntypedValue::f64_eq)
     }
 
     fn visit_f64_ne(&mut self) -> Self::Outcome {
-        self.execute_ne::<F64>()
+        self.execute_cmp(UntypedValue::f64_ne)
     }
 
     fn visit_f64_lt(&mut self) -> Self::Outcome {
-        self.execute_lt::<F64>()
+        self.execute_cmp(UntypedValue::f64_lt)
     }
 
     fn visit_f64_gt(&mut self) -> Self::Outcome {
-        self.execute_gt::<F64>()
+        self.execute_cmp(UntypedValue::f64_gt)
     }
 
     fn visit_f64_le(&mut self) -> Self::Outcome {
-        self.execute_le::<F64>()
+        self.execute_cmp(UntypedValue::f64_le)
     }
 
     fn visit_f64_ge(&mut self) -> Self::Outcome {
-        self.execute_ge::<F64>()
+        self.execute_cmp(UntypedValue::f64_ge)
     }
 
     fn visit_i32_clz(&mut self) -> Self::Outcome {

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -1,6 +1,5 @@
-use super::StackEntry;
 use core::cmp;
-use wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice};
+use wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedValue};
 
 #[derive(Debug)]
 pub struct FuncParams<'a> {
@@ -11,7 +10,7 @@ pub struct FuncParams<'a> {
     /// Therefore the length of the slice must be large enough
     /// to hold all parameters and all results but not both at
     /// the same time.
-    params_results: &'a mut [StackEntry],
+    params_results: &'a mut [UntypedValue],
     /// The length of the expected parameters of the function invocation.
     len_params: usize,
     /// The length of the expected results of the function invocation.
@@ -31,7 +30,7 @@ impl<'a> FuncParams<'a> {
     /// If the length of hte `params_results` slice does not match the maximum
     /// of the `len_params` and `Len_results`.
     pub fn new(
-        params_results: &'a mut [StackEntry],
+        params_results: &'a mut [UntypedValue],
         len_params: usize,
         len_results: usize,
     ) -> Self {
@@ -53,7 +52,7 @@ impl<'a> FuncParams<'a> {
         T: DecodeUntypedSlice,
     {
         let params_buffer = &self.params_results[..self.len_params];
-        StackEntry::decode_slice::<T>(params_buffer)
+        UntypedValue::decode_slice::<T>(params_buffer)
             .unwrap_or_else(|error| panic!("encountered unexpected invalid tuple length: {error}"))
     }
 
@@ -67,7 +66,7 @@ impl<'a> FuncParams<'a> {
         T: EncodeUntypedSlice,
     {
         let results_buffer = &mut self.params_results[..self.len_results];
-        StackEntry::encode_slice::<T>(results_buffer, results)
+        UntypedValue::encode_slice::<T>(results_buffer, results)
             .unwrap_or_else(|error| panic!("encountered unexpected invalid tuple length: {error}"));
         FuncResults {}
     }

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -1,6 +1,6 @@
-use super::{FromStackEntry, StackEntry};
-use crate::foreach_tuple::for_each_tuple;
+use super::StackEntry;
 use core::cmp;
+use wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice};
 
 #[derive(Debug)]
 pub struct FuncParams<'a> {
@@ -50,10 +50,11 @@ impl<'a> FuncParams<'a> {
     /// If the number of function parameters dictated by `T` does not match.
     pub fn read_params<T>(&self) -> T
     where
-        T: ReadParams,
+        T: DecodeUntypedSlice,
     {
         let params_buffer = &self.params_results[..self.len_params];
-        <T as ReadParams>::read_params(params_buffer)
+        StackEntry::decode_slice::<T>(params_buffer)
+            .unwrap_or_else(|error| panic!("encountered unexpected invalid tuple length: {error}"))
     }
 
     /// Sets the results of the function invocation.
@@ -63,116 +64,11 @@ impl<'a> FuncParams<'a> {
     /// If the number of results does not match the expected amount.
     pub fn write_results<T>(self, results: T) -> FuncResults
     where
-        T: WriteResults,
+        T: EncodeUntypedSlice,
     {
         let results_buffer = &mut self.params_results[..self.len_results];
-        <T as WriteResults>::write_results(results, results_buffer);
+        StackEntry::encode_slice::<T>(results_buffer, results)
+            .unwrap_or_else(|error| panic!("encountered unexpected invalid tuple length: {error}"));
         FuncResults {}
     }
 }
-
-/// Types that can be used with the `wasmi` `v1` engine as inputs and outputs.
-pub trait WasmType: FromStackEntry + Into<StackEntry> {}
-
-impl<T> WasmType for T where T: FromStackEntry + Into<StackEntry> {}
-
-/// Type sequences that can read host function parameters from the [`ValueStack`].
-///
-/// [`ValueStack`]: [`crate::engine::ValueStack`]
-pub trait ReadParams {
-    /// Reads the host parameters from the given [`ValueStack`] region.
-    ///
-    /// # Panics
-    ///
-    /// If the length of the [`ValueStack`] region does not match.
-    ///
-    /// [`ValueStack`]: [`crate::engine::ValueStack`]
-    fn read_params(params: &[StackEntry]) -> Self;
-}
-
-impl<T1> ReadParams for T1
-where
-    T1: WasmType,
-{
-    fn read_params(results: &[StackEntry]) -> Self {
-        assert_eq!(results.len(), 1);
-        <T1 as FromStackEntry>::from_stack_entry(results[0])
-    }
-}
-
-macro_rules! impl_read_params {
-    ( $n:literal $( $tuple:ident )* ) => {
-        impl<$($tuple),*> ReadParams for ($($tuple,)*)
-        where
-            $(
-                $tuple: WasmType
-            ),*
-        {
-            #[allow(non_snake_case)]
-            fn read_params(results: &[StackEntry]) -> Self {
-                match results {
-                    &[$($tuple),*] => (
-                        $(
-                            <$tuple as FromStackEntry>::from_stack_entry($tuple),
-                        )*
-                    ),
-                    unexpected => {
-                        panic!(
-                            "expected slice with {} elements but found: {:?}",
-                            $n,
-                            unexpected,
-                        )
-                    }
-                }
-            }
-        }
-    };
-}
-for_each_tuple!(impl_read_params);
-
-/// Type sequences that can write results back into the [`ValueStack`].
-///
-/// [`ValueStack`]: [`crate::engine::ValueStack`]
-pub trait WriteResults {
-    /// Writes the `results` into the given [`ValueStack`] region.
-    ///
-    /// # Panics
-    ///
-    /// If the length of the [`ValueStack`] region does not match.
-    ///
-    /// [`ValueStack`]: [`crate::engine::ValueStack`]
-    fn write_results(self, results: &mut [StackEntry]);
-}
-
-impl<T1> WriteResults for T1
-where
-    T1: WasmType,
-{
-    fn write_results(self, results: &mut [StackEntry]) {
-        assert_eq!(results.len(), 1);
-        results[0] = self.into();
-    }
-}
-
-macro_rules! impl_write_params {
-    ( $n:literal $( $tuple:ident )* ) => {
-        impl<$($tuple),*> WriteResults for ($($tuple,)*)
-        where
-            $(
-                $tuple: WasmType
-            ),*
-        {
-            #[allow(non_snake_case)]
-            fn write_results(self, results: &mut [StackEntry]) {
-                let ($($tuple,)*) = self;
-                let converted: [StackEntry; $n] = [
-                    $(
-                        <$tuple as Into<StackEntry>>::into($tuple)
-                    ),*
-                ];
-                results.copy_from_slice(&converted);
-            }
-        }
-    };
-}
-for_each_tuple!(impl_write_params);

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -10,7 +10,7 @@ mod func_types;
 mod traits;
 pub mod value_stack;
 
-pub(crate) use self::func_args::{FuncParams, FuncResults, ReadParams, WasmType, WriteResults};
+pub(crate) use self::func_args::{FuncParams, FuncResults};
 pub use self::{
     bytecode::{DropKeep, Target},
     code_map::FuncBody,
@@ -23,7 +23,7 @@ use self::{
     code_map::{CodeMap, ResolvedFuncBody},
     exec_context::ExecutionContext,
     func_types::FuncTypeRegistry,
-    value_stack::{FromStackEntry, StackEntry, ValueStack},
+    value_stack::{StackEntry, ValueStack},
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func};
 use crate::{

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -23,7 +23,7 @@ use self::{
     code_map::{CodeMap, ResolvedFuncBody},
     exec_context::ExecutionContext,
     func_types::FuncTypeRegistry,
-    value_stack::{StackEntry, ValueStack},
+    value_stack::ValueStack,
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func};
 use crate::{

--- a/wasmi_v1/src/engine/value_stack.rs
+++ b/wasmi_v1/src/engine/value_stack.rs
@@ -177,7 +177,7 @@ impl ValueStack {
         &mut self.entries[self.stack_ptr - depth - 1]
     }
 
-    /// Pops the last [`StackEntry`] from the [`ValueStack`].
+    /// Pops the last [`UntypedValue`] from the [`ValueStack`].
     ///
     /// # Note
     ///
@@ -192,7 +192,7 @@ impl ValueStack {
         self.stack_ptr -= depth;
     }
 
-    /// Pops the last [`StackEntry`] from the [`ValueStack`] as `T`.
+    /// Pops the last [`UntypedValue`] from the [`ValueStack`] as `T`.
     pub fn pop_as<T>(&mut self) -> T
     where
         T: From<UntypedValue>,
@@ -200,7 +200,7 @@ impl ValueStack {
         T::from(self.pop())
     }
 
-    /// Pops the last pair of [`StackEntry`] from the [`ValueStack`].
+    /// Pops the last pair of [`UntypedValue`] from the [`ValueStack`].
     ///
     /// # Note
     ///
@@ -233,7 +233,7 @@ impl ValueStack {
         f(e1, e2, e3)
     }
 
-    /// Pushes the [`StackEntry`] to the end of the [`ValueStack`].
+    /// Pushes the [`UntypedValue`] to the end of the [`ValueStack`].
     ///
     /// # Note
     ///

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -1,15 +1,15 @@
 use super::{
-    super::engine::{FuncParams, FuncResults, WasmType as InternalWasmType},
+    super::engine::{FuncParams, FuncResults},
     HostFuncTrampoline,
 };
 use crate::{
     core::{FromValue, Trap, Value, ValueType, F32, F64},
-    engine::{ReadParams, WriteResults},
     foreach_tuple::for_each_tuple,
     Caller,
     FuncType,
 };
 use core::{array, iter::FusedIterator};
+use wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedValue};
 
 /// Closures and functions that can be used as host functions.
 pub trait IntoFunc<T, Params, Results>: Send + Sync + 'static {
@@ -139,7 +139,7 @@ macro_rules! impl_wasm_return_type {
 for_each_tuple!(impl_wasm_return_type);
 
 /// Types that can be used as parameters or results of host functions.
-pub trait WasmType: FromValue + Into<Value> + InternalWasmType {
+pub trait WasmType: FromValue + Into<Value> + From<UntypedValue> + Into<UntypedValue> {
     /// Returns the value type of the Wasm type.
     fn value_type() -> ValueType;
 }
@@ -174,7 +174,7 @@ impl_wasm_type! {
 /// - Write host function results into a region of the value stack.
 /// - Iterate over the value types of the Wasm type sequence
 ///     - This is useful to construct host function signatures.
-pub trait WasmTypeList: ReadParams + WriteResults + Sized {
+pub trait WasmTypeList: DecodeUntypedSlice + EncodeUntypedSlice + Sized {
     /// The number of Wasm types in the list.
     const LEN: usize;
 


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/368.

Maybe we also want to support Wasm `load` and `store` operations but I have not yet come up with a decent API for those.
Also for completeness we could support `const` operations such as `i32.const`:

```rust
/// Executes `i32.const` Wasm operation.
pub fn i32_const(value: i32) -> Self {
    Self::from(value)
}
```

Does not do a lot though.

Due to missing never-impls in Rust we have to move the `ReadParams` and `WriteResults` API from `wasmi_v1` into `wasmi_core`. This is actually nice since we were able to convert it into a more generic and reusable interface this way.