### PR TITLE
Refactor Trap to be of pointer size

### DIFF
--- a/core/src/host_error.rs
+++ b/core/src/host_error.rs
@@ -37,7 +37,8 @@ use downcast_rs::{impl_downcast, DowncastSync};
 ///
 /// // Get a reference to the concrete error
 /// match failable_fn() {
-///     Err(Trap::Host(host_error)) => {
+///     Err(trap) if trap.is_host() => {
+///         let host_error = trap.as_host().unwrap();
 ///         let my_error: &MyError = host_error.downcast_ref::<MyError>().unwrap();
 ///         assert_eq!(my_error.code, 1312);
 ///     }
@@ -48,7 +49,7 @@ use downcast_rs::{impl_downcast, DowncastSync};
 /// match failable_fn() {
 ///     Err(err) => {
 ///         let my_error = match err {
-///             Trap::Host(host_error) => host_error.downcast::<MyError>().unwrap(),
+///             trap if trap.is_host() => trap.into_host().unwrap().downcast::<MyError>().unwrap(),
 ///             unexpected => panic!("expected host error but found: {}", unexpected),
 ///         };
 ///         assert_eq!(my_error.code, 1312);

--- a/core/src/trap.rs
+++ b/core/src/trap.rs
@@ -45,9 +45,36 @@ impl TrapInner {
         matches!(self, TrapInner::Code(_))
     }
 
+    /// Returns a shared reference to the [`HostError`] if any.
+    #[inline]
+    pub fn as_host(&self) -> Option<&dyn HostError> {
+        if let Self::Host(host_error) = self {
+            return Some(&**host_error);
+        }
+        None
+    }
+
+    /// Returns an exclusive reference to the [`HostError`] if any.
+    #[inline]
+    pub fn as_host_mut(&mut self) -> Option<&mut dyn HostError> {
+        if let Self::Host(host_error) = self {
+            return Some(&mut **host_error);
+        }
+        None
+    }
+
+    /// Converts into the [`HostError`] if any.
+    #[inline]
+    pub fn into_host(self) -> Option<Box<dyn HostError>> {
+        if let Self::Host(host_error) = self {
+            return Some(host_error);
+        }
+        None
+    }
+
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
     #[inline]
