### PR TITLE
Decrease sizes of stored object refs such as Func, Global, Table and …

### DIFF
--- a/wasmi_v1/src/func/mod.rs
+++ b/wasmi_v1/src/func/mod.rs
@@ -28,14 +28,17 @@ use core::{fmt, fmt::Debug};
 
 /// A raw index to a function entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FuncIdx(usize);
+pub struct FuncIdx(u32);
 
 impl Index for FuncIdx {
     fn into_usize(self) -> usize {
-        self.0
+        self.0 as usize
     }
 
     fn from_usize(value: usize) -> Self {
+        let value = value.try_into().unwrap_or_else(|error| {
+            panic!("index {value} is out of bounds as func index: {error}")
+        });
         Self(value)
     }
 }

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -4,14 +4,17 @@ use core::{fmt, fmt::Display};
 
 /// A raw index to a global variable entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct GlobalIdx(usize);
+pub struct GlobalIdx(u32);
 
 impl Index for GlobalIdx {
     fn into_usize(self) -> usize {
-        self.0
+        self.0 as usize
     }
 
     fn from_usize(value: usize) -> Self {
+        let value = value.try_into().unwrap_or_else(|error| {
+            panic!("index {value} is out of bounds as global index: {error}")
+        });
         Self(value)
     }
 }

--- a/wasmi_v1/src/instance.rs
+++ b/wasmi_v1/src/instance.rs
@@ -19,14 +19,17 @@ use core::{iter::FusedIterator, ops::Deref};
 
 /// A raw index to a module instance entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct InstanceIdx(usize);
+pub struct InstanceIdx(u32);
 
 impl Index for InstanceIdx {
     fn into_usize(self) -> usize {
-        self.0
+        self.0 as usize
     }
 
     fn from_usize(value: usize) -> Self {
+        let value = value.try_into().unwrap_or_else(|error| {
+            panic!("index {value} is out of bounds as instance index: {error}")
+        });
         Self(value)
     }
 }

--- a/wasmi_v1/src/memory/mod.rs
+++ b/wasmi_v1/src/memory/mod.rs
@@ -13,14 +13,17 @@ use wasmi_core::memory_units::{Bytes, Pages};
 
 /// A raw index to a linear memory entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct MemoryIdx(usize);
+pub struct MemoryIdx(u32);
 
 impl Index for MemoryIdx {
     fn into_usize(self) -> usize {
-        self.0
+        self.0 as usize
     }
 
     fn from_usize(value: usize) -> Self {
+        let value = value.try_into().unwrap_or_else(|error| {
+            panic!("index {value} is out of bounds as memory index: {error}")
+        });
         Self(value)
     }
 }

--- a/wasmi_v1/src/table.rs
+++ b/wasmi_v1/src/table.rs
@@ -6,14 +6,17 @@ use core::{fmt, fmt::Display};
 
 /// A raw index to a table entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TableIdx(usize);
+pub struct TableIdx(u32);
 
 impl Index for TableIdx {
     fn into_usize(self) -> usize {
-        self.0
+        self.0 as usize
     }
 
     fn from_usize(value: usize) -> Self {
+        let value = value.try_into().unwrap_or_else(|error| {
+            panic!("index {value} is out of bounds as table index: {error}")
+        });
         Self(value)
     }
 }


### PR DESCRIPTION
Decreases the memory footprint of `Func`, `Global`, `Table`, `Memory` and `Stored<T>` from 128-bits to 64-bits on 64-bit platforms. This is okay since we do not expect to support use cases with more than 2^32 entities of any of those kinds.

All of those object refs are composed of a store index and their respective entity index.
Before this change both indices were of type `usize` so the composed type was 128-bit on a 64-bit platform.
With this change those types are now all 64-bit in size for 64-bit platforms.