### PR TITLE
Make fuzz work

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ This tests both `wasmi` engines using all features available to them.
 It is recommended to test using `--release` since compiling and testing without optimizations
 usually is a lot slower compared to compiling and testing with optimizations.
 
+## Fuzzing
+
+Install `cargo-fuzz`: `$ cargo install cargo-fuzz`.
+
+List all the existing fuzz targets: `$ cargo +nightly fuzz list`.
+
+Run a fuzz target: `$ cargo +nightly run <target>`.
+
 ## Platforms
 
 Supported platforms are primarily Linux, MacOS, Windows and WebAssembly.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,14 +9,11 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
+libfuzzer-sys = "0.4"
 wasmi = { path = ".." }
 wabt = "0.9"
 wasmparser = "0.14.1"
 tempdir = "0.3.6"
-
-[dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
-rev = "737524f7de1e85342b8b6cd1c01edc71018183ba"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ name = "wasmi-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
+edition = "2018"
 
 [package.metadata]
 cargo-fuzz = true
@@ -11,8 +12,8 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 wasmi = { path = ".." }
-wabt = "0.9"
-wasmparser = "0.14.1"
+wabt = "0.10"
+wasmparser = "0.84.0"
 tempdir = "0.3.6"
 
 # Prevent this from interfering with workspaces

--- a/fuzz/fuzz_targets/load.rs
+++ b/fuzz/fuzz_targets/load.rs
@@ -1,7 +1,5 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate wasmi;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
 	// Just check if loading some arbitrary buffer doesn't panic.

--- a/fuzz/fuzz_targets/load_spec.rs
+++ b/fuzz/fuzz_targets/load_spec.rs
@@ -1,9 +1,6 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate wabt;
-extern crate wasmi;
-extern crate tempdir;
+
+use libfuzzer_sys::fuzz_target;
 
 use std::fs::File;
 use std::io::Write;

--- a/fuzz/fuzz_targets/load_wabt.rs
+++ b/fuzz/fuzz_targets/load_wabt.rs
@@ -1,8 +1,6 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate wabt;
-extern crate wasmi;
+
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
 	let wasmi_result = wasmi::Module::from_buffer(data);

--- a/fuzz/fuzz_targets/load_wasmparser.rs
+++ b/fuzz/fuzz_targets/load_wasmparser.rs
@@ -1,21 +1,9 @@
 #![no_main]
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate wasmi;
-extern crate wasmparser;
 
-use wasmparser::WasmDecoder;
+use libfuzzer_sys::fuzz_target;
 
 fn run_wasmparser(data: &[u8]) -> bool {
-	let mut parser = wasmparser::ValidatingParser::new(data, None);
-	let result = loop {
-		match *parser.read() {
-			wasmparser::ParserState::Error(..) => break false,
-			wasmparser::ParserState::EndWasm => break true,
-			_ => (),
-		}
-	};
-	result
+	wasmparser::validate(data).is_ok()
 }
 
 fn run_wasmi(data: &[u8]) -> bool {


### PR DESCRIPTION
For some reason fuzz didn't work:

```
WARNING: Failed to find function "__sanitizer_get_total_unique_coverage".
WARNING: Failed to find function "__sanitizer_reset_coverage".
INFO: Seed: 3860000992
ERROR: __sanitizer_reset_coverage is not defined. Exiting.
Did you use -fsanitize-coverage=... to build your code?
────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 1
```

I fixed it and found bugs:

1)

```
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
  left: `true`,
 right: `false`', fuzz_targets/load_wabt.rs:10:5

Output of `std::fmt::Debug`:

	[0, 97, 115, 109, 1, 0, 0, 0, 12, 1, 11]
```	

Which means `wasmi` accepts a code which is not accepted by `wabt`. To try a .wasm file: `echo AGFzbQEAAAAMAQA= | base64 --decode > test.wasm`, this file is rejected with `000000a: error: invalid section code: 12\n` error. 

2)

```
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
  left: `false`,
 right: `true`', fuzz_targets/load_wasmparser.rs:16:5

Output of `std::fmt::Debug`:

	[0, 97, 115, 109, 1, 0, 0, 0, 12, 1, 8]
```

Which means `wasmi` accepts a code which is not accepted by `wasmparser`.

======

This divergence can be avoided with CI:

```
cargo +nightly fuzz run load_wabt -- -jobs=4 -max_total_time=10
cargo +nightly fuzz run load_wasmparser -- -jobs=4 -max_total_time=10
```