### PR TITLE
Prepare for wasmi release v0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Additionally we have an `Internal` section for changes that are of interest to developers.
 
+## [0.12.0] - 2022-07-24
+
+**Note:** This is going to be the last release with the legacy `wasmi` engine.
+          Future releases are going to use the new Wasm execution engines
+          that are currently in development.
+          We may consider to publish the legacy `wasmi` engine as `wasmi-legacy`
+          crate.
+
+### Changed
+
+- `wasmi` now depends on the [`wasmi_core`](https://crates.io/crates/wasmi_core) crate.
+- Deprecated `RuntimeValue::decode_{f32,f64}` methods.
+    - **Reason**: These methods expose details about the `F32` and `F64` types.
+                  The `RuntimeValue` type provides `from_bits` methods for similar purposes.
+    - **Replacement:** Replace those deprecated methods with `F{32,64}::from_bits().into()` respectively.
+- Refactor traps in `wasmi`: [PR](https://github.com/paritytech/wasmi/commit/cd59462bc946a52a7e3e4db491ac6675e3a2f53f)
+    - This change also renames `TrapKind` to `TrapCode`.
+    - The `wasmi` crate now properly reuses the `TrapCode` definitions from the `wasmi_core` crate.
+- Updated dependency:
+    - `parity-wasm v0.42 -> v0.45`
+    - `memory_units v0.3.0 -> v0.4.0`
+
+### Internal
+
+- Rename `RuntimeValue` to `Value` internally.
+- Now uses `wat` crate dependency instead of `wabt` for reading `.wat` files in tests.
+- Updated dev-dependencies:
+    - `assert_matches: v1.1 -> v1.5`
+    - `rand 0.4.2 -> 0.8.2`
+- Fix some `clippy` warnings.
+
 ## [0.11.0] - 2022-01-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>", "Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -13,7 +13,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
 wasmi_core = { version = "0.1", path = "core", default-features = false }
-validation = { package = "wasmi-validation", version = "0.4", path = "validation", default-features = false }
+validation = { package = "wasmi-validation", version = "0.4.2", path = "validation", default-features = false }
 parity-wasm = { version = "0.45.0", default-features = false }
 
 [dev-dependencies]

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi-validation"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This is going to be the first published `wasmi` release that uses the [`wasmi_core`](https://crates.io/crates/wasmi_core) crate. 