### PR TITLE
Return NotResumable from resume_execution

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -340,7 +340,7 @@ impl<'args> FuncInvocation<'args> {
                 if interpreter.state().is_resumable() {
                     Ok(interpreter.resume_execution(return_val, externals)?)
                 } else {
-                    Err(ResumableError::AlreadyStarted)
+                    Err(ResumableError::NotResumable)
                 }
             }
             FuncInvocationKind::Host { .. } => Err(ResumableError::NotResumable),


### PR DESCRIPTION
I was looking through this repository and how the resumable execution mechanism works, and I noticed that resume_execution was returning the wrong error.

If this is not the correct fix and indeed AlreadyStarted is correct, the documentation should be changed instead.