### PR TITLE
CI: Check that the no_std build is built without std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,12 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: wasm32-unknown-unknown, thumbv7em-none-eabi
+          target: wasm32-unknown-unknown
           override: true
+      - name: Add extra targets
+        # Workaround for https://github.com/actions-rs/toolchain/issues/165
+        run: |
+          rustup target add thumbv7em-none-eabi
       - name: Build (default features)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --lib --no-default-features --target thumbv7em-none-eabi
+          args: --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli
       - name: Build (wasm32)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: wasm32-unknown-unknown
+          target: wasm32-unknown-unknown, thumbv7em-none-eabi
           override: true
       - name: Build (default features)
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           command: build
           args: --workspace --all-features
-      - name: Build (no_std)
+      - name: Build wasmi itself as no_std
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --no-default-features
+          args: --lib --no-default-features --target thumbv7em-none-eabi
       - name: Build (wasm32)
         uses: actions-rs/cargo@v1
         with:

--- a/wasmi_v1/src/engine/func_builder/control_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/control_stack.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-
 use super::ControlFrame;
 
 /// The stack of control flow frames.

--- a/wasmi_v1/src/engine/func_builder/control_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/control_stack.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::ControlFrame;
 
 /// The stack of control flow frames.

--- a/wasmi_v1/src/engine/func_builder/control_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/control_stack.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use super::ControlFrame;
+use alloc::vec::Vec;
 
 /// The stack of control flow frames.
 #[derive(Debug, Default)]

--- a/wasmi_v1/src/engine/func_builder/mod.rs
+++ b/wasmi_v1/src/engine/func_builder/mod.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 mod control_frame;
 mod control_stack;
 mod inst_builder;

--- a/wasmi_v1/src/engine/func_builder/value_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/value_stack.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
 use core::cmp;
-
 use wasmi_core::ValueType;
 
 /// The value stack that is emulated during Wasm to `wasmi` bytecode translation.

--- a/wasmi_v1/src/engine/func_builder/value_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/value_stack.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::cmp;
 
 use wasmi_core::ValueType;

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -3,6 +3,7 @@
 //! These closely mirror the WebAssembly specification definitions.
 //! The overall structure is heavily inspired by the `wasmtime` virtual
 //! machine architecture.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/wasmi_v1/src/module/builder.rs
