### PR TITLE
Reuse func builder allocations

### DIFF
--- a/wasmi_v1/src/engine/func_builder/control_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/control_stack.rs
@@ -8,6 +8,11 @@ pub struct ControlFlowStack {
 }
 
 impl ControlFlowStack {
+    /// Resets the [`ControlFlowStack`] to allow for reuse.
+    pub fn reset(&mut self) {
+        self.frames.clear()
+    }
+
     /// Returns `true` if `relative_depth` points to the first control flow frame.
     pub fn is_root(&self, relative_depth: u32) -> bool {
         debug_assert!(!self.is_empty());

--- a/wasmi_v1/src/engine/func_builder/inst_builder.rs
+++ b/wasmi_v1/src/engine/func_builder/inst_builder.rs
@@ -113,6 +113,12 @@ pub struct InstructionsBuilder {
 }
 
 impl InstructionsBuilder {
+    /// Resets the [`InstructionsBuilder`] to allow for reuse.
+    pub fn reset(&mut self) {
+        self.insts.clear();
+        self.labels.clear();
+    }
+
     /// Returns the current instruction pointer as index.
     pub fn current_pc(&self) -> InstructionIdx {
         InstructionIdx::from_usize(self.insts.len())

--- a/wasmi_v1/src/engine/func_builder/locals_registry.rs
+++ b/wasmi_v1/src/engine/func_builder/locals_registry.rs
@@ -68,6 +68,12 @@ impl LocalGroup {
 }
 
 impl LocalsRegistry {
+    /// Resets the [`LocalsRegistry`] to allow for reuse.
+    pub fn reset(&mut self) {
+        self.groups.clear();
+        self.max_index = 0;
+    }
+
     /// Returns the number of registered local variables.
     ///
     /// # Note

--- a/wasmi_v1/src/engine/func_builder/value_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/value_stack.rs
@@ -16,6 +16,12 @@ pub struct ValueStack {
 }
 
 impl ValueStack {
+    /// Resets the [`ValueStack`] to allow for reuse.
+    pub fn reset(&mut self) {
+        self.values.clear();
+        self.max_stack_height = 0;
+    }
+
     /// Returns the maximum value stack height.
     pub fn max_stack_height(&self) -> u32 {
         self.max_stack_height

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -22,7 +22,14 @@ use self::{
 pub use self::{
     bytecode::{DropKeep, Target},
     code_map::FuncBody,
-    func_builder::{FunctionBuilder, InstructionIdx, LabelIdx, RelativeDepth, Reloc},
+    func_builder::{
+        FunctionBuilder,
+        FunctionBuilderAllocations,
+        InstructionIdx,
+        LabelIdx,
+        RelativeDepth,
+        Reloc,
+    },
     traits::{CallParams, CallResults},
 };
 use super::{func::FuncEntityInternal, AsContext, AsContextMut, Func};

--- a/wasmi_v1/src/module/compile/mod.rs
+++ b/wasmi_v1/src/module/compile/mod.rs
@@ -34,11 +34,11 @@ pub fn translate<'parser>(
 }
 
 /// Translates Wasm bytecode into `wasmi` bytecode for a single Wasm function.
-struct FunctionTranslator<'engine, 'parser> {
+struct FunctionTranslator<'parser> {
     /// The function body that shall be translated.
     func_body: FunctionBody<'parser>,
     /// The interface to incrementally build up the `wasmi` bytecode function.
-    func_builder: FunctionBuilder<'engine, 'parser>,
+    func_builder: FunctionBuilder<'parser>,
     /// The Wasm validator.
     validator: FuncValidator<ValidatorResources>,
     /// The `wasmi` module resources.
@@ -48,10 +48,10 @@ struct FunctionTranslator<'engine, 'parser> {
     res: ModuleResources<'parser>,
 }
 
-impl<'engine, 'parser> FunctionTranslator<'engine, 'parser> {
+impl<'parser> FunctionTranslator<'parser> {
     /// Creates a new Wasm to `wasmi` bytecode function translator.
     fn new(
-        engine: &'engine Engine,
+        engine: &Engine,
         func: FuncIdx,
         func_body: FunctionBody<'parser>,
         validator: FuncValidator<ValidatorResources>,

--- a/wasmi_v1/src/module/compile/operator.rs
+++ b/wasmi_v1/src/module/compile/operator.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use wasmparser::{Ieee32, Ieee64, TypeOrFuncType};
 
-impl<'engine, 'parser> FunctionTranslator<'engine, 'parser> {
+impl<'parser> FunctionTranslator<'parser> {
     /// Translate a Wasm `nop` (no operation) instruction.
     pub fn translate_nop(&mut self) -> Result<(), ModuleError> {
         // We can simply ignore Wasm `nop` instructions.
@@ -448,7 +448,7 @@ macro_rules! define_translate_fn {
     };
 }
 
-impl<'engine, 'parser> FunctionTranslator<'engine, 'parser> {
+impl<'parser> FunctionTranslator<'parser> {
     define_translate_fn! {
         /// Translate a Wasm `unreachable` instruction.
         fn translate_unreachable();

--- a/wasmi_v1/src/module/compile/operator.rs
+++ b/wasmi_v1/src/module/compile/operator.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use wasmparser::{Ieee32, Ieee64, TypeOrFuncType};
 
-impl<'parser> FunctionTranslator<'parser> {
+impl<'alloc, 'parser> FunctionTranslator<'alloc, 'parser> {
     /// Translate a Wasm `nop` (no operation) instruction.
     pub fn translate_nop(&mut self) -> Result<(), ModuleError> {
         // We can simply ignore Wasm `nop` instructions.
@@ -448,7 +448,7 @@ macro_rules! define_translate_fn {
     };
 }
 
-impl<'parser> FunctionTranslator<'parser> {
+impl<'alloc, 'parser> FunctionTranslator<'alloc, 'parser> {
     define_translate_fn! {
         /// Translate a Wasm `unreachable` instruction.
         fn translate_unreachable();


### PR DESCRIPTION
This PR allows to reuse allocations of `FunctionBuilder` between different Wasm function translation units.
Benchmarks show an improvement in compilation time by ~10%.