### PR TITLE
Add initial naive fuzz testing based on wasm-smith

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 **/*.rs.bk
 Cargo.lock
 spec/target
+
+**/fuzz/corpus/
+**/fuzz/target/
+**/fuzz/artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 **/*.rs.bk
 Cargo.lock
 spec/target
-.idea

--- a/wasmi_v1/fuzz/Cargo.toml
+++ b/wasmi_v1/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "wasmi-fuzz"
+version = "0.0.0"
+authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin.freyler@gmail.com>"]
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+wasm-smith = "0.11"
+
+[dependencies.wasmi]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "translate"
+path = "fuzz_targets/translate.rs"
+test = false
+doc = false

--- a/wasmi_v1/fuzz/fuzz_targets/translate.rs
+++ b/wasmi_v1/fuzz/fuzz_targets/translate.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use wasmi::{Engine, Module};
+
+fuzz_target!(|data: wasm_smith::Module| {
+    let wasm = data.to_bytes();
+    let engine = Engine::default();
+    Module::new(&engine, &mut &wasm[..]).unwrap();
+});


### PR DESCRIPTION
This is a very naive fuzz testing framework based on the BytecodeAlliance's `wasm-smith` tool.
It currently only fuzz tests Wasm parsing, validation and translation to `wasmi`'s internal bytecode.

In later revisions we want to add fuzz testing for execution as well.
However, this requires a proper baseline Wasm execution engine that we can use to compare `wasmi` against.
For this the BytecodeAlliance's Wasm spec interpreter is the best candidate but it is lacking a proper Rust crate and just lives inside of the Wasmtime repository as of now. This might change in the future.

We want to merge this PR because it is currently a major headache to work in difference feature branches with all of the fuzz testing artifacts around.