+++ b/wasmi_v1/src/module/builder.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use super::{
     import::FuncTypeIdx,
     DataSegment,
@@ -22,6 +21,7 @@ use crate::{
     ModuleError,
     TableType,
 };
+use alloc::vec::Vec;
 
 /// A builder for a WebAssembly [`Module`].
 #[derive(Debug)]

--- a/wasmi_v1/src/module/builder.rs
+++ b/wasmi_v1/src/module/builder.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::{
     import::FuncTypeIdx,
     DataSegment,

--- a/wasmi_v1/src/module/builder.rs
+++ b/wasmi_v1/src/module/builder.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-
 use super::{
     import::FuncTypeIdx,
     DataSegment,

--- a/wasmi_v1/src/module/data.rs
+++ b/wasmi_v1/src/module/data.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use super::{InitExpr, MemoryIdx, ModuleError};
 
 /// A linear memory data segment within a [`Module`].

--- a/wasmi_v1/src/module/data.rs
+++ b/wasmi_v1/src/module/data.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::Box;
 use super::{InitExpr, MemoryIdx, ModuleError};
+use alloc::boxed::Box;
 
 /// A linear memory data segment within a [`Module`].
 ///

--- a/wasmi_v1/src/module/element.rs
+++ b/wasmi_v1/src/module/element.rs
@@ -1,5 +1,4 @@
 use alloc::{boxed::Box, vec::Vec};
-
 use crate::ModuleError;
 
 use super::{FuncIdx, InitExpr, TableIdx};

--- a/wasmi_v1/src/module/element.rs
+++ b/wasmi_v1/src/module/element.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use crate::ModuleError;
 
 use super::{FuncIdx, InitExpr, TableIdx};

--- a/wasmi_v1/src/module/element.rs
+++ b/wasmi_v1/src/module/element.rs
@@ -1,5 +1,4 @@
-use alloc::boxed::Box;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 use crate::ModuleError;
 

--- a/wasmi_v1/src/module/element.rs
+++ b/wasmi_v1/src/module/element.rs
@@ -1,5 +1,5 @@
-use alloc::{boxed::Box, vec::Vec};
 use crate::ModuleError;
+use alloc::{boxed::Box, vec::Vec};
 
 use super::{FuncIdx, InitExpr, TableIdx};
 

--- a/wasmi_v1/src/module/error.rs
+++ b/wasmi_v1/src/module/error.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use super::ReadError;
 use core::{
     fmt,

--- a/wasmi_v1/src/module/error.rs
+++ b/wasmi_v1/src/module/error.rs
@@ -1,5 +1,4 @@
 use alloc::string::String;
-
 use super::ReadError;
 use core::{
     fmt,

--- a/wasmi_v1/src/module/error.rs
+++ b/wasmi_v1/src/module/error.rs
@@ -1,5 +1,5 @@
-use alloc::string::String;
 use super::ReadError;
+use alloc::string::String;
 use core::{
     fmt,
     fmt::{Debug, Display},

--- a/wasmi_v1/src/module/export.rs
+++ b/wasmi_v1/src/module/export.rs
@@ -1,6 +1,6 @@
-use alloc::boxed::Box;
 use super::GlobalIdx;
 use crate::ModuleError;
+use alloc::boxed::Box;
 
 /// The index of a function declaration within a [`Module`].
 ///

--- a/wasmi_v1/src/module/export.rs
+++ b/wasmi_v1/src/module/export.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use super::GlobalIdx;
 use crate::ModuleError;
 

--- a/wasmi_v1/src/module/export.rs
+++ b/wasmi_v1/src/module/export.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-
 use super::GlobalIdx;
 use crate::ModuleError;
 

--- a/wasmi_v1/src/module/import.rs
+++ b/wasmi_v1/src/module/import.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::fmt::{self, Display};
 
 use crate::{GlobalType, MemoryType, ModuleError, TableType};

--- a/wasmi_v1/src/module/import.rs
+++ b/wasmi_v1/src/module/import.rs
@@ -1,6 +1,6 @@
+use crate::{GlobalType, MemoryType, ModuleError, TableType};
 use alloc::boxed::Box;
 use core::fmt::{self, Display};
-use crate::{GlobalType, MemoryType, ModuleError, TableType};
 use wasmparser::ImportSectionEntryType;
 
 /// A [`Module`] import item.

--- a/wasmi_v1/src/module/import.rs
+++ b/wasmi_v1/src/module/import.rs
@@ -1,6 +1,5 @@
 use alloc::boxed::Box;
 use core::fmt::{self, Display};
-
 use crate::{GlobalType, MemoryType, ModuleError, TableType};
 use wasmparser::ImportSectionEntryType;
 

--- a/wasmi_v1/src/module/mod.rs
+++ b/wasmi_v1/src/module/mod.rs
@@ -1,5 +1,4 @@
-use alloc::boxed::Box;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 mod builder;
 mod compile;

--- a/wasmi_v1/src/module/mod.rs
+++ b/wasmi_v1/src/module/mod.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 mod builder;
 mod compile;
 mod data;

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::{
     compile::translate,
     import::FuncTypeIdx,

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-
 use super::{
     compile::translate,
     import::FuncTypeIdx,

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use super::{
     compile::translate,
     import::FuncTypeIdx,
@@ -10,6 +9,7 @@ use super::{
     Read,
 };
 use crate::Engine;
+use alloc::vec::Vec;
 use wasmparser::{
     Chunk,
     DataSectionReader,


### PR DESCRIPTION
... by placing it on a target without an operating system.

The test's scope is reduced from --workspace to --lib, as only that
component (and its transitive dependencies) are expected to be no_std.

Closes: https://github.com/paritytech/wasmi/issues/374