### PR TITLE
wasmi: bump version to 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Additionally we have an `Internal` section for changes that are of interest to d
   resources instead of spinning up a new Wasm execution engine for every
   function call.
 
-  **Note:** If you plan to use `wasmi` it is of critically importance
+  **Note:** If you plan to use `wasmi` it is of critical importance
   to compile `wasmi` using the following Cargo `profile` settings:
 
   ```toml

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The following list states some of the distinct features of `wasmi`.
     - WebAssembly specification compliance.
 - Can itself be compiled to WebAssembly.
 - Low-overhead and cross-platform WebAssembly runtime.
-- New experimental `v1` engine allows to be used as a drop-in solution for Wasmtime.
+- Loosely mirrors the [Wasmtime API](https://docs.rs/wasmtime/0.39.1/wasmtime/)
+  to act as a drop-in solution.
 
 # Wasm Proposals
 

--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.11.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin.freyler@gmail.com>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Wasmi version was 0.11 before because the latest release was with the legacy wasmi engine and we forgot to synchronize versions until then.