-    pub fn code(&self) -> Option<TrapCode> {
+    pub fn as_code(&self) -> Option<TrapCode> {
         if let Self::Code(trap_code) = self {
             return Some(*trap_code);
         }
@@ -84,10 +111,28 @@ impl Trap {
         self.inner.is_code()
     }
 
+    /// Returns a shared reference to the [`HostError`] if any.
+    #[inline]
+    pub fn as_host(&self) -> Option<&dyn HostError> {
+        self.inner.as_host()
+    }
+
+    /// Returns an exclusive reference to the [`HostError`] if any.
+    #[inline]
+    pub fn as_host_mut(&mut self) -> Option<&mut dyn HostError> {
+        self.inner.as_host_mut()
+    }
+
+    /// Converts into the [`HostError`] if any.
+    #[inline]
+    pub fn into_host(self) -> Option<Box<dyn HostError>> {
+        self.inner.into_host()
+    }
+
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
     #[inline]
-    pub fn code(&self) -> Option<TrapCode> {
-        self.inner.code()
+    pub fn as_code(&self) -> Option<TrapCode> {
+        self.inner.as_code()
     }
 }
 
@@ -126,7 +171,7 @@ impl Display for Trap {
 #[cfg(feature = "std")]
 impl StdError for Trap {
     fn description(&self) -> &str {
-        self.code().map(|code| code.trap_message()).unwrap_or("")
+        self.as_code().map(|code| code.trap_message()).unwrap_or("")
     }
 }
 

--- a/core/src/trap.rs
+++ b/core/src/trap.rs
@@ -10,27 +10,39 @@ use std::error::Error as StdError;
 /// Under some conditions, wasm execution may produce a `Trap`, which immediately aborts execution.
 /// Traps can't be handled by WebAssembly code, but are reported to the embedder.
 #[derive(Debug)]
-pub enum Trap {
+pub struct Trap {
+    /// The internal data structure of a [`Trap`].
+    inner: Box<TrapInner>,
+}
+
+#[test]
+fn trap_size() {
+    assert_eq!(
+        core::mem::size_of::<Trap>(),
+        core::mem::size_of::<*const ()>()
+    );
+}
+
+/// The internal of a [`Trap`].
+#[derive(Debug)]
+enum TrapInner {
     /// Traps during Wasm execution.
     Code(TrapCode),
     /// Traps and errors during host execution.
     Host(Box<dyn HostError>),
 }
 
-impl Trap {
-    /// Wraps the host error in a [`Trap`].
-    #[inline]
-    pub fn host<U>(host_error: U) -> Self
-    where
-        U: HostError + Sized,
-    {
-        Self::Host(Box::new(host_error))
-    }
-
+impl TrapInner {
     /// Returns `true` if `self` trap originating from host code.
     #[inline]
     pub fn is_host(&self) -> bool {
-        matches!(self, Self::Host(_))
+        matches!(self, TrapInner::Host(_))
+    }
+
+    /// Returns `true` if `self` trap originating from Wasm code.
+    #[inline]
+    pub fn is_code(&self) -> bool {
+        matches!(self, TrapInner::Code(_))
     }
 
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
@@ -43,10 +55,46 @@ impl Trap {
     }
 }
 
-impl From<TrapCode> for Trap {
+impl Trap {
+    /// Create a new [`Trap`] from the [`TrapInner`].
+    fn new(inner: TrapInner) -> Self {
+        Self {
+            inner: Box::new(inner),
+        }
+    }
+
+    /// Wraps the host error in a [`Trap`].
+    #[cold]
+    pub fn host<U>(host_error: U) -> Self
+    where
+        U: HostError + Sized,
+    {
+        Self::new(TrapInner::Host(Box::new(host_error)))
+    }
+
+    /// Returns `true` if `self` trap originating from host code.
     #[inline]
+    pub fn is_host(&self) -> bool {
+        self.inner.is_host()
+    }
+
+    /// Returns `true` if `self` trap originating from Wasm code.
+    #[inline]
+    pub fn is_code(&self) -> bool {
+        self.inner.is_code()
+    }
+
+    /// Returns the [`TrapCode`] traps originating from Wasm execution.
+    #[inline]
+    pub fn code(&self) -> Option<TrapCode> {
+        self.inner.code()
+    }
+}
+
+impl From<TrapCode> for Trap {
+    #[cold]
     fn from(error: TrapCode) -> Self {
-        Self::Code(error)
+        Self::new(TrapInner::Code(error))
     }
 }
 
@@ -56,16 +104,22 @@ where
 {
     #[inline]
     fn from(e: U) -> Self {
-        Trap::host(e)
+        Self::host(e)
+    }
+}
+
+impl Display for TrapInner {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Code(trap_code) => Display::fmt(trap_code, f),
+            Self::Host(host_error) => Display::fmt(host_error, f),
+        }
     }
 }
 
 impl Display for Trap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Trap::Code(trap_code) => Display::fmt(trap_code, f),
-            Trap::Host(host_error) => Display::fmt(host_error, f),
-        }
+        <TrapInner as Display>::fmt(&self.inner, f)
     }
 }
 

--- a/wasmi_v1/benches/benches.rs
+++ b/wasmi_v1/benches/benches.rs
@@ -347,7 +347,7 @@ fn bench_execute_recursive_trap_v1(c: &mut Criterion) {
                 .unwrap_err();
             match error {
                 v1::Error::Trap(trap) => assert_matches::assert_matches!(
-                    trap.code(),
+                    trap.as_code(),
                     Some(v1::core::TrapCode::Unreachable),
                     "expected unreachable trap",
                 ),

--- a/wasmi_v1/tests/spec/run.rs
+++ b/wasmi_v1/tests/spec/run.rs
@@ -1,7 +1,7 @@
 use super::{error::TestError, TestContext, TestDescriptor};
 use anyhow::Result;
 use wasmi::{Config, Error as WasmiError};
-use wasmi_core::{Trap, Value, F32, F64};
+use wasmi_core::{Value, F32, F64};
 use wast::{
     lexer::Lexer,
     parser::ParseBuffer,
@@ -200,9 +200,10 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
 /// - If the trap message of the `error` is not as expected.
 fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message: &str) {
     match error {
-        TestError::Wasmi(WasmiError::Trap(Trap::Code(trap_code))) => {
+        TestError::Wasmi(WasmiError::Trap(trap)) if trap.is_code() => {
+            let code = trap.code().unwrap();
             assert_eq!(
-                trap_code.trap_message(),
+                code.trap_message(),
                 message,
                 "{}: the directive trapped as expected but with an unexpected message",
                 test_context.spanned(span),

--- a/wasmi_v1/tests/spec/run.rs
+++ b/wasmi_v1/tests/spec/run.rs
@@ -201,7 +201,7 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
 fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message: &str) {
     match error {
         TestError::Wasmi(WasmiError::Trap(trap)) if trap.is_code() => {
-            let code = trap.code().unwrap();
+            let code = trap.as_code().unwrap();
             assert_eq!(
                 code.trap_message(),
                 message,


### PR DESCRIPTION
This PR refactors the `wasmi_core` `Trap` type to have a `size_of` equal to a pointer type.
Benchmarks show that this improves performance across the board especially for call intense workloads which was to be expected by roughly 5-7%.