### PR TITLE
Add cli tool to execute .wat or .wasm using wasmi_v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ virtual_memory = ["wasmi_core/virtual_memory", "std"]
 reduced-stack-buffer = [ "parity-wasm/reduced-stack-buffer" ]
 
 [workspace]
-members = ["validation", "core", "wasmi_v1"]
+members = ["validation", "core", "wasmi_v1", "cli"]
 exclude = []
 
 [[bench]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wasmi_cli"
+version = "0.11.0"
+edition = "2021"
+authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin.freyler@gmail.com>"]
+license = "MIT/Apache-2.0"
+readme = "../README.md"
+repository = "https://github.com/paritytech/wasmi"
+documentation = "https://paritytech.github.io/wasmi/"
+description = "WebAssembly interpreter"
+keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
+
+[dependencies]
+clap = { version = "3.2", features = ["derive"] }
+wasmi_v1 = { path = "../wasmi_v1" }
+wat = "1"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,11 +13,11 @@ struct Args {
 
     /// The exported name of the Wasm function to call.
     #[clap(value_parser)]
-    wasm_func: String,
+    func_name: String,
 
     /// The arguments provided to the called function.
     #[clap(value_parser)]
-    wasm_args: Vec<String>,
+    func_args: Vec<String>,
 }
 
 /// Converts the given `.wat` into `.wasm`.
@@ -29,8 +29,8 @@ fn main() -> Result<(), String> {
     let args = Args::parse();
 
     let wasm_file = args.wasm_file;
-    let func_name = args.wasm_func;
-    let func_args = args.wasm_args;
+    let func_name = args.func_name;
+    let func_args = args.func_args;
 
     let mut file_contents =
         fs::read(&wasm_file).map_err(|_| format!("failed to read Wasm file {wasm_file}"))?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,113 @@
+use clap::Parser;
+use std::fs;
+use wasmi::core::{Value, ValueType, F32, F64};
+use wasmi_v1 as wasmi;
+
+/// Simple program to greet a person
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// The WebAssembly file to execute.
+    #[clap(value_parser)]
+    wasm_file: String,
+
+    /// The exported name of the Wasm function to call.
+    #[clap(value_parser)]
+    wasm_func: String,
+
+    /// The arguments provided to the called function.
+    #[clap(value_parser)]
+    wasm_args: Vec<String>,
+}
+
+/// Converts the given `.wat` into `.wasm`.
+fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
+    wat::parse_str(&wat)
+}
+
+fn main() -> Result<(), String> {
+    let args = Args::parse();
+
+    let wasm_file = args.wasm_file;
+    let func_name = args.wasm_func;
+    let func_args = args.wasm_args;
+
+    let mut file_contents =
+        fs::read(&wasm_file).map_err(|_| format!("failed to read Wasm file {wasm_file}"))?;
+    if wasm_file.ends_with(".wat") {
+        let wat = String::from_utf8(file_contents)
+            .map_err(|error| format!("failed to read UTF-8 file {wasm_file}: {error}"))?;
+        file_contents = wat2wasm(&wat)
+            .map_err(|error| format!("failed to parse .wat file {wasm_file}: {error}"))?;
+    }
+
+    let engine = wasmi::Engine::default();
+    let mut store = wasmi::Store::new(&engine, ());
+    let module = wasmi::Module::new(&engine, &mut &file_contents[..]).map_err(|error| {
+        format!("failed to parse and validate Wasm module {wasm_file}: {error}")
+    })?;
+
+    let mut linker = <wasmi::Linker<()>>::new();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .and_then(|pre| pre.start(&mut store))
+        .map_err(|error| format!("failed to instantiate and start the Wasm module: {error}"))?;
+
+    let func = instance
+        .get_export(&store, &func_name)
+        .and_then(|ext| ext.into_func())
+        .ok_or_else(|| format!("could not find function {func_name} in {wasm_file}"))?;
+    let func_type = func.func_type(&store);
+
+    if func_type.params().len() != func_args.len() {
+        return Err(format!(
+            "invalid number of arguments given for {func_name} of type {func_type}. \
+            expected {} argument but got {}",
+            func_type.params().len(),
+            func_args.len()
+        ));
+    }
+
+    let func_args = func_type
+        .params()
+        .iter()
+        .zip(&func_args)
+        .enumerate()
+        .map(|(n, (param_type, arg))| match param_type {
+            ValueType::I32 => arg.parse::<i32>().map(Value::from).map_err(|error| {
+                format!("failed to parse argument {arg} at index {n} as {param_type}: {error}")
+            }),
+            ValueType::I64 => arg.parse::<i64>().map(Value::from).map_err(|error| {
+                format!("failed to parse argument {arg} at index {n} as {param_type}: {error}")
+            }),
+            ValueType::F32 => arg
+                .parse::<f32>()
+                .map(F32::from)
+                .map(Value::from)
+                .map_err(|error| {
+                    format!("failed to parse argument {arg} at index {n} as {param_type}: {error}")
+                }),
+            ValueType::F64 => arg
+                .parse::<f64>()
+                .map(F64::from)
+                .map(Value::from)
+                .map_err(|error| {
+                    format!("failed to parse argument {arg} at index {n} as {param_type}: {error}")
+                }),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut results = func_type
+        .results()
+        .iter()
+        .copied()
+        .map(Value::default)
+        .collect::<Vec<_>>();
+    println!("executing {wasm_file}::{func_name} ...");
+    func.call(&mut store, &func_args, &mut results)
+        .map_err(|error| format!("failed during exeuction of {func_name}: {error}"))?;
+
+    println!("execution results = {:?}", results);
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,7 +103,16 @@ fn main() -> Result<(), String> {
         .copied()
         .map(Value::default)
         .collect::<Vec<_>>();
-    println!("executing {wasm_file}::{func_name} ...");
+
+    print!("executing {wasm_file}::{func_name}(");
+    if let Some((first_arg, rest_args)) = func_args.split_first() {
+        print!("{first_arg}");
+        for arg in rest_args {
+            print!(", {arg}");
+        }
+    }
+    println!(") ...");
+
     func.call(&mut store, &func_args, &mut results)
         .map_err(|error| format!("failed during exeuction of {func_name}: {error}"))?;
 

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -76,6 +76,17 @@ pub enum Value {
     F64(F64),
 }
 
+impl Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::I32(value) => write!(f, "{value}"),
+            Self::I64(value) => write!(f, "{value}"),
+            Self::F32(value) => write!(f, "{}", f32::from(*value)),
+            Self::F64(value) => write!(f, "{}", f64::from(*value)),
+        }
+    }
+}
+
 /// Trait for creating value from a [`Value`].
 ///
 /// Typically each implementation can create a value from the specific type.


### PR DESCRIPTION
Simple CLI tool to run `.wat` or `.wasm` files given a function name and parameters. Prints the results after execution.
This should improve accessibility of `wasmi` to new users, people who want to toy with it or developers who want to see how `wasmi` is to be used as a library.

![2022-07-15-230725_1349x527_scrot](https://user-images.githubusercontent.com/8193155/179310791-332f17fa-cd0b-46cf-8f7e-15ca996f9e56.png)

![2022-07-15-233735_2230x245_scrot](https://user-images.githubusercontent.com/8193155/179314427-59824787-ff4b-44fa-99f2-4a000dac30b4.png)