### PR TITLE
v1: Optimize calls

### DIFF
--- a/wasmi_v1/src/engine/bytecode/mod.rs
+++ b/wasmi_v1/src/engine/bytecode/mod.rs
@@ -18,22 +18,14 @@ use wasmi_core::UntypedValue;
 /// each representing either the `BrTable` head or one of its branching targets.
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum Instruction {
-    GetLocal {
-        local_depth: LocalIdx,
-    },
-    SetLocal {
-        local_depth: LocalIdx,
-    },
-    TeeLocal {
-        local_depth: LocalIdx,
-    },
+    GetLocal { local_depth: LocalIdx },
+    SetLocal { local_depth: LocalIdx },
+    TeeLocal { local_depth: LocalIdx },
     Br(Target),
     BrIfEqz(Target),
     BrIfNez(Target),
     ReturnIfNez(DropKeep),
-    BrTable {
-        len_targets: usize,
-    },
+    BrTable { len_targets: usize },
     Unreachable,
     Return(DropKeep),
     Call(FuncIdx),
@@ -204,43 +196,6 @@ pub enum Instruction {
     I64TruncSatF32U,
     I64TruncSatF64S,
     I64TruncSatF64U,
-
-    /// The start of a Wasm function body.
-    ///
-    /// - This stores the `wasmi` bytecode length of the function body as well
-    ///   as the amount of local variables.
-    /// - Note that the length of the `wasmi` bytecode might differ from the length
-    ///   of the original WebAssembly bytecode.
-    /// - The types of the local variables do not matter since all stack values
-    ///   are equally sized with 64-bits per value. Storing the amount of local
-    ///   variables eliminates one indirection when calling a Wasm function.
-    ///
-    /// # Note
-    ///
-    /// This is a non-WebAssembly instruction that is specific to how the `wasmi`
-    /// interpreter organizes its internal bytecode.
-    FuncBodyStart {
-        /// This field represents the amount of instruction of the function body.
-        ///
-        /// Note: This does not include any meta instructions such as
-        /// [`Instruction::FuncBodyStart`] or [`Instruction::FuncBodyEnd`].
-        len_instructions: u32,
-        /// Represents the number of local variables of the function body.
-        ///
-        /// Note: The types of the locals do not matter since all stack values
-        ///       use 64-bit encoding in the `wasmi` bytecode interpreter.
-        /// Note: Storing the amount of locals inline with the rest of the
-        ///       function body eliminates one indirection when calling a function.
-        len_locals: u32,
-        max_stack_height: u32,
-    },
-    /// The end of a Wasm function body.
-    ///
-    /// # Note
-    ///
-    /// This is a non-WebAssembly instruction that is specific to how the `wasmi`
-    /// interpreter organizes its internal bytecode.
-    FuncBodyEnd,
 }
 
 impl Instruction {

--- a/wasmi_v1/src/engine/cache.rs
+++ b/wasmi_v1/src/engine/cache.rs
@@ -1,0 +1,143 @@
+use crate::{
+    module::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX},
+    AsContext,
+    Func,
+    Instance,
+    Memory,
+    Table,
+};
+
+/// A cache for frequently used entities of an [`Instance`].
+#[derive(Debug)]
+pub struct InstanceCache {
+    /// The current instance in use.
+    instance: Instance,
+    /// The default linear memory of the currently used [`Instance`].
+    default_memory: Option<Memory>,
+    /// The default table of the currently used [`Instance`].
+    default_table: Option<Table>,
+    /// The last accessed function of the currently used [`Instance`].
+    last_func: Option<(u32, Func)>,
+}
+
+impl From<Instance> for InstanceCache {
+    fn from(instance: Instance) -> Self {
+        Self {
+            instance,
+            default_memory: None,
+            default_table: None,
+            last_func: None,
+        }
+    }
+}
+
+impl InstanceCache {
+    /// Resolves the instances.
+    fn instance(&self) -> Instance {
+        self.instance
+    }
+
+    /// Updates the cached [`Instance`].
+    fn set_instance(&mut self, instance: Instance) {
+        self.instance = instance;
+    }
+
+    /// Updates the currently used instance resetting all cached entities.
+    pub fn update_instance(&mut self, instance: Instance) {
+        if instance == self.instance() {
+            return;
+        }
+        self.set_instance(instance);
+        self.default_memory = None;
+        self.default_table = None;
+        self.last_func = None;
+    }
+
+    /// Loads the default [`Memory`] of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a default linear memory.
+    fn load_default_memory(&mut self, ctx: impl AsContext) -> Memory {
+        let default_memory = self
+            .instance()
+            .get_memory(ctx.as_context(), DEFAULT_MEMORY_INDEX)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing default linear memory for instance: {:?}",
+                    self.instance
+                )
+            });
+        self.default_memory = Some(default_memory);
+        default_memory
+    }
+
+    /// Loads the default [`Table`] of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a default table.
+    fn load_default_table(&mut self, ctx: impl AsContext) -> Table {
+        let default_table = self
+            .instance()
+            .get_table(ctx.as_context(), DEFAULT_TABLE_INDEX)
+            .unwrap_or_else(|| panic!("missing default table for instance: {:?}", self.instance));
+        self.default_table = Some(default_table);
+        default_table
+    }
+
+    /// Returns the default [`Memory`] of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a default linear memory.
+    pub fn default_memory(&mut self, ctx: impl AsContext, _instance: Instance) -> Memory {
+        match self.default_memory {
+            Some(default_memory) => default_memory,
+            None => self.load_default_memory(ctx),
+        }
+    }
+
+    /// Returns the default [`Table`] of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a default table.
+    pub fn default_table(&mut self, ctx: impl AsContext, _instance: Instance) -> Table {
+        match self.default_table {
+            Some(default_table) => default_table,
+            None => self.load_default_table(ctx),
+        }
+    }
+
+    /// Loads the [`Func`] at `index` of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a default table.
+    fn load_func_at(&mut self, ctx: impl AsContext, index: u32) -> Func {
+        let func = self
+            .instance()
+            .get_func(ctx.as_context(), index)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing func at index {index} for instance: {:?}",
+                    self.instance
+                )
+            });
+        self.last_func = Some((index, func));
+        func
+    }
+
+    /// Loads the [`Func`] at `index` of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a [`Func`] at the index.
+    pub fn get_func(&mut self, ctx: impl AsContext, _instance: Instance, func_idx: u32) -> Func {
+        match self.last_func {
+            Some((index, func)) if index == func_idx => func,
+            _ => self.load_func_at(ctx, func_idx),
+        }
+    }
+}

--- a/wasmi_v1/src/engine/code_map.rs
+++ b/wasmi_v1/src/engine/code_map.rs
@@ -148,7 +148,12 @@ pub struct ResolvedFuncBody<'a> {
     max_stack_height: usize,
 }
 
-impl ResolvedFuncBody<'_> {
+impl<'a> ResolvedFuncBody<'a> {
+    /// Returns the instructions of the [`ResolvedFuncBody`].
+    pub fn insts(&self) -> Instructions<'a> {
+        Instructions { insts: &self.insts }
+    }
+
     /// Returns the instruction at the given index.
     ///
     /// # Panics
@@ -175,7 +180,13 @@ impl ResolvedFuncBody<'_> {
     }
 }
 
-impl<'a> ResolvedFuncBody<'a> {
+/// The instructions of a resolved [`FuncBody`].
+#[derive(Debug, Copy, Clone)]
+pub struct Instructions<'a> {
+    insts: &'a [Instruction],
+}
+
+impl<'a> Instructions<'a> {
     /// Returns a shared reference to the instruction at the given `pc`.
     ///
     /// # Panics (Debug)

--- a/wasmi_v1/src/engine/code_map.rs
+++ b/wasmi_v1/src/engine/code_map.rs
@@ -2,7 +2,6 @@
 
 use super::{super::Index, Instruction};
 use alloc::vec::Vec;
-use core::iter;
 
 /// A reference to a Wasm function body stored in the [`CodeMap`].
 #[derive(Debug, Copy, Clone)]
@@ -27,147 +26,18 @@ pub struct InstructionsRef {
     end: usize,
 }
 
-/// Datastructure to efficiently store Wasm function bodies.
-#[derive(Debug, Default)]
-pub struct CodeMap {
-    /// The instructions of all allocated function bodies.
-    ///
-    /// By storing all `wasmi` bytecode instructions in a single
-    /// allocation we avoid an indirection when calling a function
-    /// compared to a solution that stores instructions of different
-    /// function bodies in different allocations.
-    ///
-    /// Also this improves efficiency of deallocating the [`CodeMap`]
-    /// and generally improves data locality.
-    insts: Vec<Instruction>,
-}
-
-impl CodeMap {
-    /// Returns the next [`FuncBody`] index.
-    fn next_index(&self) -> FuncBody {
-        FuncBody(self.insts.len())
-    }
-
-    /// Allocates a new function body to the [`CodeMap`].
-    ///
-    /// Returns a reference to the allocated function body that can
-    /// be used with [`CodeMap::resolve`] in order to resolve its
-    /// instructions.
-    pub fn alloc<I>(&mut self, len_locals: usize, max_stack_height: usize, insts: I) -> FuncBody
-    where
-        I: IntoIterator<Item = Instruction>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let idx = self.next_index();
-        // We are inserting an artificial `unreachable` Wasm instruction
-        // in between instructions of different function bodies as a small
-        // safety precaution.
-        let insts = insts.into_iter();
-        let len_instructions = insts.len().try_into().unwrap_or_else(|error| {
-            panic!(
-                "encountered too many instructions (= {}) for function: {}",
-                insts.len(),
-                error
-            )
-        });
-        let max_stack_height = (max_stack_height + len_locals)
-            .try_into()
-            .unwrap_or_else(|error| {
-                panic!(
-                "encountered function that requires too many stack values (= {}) for function: {}",
-                max_stack_height, error
-            )
-            });
-        let len_locals = len_locals.try_into().unwrap_or_else(|error| {
-            panic!(
-                "encountered too many local variables (= {}) for function: {}",
-                len_locals, error
-            )
-        });
-        let start = iter::once(Instruction::FuncBodyStart {
-            len_instructions,
-            len_locals,
-            max_stack_height,
-        });
-        let end = iter::once(Instruction::FuncBodyEnd);
-        self.insts.extend(start.chain(insts).chain(end));
-        idx
-    }
-
-    /// Resolves the instructions given an [`InstructionsRef`].
-    pub fn insts(&self, iref: InstructionsRef) -> Instructions {
-        Instructions {
-            insts: &self.insts[iref.start..iref.end],
-        }
-    }
-
-    /// Resolves the instruction of the function body.
-    ///
-    /// # Panics
-    ///
-    /// If the given `func_body` is invalid for this [`CodeMap`].
-    pub fn resolve(&self, func_body: FuncBody) -> ResolvedFuncBody {
-        let offset = func_body.into_usize();
-        let (len_instructions, len_locals, max_stack_height) = match &self.insts[offset] {
-            Instruction::FuncBodyStart {
-                len_instructions,
-                len_locals,
-                max_stack_height,
-            } => (*len_instructions, *len_locals, *max_stack_height),
-            unexpected => panic!(
-                "expected function start instruction but found: {:?}",
-                unexpected
-            ),
-        };
-        let len_instructions = len_instructions as usize;
-        let len_locals = len_locals as usize;
-        let max_stack_height = max_stack_height as usize;
-        // The index of the first instruction in the function body.
-        let first_inst = offset + 1;
-        {
-            // Assert that the end of the function instructions is
-            // properly guarded with the `FuncBodyEnd` sentinel.
-            //
-            // This check is not needed to validate the integrity of
-            // the resolution procedure and therefore the below assertion
-            // is only performed in debug mode.
-            let end = &self.insts[first_inst + len_instructions];
-            debug_assert!(
-                matches!(end, Instruction::FuncBodyEnd),
-                "expected function end instruction but found: {:?}",
-                end,
-            );
-        }
-        let iref = InstructionsRef {
-            start: first_inst,
-            end: first_inst + len_instructions,
-        };
-        ResolvedFuncBody {
-            iref,
-            len_locals,
-            max_stack_height,
-        }
-    }
-}
-
-/// A resolved Wasm function body that is stored in a [`CodeMap`].
-///
-/// Allows to immutably access the `wasmi` instructions of a Wasm
-/// function stored in the [`CodeMap`].
-///
-/// # Dev. Note
-///
-/// This does not include the [`Instruction::FuncBodyStart`] and
-/// [`Instruction::FuncBodyEnd`] instructions surrounding the instructions
-/// of a function body in the [`CodeMap`].
+/// Meta information about a compiled function.
 #[derive(Debug, Copy, Clone)]
-pub struct ResolvedFuncBody {
+pub struct FuncHeader {
+    /// A reference to the instructions of the function.
     iref: InstructionsRef,
+    /// The number of local variables of the function.
     len_locals: usize,
+    /// The maximum stack heihgt usage of the function during execution.
     max_stack_height: usize,
 }
 
-impl ResolvedFuncBody {
+impl FuncHeader {
     /// Returns a reference to the instructions of the [`ResolvedFuncBody`].
     pub fn iref(&self) -> InstructionsRef {
         self.iref
@@ -186,6 +56,63 @@ impl ResolvedFuncBody {
     /// _not_ include the amount of input parameters to the function.
     pub fn max_stack_height(&self) -> usize {
         self.max_stack_height
+    }
+}
+
+/// Datastructure to efficiently store Wasm function bodies.
+#[derive(Debug, Default)]
+pub struct CodeMap {
+    /// The headers of all compiled functions.
+    headers: Vec<FuncHeader>,
+    /// The instructions of all allocated function bodies.
+    ///
+    /// By storing all `wasmi` bytecode instructions in a single
+    /// allocation we avoid an indirection when calling a function
+    /// compared to a solution that stores instructions of different
+    /// function bodies in different allocations.
+    ///
+    /// Also this improves efficiency of deallocating the [`CodeMap`]
+    /// and generally improves data locality.
+    insts: Vec<Instruction>,
+}
+
+impl CodeMap {
+    /// Allocates a new function body to the [`CodeMap`].
+    ///
+    /// Returns a reference to the allocated function body that can
+    /// be used with [`CodeMap::resolve`] in order to resolve its
+    /// instructions.
+    pub fn alloc<I>(&mut self, len_locals: usize, max_stack_height: usize, insts: I) -> FuncBody
+    where
+        I: IntoIterator<Item = Instruction>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let start = self.insts.len();
+        self.insts.extend(insts);
+        let end = self.insts.len();
+        let iref = InstructionsRef { start, end };
+        let header = FuncHeader {
+            iref,
+            len_locals,
+            max_stack_height: len_locals + max_stack_height,
+        };
+        let header_index = self.headers.len();
+        self.headers.push(header);
+        FuncBody(header_index)
+    }
+
+    /// Resolves the instructions given an [`InstructionsRef`].
+    pub fn insts(&self, iref: InstructionsRef) -> Instructions {
+        Instructions {
+            // insts: &self.insts[iref.start..iref.end],
+            insts: unsafe { self.insts.get_unchecked(iref.start..iref.end) },
+        }
+    }
+
+    /// Returns the [`FuncHeader`] of the [`FuncBody`].
+    pub fn header(&self, func_body: FuncBody) -> &FuncHeader {
+        unsafe { self.headers.get_unchecked(func_body.0) }
+        // self.headers[func_body.0]
     }
 }
 

--- a/wasmi_v1/src/engine/code_map.rs
+++ b/wasmi_v1/src/engine/code_map.rs
@@ -85,7 +85,6 @@ impl CodeMap {
     pub fn alloc<I>(&mut self, len_locals: usize, max_stack_height: usize, insts: I) -> FuncBody
     where
         I: IntoIterator<Item = Instruction>,
-        I::IntoIter: ExactSizeIterator,
     {
         let start = self.insts.len();
         self.insts.extend(insts);

--- a/wasmi_v1/src/engine/code_map.rs
+++ b/wasmi_v1/src/engine/code_map.rs
@@ -104,15 +104,13 @@ impl CodeMap {
     /// Resolves the instructions given an [`InstructionsRef`].
     pub fn insts(&self, iref: InstructionsRef) -> Instructions {
         Instructions {
-            // insts: &self.insts[iref.start..iref.end],
-            insts: unsafe { self.insts.get_unchecked(iref.start..iref.end) },
+            insts: &self.insts[iref.start..iref.end],
         }
     }
 
     /// Returns the [`FuncHeader`] of the [`FuncBody`].
     pub fn header(&self, func_body: FuncBody) -> &FuncHeader {
-        unsafe { self.headers.get_unchecked(func_body.0) }
-        // self.headers[func_body.0]
+        &self.headers[func_body.0]
     }
 }
 

--- a/wasmi_v1/src/engine/code_map.rs
+++ b/wasmi_v1/src/engine/code_map.rs
@@ -38,7 +38,7 @@ pub struct FuncHeader {
 }
 
 impl FuncHeader {
-    /// Returns a reference to the instructions of the [`ResolvedFuncBody`].
+    /// Returns a reference to the instructions of the function.
     pub fn iref(&self) -> InstructionsRef {
         self.iref
     }
@@ -80,7 +80,7 @@ impl CodeMap {
     /// Allocates a new function body to the [`CodeMap`].
     ///
     /// Returns a reference to the allocated function body that can
-    /// be used with [`CodeMap::resolve`] in order to resolve its
+    /// be used with [`CodeMap::header`] in order to resolve its
     /// instructions.
     pub fn alloc<I>(&mut self, len_locals: usize, max_stack_height: usize, insts: I) -> FuncBody
     where
@@ -134,7 +134,7 @@ impl<'a> Instructions<'a> {
     ///
     /// # Panics (Debug)
     ///
-    /// Panics in debug mode if the `pc` is invalid for the [`ResolvedFuncBody`].
+    /// Panics in debug mode if the `pc` is invalid for the [`Instructions`].
     #[inline(always)]
     pub unsafe fn get_release_unchecked(&self, pc: usize) -> &Instruction {
         debug_assert!(

--- a/wasmi_v1/src/engine/config.rs
+++ b/wasmi_v1/src/engine/config.rs
@@ -30,9 +30,14 @@ impl Default for Config {
 
 impl Config {
     /// Sets the [`StackLimits`] for the [`Config`].
-    pub fn stack_limits(&mut self, stack_limits: StackLimits) -> &mut Self {
+    pub fn set_stack_limits(&mut self, stack_limits: StackLimits) -> &mut Self {
         self.stack_limits = stack_limits;
         self
+    }
+
+    /// Returns the [`StackLimits`] of the [`Config`].
+    pub(super) fn stack_limits(&self) -> StackLimits {
+        self.stack_limits
     }
 
     /// Enable or disable the [`mutable-global`] Wasm proposal for the [`Config`].

--- a/wasmi_v1/src/engine/config.rs
+++ b/wasmi_v1/src/engine/config.rs
@@ -1,0 +1,105 @@
+use super::stack::StackLimits;
+
+/// Configuration for an [`Engine`].
+#[derive(Debug, Copy, Clone)]
+pub struct Config {
+    /// The limits set on the value stack and call stack.
+    stack_limits: StackLimits,
+    /// Is `true` if the `mutable-global` Wasm proposal is enabled.
+    mutable_global: bool,
+    /// Is `true` if the `sign-extension` Wasm proposal is enabled.
+    sign_extension: bool,
+    /// Is `true` if the `saturating-float-to-int` Wasm proposal is enabled.
+    saturating_float_to_int: bool,
+    /// Is `true` if the [`multi-value`] Wasm proposal is enabled.
+    multi_value: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            stack_limits: StackLimits::default(),
+            mutable_global: true,
+            sign_extension: true,
+            saturating_float_to_int: true,
+            multi_value: true,
+        }
+    }
+}
+
+impl Config {
+    /// Sets the [`StackLimits`] for the [`Config`].
+    pub fn stack_limits(&mut self, stack_limits: StackLimits) -> &mut Self {
+        self.stack_limits = stack_limits;
+        self
+    }
+
+    /// Enable or disable the [`mutable-global`] Wasm proposal for the [`Config`].
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`mutable-global`]: https://github.com/WebAssembly/mutable-global
+    pub fn wasm_mutable_global(&mut self, enable: bool) -> &mut Self {
+        self.mutable_global = enable;
+        self
+    }
+
+    /// Enable or disable the [`sign-extension`] Wasm proposal for the [`Config`].
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`sign-extension`]: https://github.com/WebAssembly/sign-extension-ops
+    pub fn wasm_sign_extension(&mut self, enable: bool) -> &mut Self {
+        self.sign_extension = enable;
+        self
+    }
+
+    /// Enable or disable the [`saturating-float-to-int`] Wasm proposal for the [`Config`].
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`saturating-float-to-int`]:
+    /// https://github.com/WebAssembly/nontrapping-float-to-int-conversions
+    pub fn wasm_saturating_float_to_int(&mut self, enable: bool) -> &mut Self {
+        self.saturating_float_to_int = enable;
+        self
+    }
+
+    /// Enable or disable the [`multi-value`] Wasm proposal for the [`Config`].
+    ///
+    /// # Note
+    ///
+    /// Enabled by default.
+    ///
+    /// [`multi-value`]: https://github.com/WebAssembly/multi-value
+    pub fn wasm_multi_value(&mut self, enable: bool) -> &mut Self {
+        self.multi_value = enable;
+        self
+    }
+
+    /// Returns `true` if the `mutable-global` Wasm proposal is enabled.
+    pub(crate) fn get_mutable_global(&self) -> bool {
+        self.mutable_global
+    }
+
+    /// Returns `true` if the `sign-extension` Wasm proposal is enabled.
+    pub(crate) fn get_sign_extension(&self) -> bool {
+        self.sign_extension
+    }
+
+    /// Returns `true` if the `saturating-float-to-int` Wasm proposal is enabled.
+    pub(crate) fn get_saturating_float_to_int(&self) -> bool {
+        self.saturating_float_to_int
+    }
+
+    /// Returns `true` if the `multi-value` Wasm proposal is enabled.
+    pub(crate) fn get_multi_value(&self) -> bool {
+        self.multi_value
+    }
+}

--- a/wasmi_v1/src/engine/config.rs
+++ b/wasmi_v1/src/engine/config.rs
@@ -7,13 +7,13 @@ pub struct Config {
     /// The limits set on the value stack and call stack.
     stack_limits: StackLimits,
     /// Is `true` if the `mutable-global` Wasm proposal is enabled.
-    pub(super) mutable_global: bool,
+    mutable_global: bool,
     /// Is `true` if the `sign-extension` Wasm proposal is enabled.
-    pub(super) sign_extension: bool,
+    sign_extension: bool,
     /// Is `true` if the `saturating-float-to-int` Wasm proposal is enabled.
-    pub(super) saturating_float_to_int: bool,
+    saturating_float_to_int: bool,
     /// Is `true` if the [`multi-value`] Wasm proposal is enabled.
-    pub(super) multi_value: bool,
+    multi_value: bool,
 }
 
 impl Default for Config {

--- a/wasmi_v1/src/engine/config.rs
+++ b/wasmi_v1/src/engine/config.rs
@@ -1,4 +1,5 @@
 use super::stack::StackLimits;
+use wasmparser::WasmFeatures;
 
 /// Configuration for an [`Engine`].
 #[derive(Debug, Copy, Clone)]
@@ -6,13 +7,13 @@ pub struct Config {
     /// The limits set on the value stack and call stack.
     stack_limits: StackLimits,
     /// Is `true` if the `mutable-global` Wasm proposal is enabled.
-    mutable_global: bool,
+    pub(super) mutable_global: bool,
     /// Is `true` if the `sign-extension` Wasm proposal is enabled.
-    sign_extension: bool,
+    pub(super) sign_extension: bool,
     /// Is `true` if the `saturating-float-to-int` Wasm proposal is enabled.
-    saturating_float_to_int: bool,
+    pub(super) saturating_float_to_int: bool,
     /// Is `true` if the [`multi-value`] Wasm proposal is enabled.
-    multi_value: bool,
+    pub(super) multi_value: bool,
 }
 
 impl Default for Config {
@@ -83,23 +84,25 @@ impl Config {
         self
     }
 
-    /// Returns `true` if the `mutable-global` Wasm proposal is enabled.
-    pub(crate) fn get_mutable_global(&self) -> bool {
-        self.mutable_global
-    }
-
-    /// Returns `true` if the `sign-extension` Wasm proposal is enabled.
-    pub(crate) fn get_sign_extension(&self) -> bool {
-        self.sign_extension
-    }
-
-    /// Returns `true` if the `saturating-float-to-int` Wasm proposal is enabled.
-    pub(crate) fn get_saturating_float_to_int(&self) -> bool {
-        self.saturating_float_to_int
-    }
-
-    /// Returns `true` if the `multi-value` Wasm proposal is enabled.
-    pub(crate) fn get_multi_value(&self) -> bool {
-        self.multi_value
+    /// Returns the [`WasmFeatures`] represented by the [`Config`].
+    pub fn wasm_features(&self) -> WasmFeatures {
+        WasmFeatures {
+            multi_value: self.multi_value,
+            mutable_global: self.mutable_global,
+            saturating_float_to_int: self.saturating_float_to_int,
+            sign_extension: self.sign_extension,
+            reference_types: false,
+            bulk_memory: false,
+            module_linking: false,
+            simd: false,
+            relaxed_simd: false,
+            threads: false,
+            tail_call: false,
+            deterministic_only: true,
+            multi_memory: false,
+            exceptions: false,
+            memory64: false,
+            extended_const: false,
+        }
     }
 }

--- a/wasmi_v1/src/engine/config.rs
+++ b/wasmi_v1/src/engine/config.rs
@@ -2,6 +2,8 @@ use super::stack::StackLimits;
 use wasmparser::WasmFeatures;
 
 /// Configuration for an [`Engine`].
+///
+/// [`Engine`]: [`crate::Engine`]
 #[derive(Debug, Copy, Clone)]
 pub struct Config {
     /// The limits set on the value stack and call stack.

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -5,7 +5,7 @@ use super::{
     CallOutcome,
     DropKeep,
     EngineInner,
-    FunctionFrame,
+    FuncFrame,
     ResolvedFuncBody,
     Target,
     ValueStack,
@@ -23,7 +23,7 @@ pub struct FunctionExecutor<'engine, 'func> {
     /// Stores the value stack of live values on the Wasm stack.
     value_stack: &'engine mut ValueStack,
     /// The function frame that is being executed.
-    frame: &'func mut FunctionFrame,
+    frame: &'func mut FuncFrame,
     /// The resolved function body of the executed function frame.
     func_body: ResolvedFuncBody<'engine>,
 }
@@ -32,7 +32,7 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
     /// Creates an execution context for the given [`FunctionFrame`].
     pub fn new(
         engine: &'engine mut EngineInner,
-        frame: &'func mut FunctionFrame,
+        frame: &'func mut FuncFrame,
     ) -> Result<Self, Trap> {
         let resolved = engine.code_map.resolve(frame.func_body);
         frame.initialize(resolved, &mut engine.stack.values)?;
@@ -286,7 +286,7 @@ struct ExecutionContext<'engine, 'func, Ctx> {
     /// Stores the value stack of live values on the Wasm stack.
     value_stack: &'engine mut ValueStack,
     /// The function frame that is being executed.
-    frame: &'func mut FunctionFrame,
+    frame: &'func mut FuncFrame,
     /// A mutable [`Store`] context.
     ///
     /// [`Store`]: [`crate::v1::Store`]
@@ -300,7 +300,7 @@ where
     /// Creates a new [`ExecutionContext`] for executing a single `wasmi` bytecode instruction.
     pub fn new(
         value_stack: &'engine mut ValueStack,
-        frame: &'func mut FunctionFrame,
+        frame: &'func mut FuncFrame,
         ctx: Ctx,
         pc: usize,
     ) -> Self {

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -1,11 +1,11 @@
 use super::{
     super::{Global, Memory, Table},
     bytecode::{FuncIdx, GlobalIdx, Instruction, LocalIdx, Offset, SignatureIdx},
+    code_map::Instructions,
     AsContextMut,
     CallOutcome,
     DropKeep,
     FuncFrame,
-    ResolvedFuncBody,
     Target,
     ValueStack,
 };
@@ -24,19 +24,19 @@ pub struct FunctionExecutor<'engine, 'func> {
     /// The function frame that is being executed.
     frame: &'func mut FuncFrame,
     /// The resolved function body of the executed function frame.
-    func_body: ResolvedFuncBody<'engine>,
+    insts: Instructions<'engine>,
 }
 
 impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
     /// Creates an execution context for the given [`FunctionFrame`].
     pub fn new(
         frame: &'func mut FuncFrame,
-        func_body: ResolvedFuncBody<'engine>,
+        insts: Instructions<'engine>,
         value_stack: &'engine mut ValueStack,
     ) -> Self {
         Self {
             frame,
-            func_body,
+            insts,
             value_stack,
         }
     }
@@ -56,7 +56,7 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
             //
             // Properly constructed `wasmi` bytecode can never produce invalid `pc`.
             let instr = unsafe {
-                self.func_body.get_release_unchecked(exec_ctx.pc)
+                self.insts.get_release_unchecked(exec_ctx.pc)
             };
             match instr {
                 Instr::GetLocal { local_depth } => { exec_ctx.visit_get_local(*local_depth)?; }

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -29,6 +29,7 @@ pub struct FunctionExecutor<'engine, 'func> {
 
 impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
     /// Creates an execution context for the given [`FunctionFrame`].
+    #[inline(always)]
     pub fn new(
         frame: &'func mut FuncFrame,
         insts: Instructions<'engine>,
@@ -47,6 +48,7 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
     ///
     /// This executes instructions sequentially until either the function
     /// calls into another function or the function returns to its caller.
+    #[inline(always)]
     #[rustfmt::skip]
     pub fn execute_frame(self, mut ctx: impl AsContextMut) -> Result<CallOutcome, Trap> {
         use Instruction as Instr;

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -334,7 +334,7 @@ where
     /// If there is no global variable at the given index.
     fn global(&self, global_index: GlobalIdx) -> Global {
         self.frame
-            .instance
+            .instance()
             .get_global(self.ctx.as_context(), global_index.into_inner())
             .unwrap_or_else(|| panic!("missing global at index {:?}", global_index))
     }
@@ -645,7 +645,7 @@ where
     fn visit_call(&mut self, func_index: FuncIdx) -> Result<CallOutcome, Trap> {
         let func = self
             .frame
-            .instance
+            .instance()
             .get_func(self.ctx.as_context_mut(), func_index.into_inner())
             .unwrap_or_else(|| panic!("missing function at index {:?}", func_index));
         self.call_func(func)
@@ -661,7 +661,7 @@ where
         let actual_signature = func.signature(self.ctx.as_context());
         let expected_signature = self
             .frame
-            .instance
+            .instance()
             .get_signature(self.ctx.as_context(), signature_index.into_inner())
             .unwrap_or_else(|| {
                 panic!(

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -4,7 +4,6 @@ use super::{
     AsContextMut,
     CallOutcome,
     DropKeep,
-    EngineInner,
     FuncFrame,
     ResolvedFuncBody,
     Target,
@@ -31,16 +30,15 @@ pub struct FunctionExecutor<'engine, 'func> {
 impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
     /// Creates an execution context for the given [`FunctionFrame`].
     pub fn new(
-        engine: &'engine mut EngineInner,
         frame: &'func mut FuncFrame,
-    ) -> Result<Self, Trap> {
-        let resolved = engine.code_map.resolve(frame.func_body);
-        frame.initialize(resolved, &mut engine.stack.values)?;
-        Ok(Self {
-            value_stack: &mut engine.stack.values,
+        func_body: ResolvedFuncBody<'engine>,
+        value_stack: &'engine mut ValueStack,
+    ) -> Self {
+        Self {
             frame,
-            func_body: resolved,
-        })
+            func_body,
+            value_stack,
+        }
     }
 
     /// Executes the current function frame.

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -29,7 +29,7 @@ pub struct FunctionExecutor<'engine, 'func> {
 }
 
 impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
-    /// Creates an execution context for the given [`FunctionFrame`].
+    /// Creates an execution context for the given [`FuncFrame`].
     #[inline(always)]
     pub fn new(
         frame: &'func mut FuncFrame,

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -47,7 +47,6 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
     ///
     /// This executes instructions sequentially until either the function
     /// calls into another function or the function returns to its caller.
-    #[inline(always)]
     #[rustfmt::skip]
     pub fn execute_frame(self, mut ctx: impl AsContextMut) -> Result<CallOutcome, Trap> {
         use Instruction as Instr;

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -35,9 +35,9 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
         frame: &'func mut FunctionFrame,
     ) -> Result<Self, Trap> {
         let resolved = engine.code_map.resolve(frame.func_body);
-        frame.initialize(resolved, &mut engine.value_stack)?;
+        frame.initialize(resolved, &mut engine.stack.values)?;
         Ok(Self {
-            value_stack: &mut engine.value_stack,
+            value_stack: &mut engine.stack.values,
             frame,
             func_body: resolved,
         })

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -250,26 +250,6 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 Instr::I64Extend8S => { exec_ctx.visit_i64_sign_extend8()?; }
                 Instr::I64Extend16S => { exec_ctx.visit_i64_sign_extend16()?; }
                 Instr::I64Extend32S => { exec_ctx.visit_i64_sign_extend32()?; }
-                Instr::FuncBodyStart { .. } | Instruction::FuncBodyEnd => {
-                    if cfg!(debug) {
-                        unreachable!(
-                            "expected start of a new instruction \
-                            at index {} but found: {instr:?}",
-                            exec_ctx.pc
-                        )
-                    } else {
-                        // # Safety (--release)
-                        //
-                        // It is guaranteed by construction of the `wasmi` bytecode
-                        // that these variants are never visited during execution.
-                        // We do not use the `unreachable!()` macro since that
-                        // results in significant slowdown in the range of 5-15%
-                        // for most execution benchmarks.
-                        unsafe {
-                            core::hint::unreachable_unchecked()
-                        }
-                    }
-                }
             }
         }
     }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -17,7 +17,7 @@ use self::{
     code_map::{CodeMap, ResolvedFuncBody},
     exec_context::FunctionExecutor,
     func_types::FuncTypeRegistry,
-    stack::{FunctionFrame, ValueStack, Stack, StackLimits},
+    stack::{FunctionFrame, ValueStack, Stack},
 };
 pub use self::{
     bytecode::{DropKeep, Target},
@@ -234,7 +234,7 @@ impl EngineInner {
         let engine_idx = EngineIdx::new();
         Self {
             config: *config,
-            stack: Stack::new(StackLimits::default()), // TODO
+            stack: Stack::new(config.stack_limits()),
             code_map: CodeMap::default(),
             func_types: FuncTypeRegistry::new(engine_idx),
         }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod bytecode;
 pub mod code_map;
+mod config;
 pub mod exec_context;
 mod func_args;
 mod func_builder;
@@ -9,6 +10,7 @@ mod func_types;
 pub mod stack;
 mod traits;
 
+pub use self::config::Config;
 pub(crate) use self::func_args::{FuncParams, FuncResults};
 use self::{
     bytecode::Instruction,
@@ -99,114 +101,6 @@ type Guarded<Idx> = GuardedEntity<EngineIdx, Idx>;
 #[derive(Debug, Clone)]
 pub struct Engine {
     inner: Arc<Mutex<EngineInner>>,
-}
-
-/// Configuration for an [`Engine`].
-#[derive(Debug, Copy, Clone)]
-pub struct Config {
-    /// Is `true` if the [`mutable-global`] Wasm proposal is enabled.
-    ///
-    /// # Note
-    ///
-    /// Enabled by default.
-    ///
-    /// [`mutable-global`]: https://github.com/WebAssembly/mutable-global
-    mutable_global: bool,
-    /// Is `true` if the [`sign-extension`] Wasm proposal is enabled.
-    ///
-    /// # Note
-    ///
-    /// Enabled by default.
-    ///
-    /// [`sign-extension`]: https://github.com/WebAssembly/sign-extension-ops
-    sign_extension: bool,
-    /// Is `true` if the [`saturating-float-to-int`] Wasm proposal is enabled.
-    ///
-    /// # Note
-    ///
-    /// Enabled by default.
-    ///
-    /// [`saturating-float-to-int`]: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
-    saturating_float_to_int: bool,
-    /// Is `true` if the [`multi-value`] Wasm proposal is enabled.
-    ///
-    /// # Note
-    ///
-    /// Enabled by default.
-    ///
-    /// [`multi-value`]: https://github.com/WebAssembly/multi-value
-    multi_value: bool,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            mutable_global: true,
-            sign_extension: true,
-            saturating_float_to_int: true,
-            multi_value: true,
-        }
-    }
-}
-
-impl Config {
-    /// Creates the [`Config`] for the Wasm MVP (minimum viable product).
-    ///
-    /// # Note
-    ///
-    /// The Wasm MVP has no Wasm proposals enabled by default.
-    pub const fn mvp() -> Self {
-        Self {
-            mutable_global: false,
-            sign_extension: false,
-            saturating_float_to_int: false,
-            multi_value: false,
-        }
-    }
-
-    /// Enables the `mutable-global` Wasm proposal.
-    pub const fn enable_mutable_global(mut self, enable: bool) -> Self {
-        self.mutable_global = enable;
-        self
-    }
-
-    /// Returns `true` if the `mutable-global` Wasm proposal is enabled.
-    pub const fn mutable_global(&self) -> bool {
-        self.mutable_global
-    }
-
-    /// Enables the `sign-extension` Wasm proposal.
-    pub const fn enable_sign_extension(mut self, enable: bool) -> Self {
-        self.sign_extension = enable;
-        self
-    }
-
-    /// Returns `true` if the `sign-extension` Wasm proposal is enabled.
-    pub const fn sign_extension(&self) -> bool {
-        self.sign_extension
-    }
-
-    /// Enables the `saturating-float-to-int` Wasm proposal.
-    pub const fn enable_saturating_float_to_int(mut self, enable: bool) -> Self {
-        self.saturating_float_to_int = enable;
-        self
-    }
-
-    /// Returns `true` if the `saturating-float-to-int` Wasm proposal is enabled.
-    pub const fn saturating_float_to_int(&self) -> bool {
-        self.saturating_float_to_int
-    }
-
-    /// Enables the `multi-value` Wasm proposal.
-    pub const fn enable_multi_value(mut self, enable: bool) -> Self {
-        self.multi_value = enable;
-        self
-    }
-
-    /// Returns `true` if the `multi-value` Wasm proposal is enabled.
-    pub const fn multi_value(&self) -> bool {
-        self.multi_value
-    }
 }
 
 impl Default for Engine {

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -285,7 +285,7 @@ impl EngineInner {
             FuncEntityInternal::Wasm(wasm_func) => {
                 let signature = wasm_func.signature();
                 let fref = self.stack.call_wasm(func, wasm_func, &self.code_map)?;
-                self.execute_wasm_func2(&mut ctx, fref)?;
+                self.execute_wasm_func(&mut ctx, fref)?;
                 signature
             }
             FuncEntityInternal::Host(host_func) => {
@@ -347,7 +347,7 @@ impl EngineInner {
         )
     }
 
-    fn execute_wasm_func2(
+    fn execute_wasm_func(
         &mut self,
         mut ctx: impl AsContextMut,
         mut fref: FuncFrameRef,

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -171,12 +171,9 @@ impl Engine {
     /// If the [`FuncBody`] is invalid for the [`Engine`].
     #[cfg(test)]
     pub(crate) fn resolve_inst(&self, func_body: FuncBody, index: usize) -> Option<Instruction> {
-        self.inner
-            .lock()
-            .code_map
-            .resolve(func_body)
-            .get(index)
-            .map(Clone::clone)
+        let this = self.inner.lock();
+        let iref = this.code_map.resolve(func_body).iref();
+        this.code_map.insts(iref).get(index).copied()
     }
 
     /// Executes the given [`Func`] using the given arguments `params` and stores the result into `results`.
@@ -356,31 +353,32 @@ impl EngineInner {
     fn execute_wasm_func(
         &mut self,
         mut ctx: impl AsContextMut,
-        frame: FuncFrame,
+        mut frame: FuncFrame,
     ) -> Result<(), Trap> {
-        let mut func = self.stack.resolve(frame, &self.code_map);
+        // let mut func = self.stack.resolve(frame, &self.code_map);
         'outer: loop {
-            match self.stack.executor(&mut func).execute_frame(&mut ctx)? {
-                CallOutcome::Return => match self.stack.return_wasm(&self.code_map) {
+            match self
+                .stack
+                .executor(&mut frame, &self.code_map)
+                .execute_frame(&mut ctx)?
+            {
+                CallOutcome::Return => match self.stack.return_wasm() {
                     Some(caller) => {
-                        func = caller;
+                        frame = caller;
                         continue 'outer;
                     }
                     None => return Ok(()),
                 },
                 CallOutcome::NestedCall(called_func) => match called_func.as_internal(&ctx) {
                     FuncEntityInternal::Wasm(wasm_func) => {
-                        func = self.stack.call_wasm(
-                            func.frame,
-                            called_func,
-                            wasm_func,
-                            &self.code_map,
-                        )?;
+                        frame =
+                            self.stack
+                                .call_wasm(frame, called_func, wasm_func, &self.code_map)?;
                     }
                     FuncEntityInternal::Host(host_func) => {
                         let host_func = host_func.clone();
                         self.stack
-                            .call_host(&mut ctx, &func, host_func, &self.func_types)?;
+                            .call_host(&mut ctx, &frame, host_func, &self.func_types)?;
                     }
                 },
             }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -353,7 +353,6 @@ impl EngineInner {
         mut fref: FuncFrameRef,
     ) -> Result<(), Trap> {
         'outer: loop {
-            // println!("EngineInner::execute_wasm_func2 fref = {fref:?}");
             match self
                 .stack
                 .executor(fref, &self.code_map)

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -347,6 +347,12 @@ impl EngineInner {
         )
     }
 
+    /// Executes the top most Wasm function on the [`Stack`] until the [`Stack`] is empty.
+    ///
+    /// # Errors
+    ///
+    /// - When encountering a Wasm trap during the execution of `func`.
+    /// - When a called host function trapped.
     fn execute_wasm_func(
         &mut self,
         mut ctx: impl AsContextMut,

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -172,7 +172,7 @@ impl Engine {
     #[cfg(test)]
     pub(crate) fn resolve_inst(&self, func_body: FuncBody, index: usize) -> Option<Instruction> {
         let this = self.inner.lock();
-        let iref = this.code_map.resolve(func_body).iref();
+        let iref = this.code_map.header(func_body).iref();
         this.code_map.insts(iref).get(index).copied()
     }
 

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -8,7 +8,7 @@ mod func_args;
 mod func_builder;
 mod func_types;
 mod traits;
-pub mod value_stack;
+pub mod stack;
 
 pub(crate) use self::func_args::{FuncParams, FuncResults};
 use self::{
@@ -17,7 +17,7 @@ use self::{
     code_map::{CodeMap, ResolvedFuncBody},
     exec_context::FunctionExecutor,
     func_types::FuncTypeRegistry,
-    value_stack::ValueStack,
+    stack::ValueStack,
 };
 pub use self::{
     bytecode::{DropKeep, Target},

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -17,7 +17,7 @@ use self::{
     code_map::{CodeMap, ResolvedFuncBody},
     exec_context::FunctionExecutor,
     func_types::FuncTypeRegistry,
-    stack::{FunctionFrame, ValueStack, Stack},
+    stack::{FuncFrame, ValueStack, Stack},
 };
 pub use self::stack::StackLimits;
 pub use self::{
@@ -356,7 +356,7 @@ impl EngineInner {
     /// - If the given `results` do not match the the length of the expected results of `func`.
     /// - When encountering a Wasm trap during the execution of `func`.
     fn execute_wasm_func(&mut self, mut ctx: impl AsContextMut, func: Func) -> Result<(), Trap> {
-        let mut function_frame = FunctionFrame::new(&ctx, func);
+        let mut function_frame = FuncFrame::new(&ctx, func);
         'outer: loop {
             match self.execute_frame(&mut ctx, &mut function_frame)? {
                 CallOutcome::Return => match self.stack.frames.pop() {
@@ -368,7 +368,7 @@ impl EngineInner {
                 },
                 CallOutcome::NestedCall(func) => match func.as_internal(&ctx) {
                     FuncEntityInternal::Wasm(wasm_func) => {
-                        let nested_frame = FunctionFrame::new_wasm(func, wasm_func);
+                        let nested_frame = FuncFrame::new_wasm(func, wasm_func);
                         self.stack.frames.push(function_frame)?;
                         function_frame = nested_frame;
                     }
@@ -391,7 +391,7 @@ impl EngineInner {
     fn execute_frame(
         &mut self,
         mut ctx: impl AsContextMut,
-        frame: &mut FunctionFrame,
+        frame: &mut FuncFrame,
     ) -> Result<CallOutcome, Trap> {
         FunctionExecutor::new(self, frame)?.execute_frame(&mut ctx)
     }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -19,6 +19,7 @@ use self::{
     func_types::FuncTypeRegistry,
     stack::{FunctionFrame, ValueStack, Stack},
 };
+pub use self::stack::StackLimits;
 pub use self::{
     bytecode::{DropKeep, Target},
     code_map::FuncBody,

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -1,23 +1,21 @@
 //! The `wasmi` interpreter.
 
 pub mod bytecode;
-pub mod call_stack;
 pub mod code_map;
 pub mod exec_context;
 mod func_args;
 mod func_builder;
 mod func_types;
-mod traits;
 pub mod stack;
+mod traits;
 
 pub(crate) use self::func_args::{FuncParams, FuncResults};
 use self::{
     bytecode::Instruction,
-    call_stack::{CallStack, FunctionFrame},
     code_map::{CodeMap, ResolvedFuncBody},
     exec_context::FunctionExecutor,
     func_types::FuncTypeRegistry,
-    stack::ValueStack,
+    stack::{CallStack, FunctionFrame, ValueStack},
 };
 pub use self::{
     bytecode::{DropKeep, Target},

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -355,7 +355,6 @@ impl EngineInner {
         mut ctx: impl AsContextMut,
         mut frame: FuncFrame,
     ) -> Result<(), Trap> {
-        // let mut func = self.stack.resolve(frame, &self.code_map);
         'outer: loop {
             match self
                 .stack

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -42,12 +42,6 @@ use core::{
 pub use func_types::DedupFuncType;
 use spin::mutex::Mutex;
 
-/// Maximum number of bytes on the value stack.
-pub const DEFAULT_VALUE_STACK_LIMIT: usize = 1024 * 1024;
-
-/// Maximum number of levels on the call stack.
-pub const DEFAULT_CALL_STACK_LIMIT: usize = 64 * 1024;
-
 /// The outcome of a `wasmi` function execution.
 #[derive(Debug, Copy, Clone)]
 pub enum CallOutcome {

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -380,7 +380,7 @@ impl EngineInner {
                     FuncEntityInternal::Host(host_func) => {
                         let host_func = host_func.clone();
                         self.stack
-                            .call_host(&mut ctx, &frame, host_func, &self.func_types)?;
+                            .call_host(&mut ctx, frame, host_func, &self.func_types)?;
                     }
                 },
             }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -281,7 +281,7 @@ impl EngineInner {
         let signature = match func.as_internal(&ctx) {
             FuncEntityInternal::Wasm(wasm_func) => {
                 let signature = wasm_func.signature();
-                let mut frame = self.stack.call_wasm_root(func, wasm_func, &self.code_map)?;
+                let mut frame = self.stack.call_wasm_root(wasm_func, &self.code_map)?;
                 self.execute_wasm_func(&mut ctx, &mut frame)?;
                 signature
             }
@@ -370,8 +370,7 @@ impl EngineInner {
                 },
                 CallOutcome::NestedCall(called_func) => match called_func.as_internal(&ctx) {
                     FuncEntityInternal::Wasm(wasm_func) => {
-                        self.stack
-                            .call_wasm(frame, called_func, wasm_func, &self.code_map)?;
+                        self.stack.call_wasm(frame, wasm_func, &self.code_map)?;
                     }
                     FuncEntityInternal::Host(host_func) => {
                         let host_func = host_func.clone();

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -215,6 +215,12 @@ impl CallStack {
         }
     }
 
+    /// Returns a [`TrapCode`] signalling a stack overflow.
+    #[cold]
+    fn err_stack_overflow() -> TrapCode {
+        TrapCode::StackOverflow
+    }
+
     /// Pushes another [`FuncFrame`] to the [`CallStack`].
     ///
     /// # Errors
@@ -222,7 +228,7 @@ impl CallStack {
     /// If the [`FuncFrame`] is at the set recursion limit.
     pub fn push(&mut self, frame: FuncFrame) -> Result<(), TrapCode> {
         if self.len() == self.recursion_limit {
-            return Err(TrapCode::StackOverflow);
+            return Err(Self::err_stack_overflow());
         }
         self.frames.push(frame);
         Ok(())

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -15,6 +15,7 @@ use crate::{
     Table,
 };
 use alloc::vec::Vec;
+use super::err_stack_overflow;
 
 /// A function frame of a function on the call stack.
 #[derive(Debug, Copy, Clone)]
@@ -215,12 +216,6 @@ impl CallStack {
         }
     }
 
-    /// Returns a [`TrapCode`] signalling a stack overflow.
-    #[cold]
-    fn err_stack_overflow() -> TrapCode {
-        TrapCode::StackOverflow
-    }
-
     /// Pushes another [`FuncFrame`] to the [`CallStack`].
     ///
     /// # Errors
@@ -228,7 +223,7 @@ impl CallStack {
     /// If the [`FuncFrame`] is at the set recursion limit.
     pub fn push(&mut self, frame: FuncFrame) -> Result<(), TrapCode> {
         if self.len() == self.recursion_limit {
-            return Err(Self::err_stack_overflow());
+            return Err(err_stack_overflow());
         }
         self.frames.push(frame);
         Ok(())

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -12,6 +12,7 @@ use crate::{
     Table,
 };
 use alloc::vec::Vec;
+use core::mem::replace;
 
 /// A function frame of a function on the call stack.
 #[derive(Debug, Copy, Clone)]
@@ -174,7 +175,7 @@ impl CallStack {
     /// Pushes a Wasm function onto the [`CallStack`].
     pub(crate) fn push(
         &mut self,
-        caller: FuncFrame,
+        caller: &mut FuncFrame,
         func: Func,
         iref: InstructionsRef,
         instance: Instance,
@@ -183,6 +184,7 @@ impl CallStack {
             return Err(err_stack_overflow());
         }
         let frame = FuncFrame::new(func, iref, instance);
+        let caller = replace(caller, frame);
         self.frames.push(caller);
         Ok(frame)
     }

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -18,7 +18,7 @@ use alloc::vec::Vec;
 
 /// A function frame of a function in the call stack.
 #[derive(Debug, Copy, Clone)]
-pub struct FunctionFrame {
+pub struct FuncFrame {
     /// Is `true` if the function frame has already been instantiated.
     ///
     /// # Note
@@ -68,8 +68,8 @@ pub struct FunctionFrame {
     pc: usize,
 }
 
-impl FunctionFrame {
-    /// Creates a new [`FunctionFrame`] from the given `func`.
+impl FuncFrame {
+    /// Creates a new [`FuncFrame`] from the given `func`.
     ///
     /// # Panics
     ///
@@ -94,7 +94,7 @@ impl FunctionFrame {
         self.pc = new_pc;
     }
 
-    /// Creates a new [`FunctionFrame`] from the given Wasm function entity.
+    /// Creates a new [`FuncFrame`] from the given Wasm function entity.
     pub(crate) fn new_wasm(func: Func, wasm_func: &WasmFuncEntity) -> Self {
         let instance = wasm_func.instance();
         let func_body = wasm_func.func_body();
@@ -185,7 +185,7 @@ impl FunctionFrame {
         Ok(())
     }
 
-    /// Returns the instance of the [`FunctionFrame`].
+    /// Returns the instance of the [`FuncFrame`].
     pub fn instance(&self) -> Instance {
         self.instance
     }
@@ -195,7 +195,7 @@ impl FunctionFrame {
 #[derive(Debug)]
 pub struct CallStack {
     /// The call stack featuring the function frames in order.
-    frames: Vec<FunctionFrame>,
+    frames: Vec<FuncFrame>,
     /// The maximum allowed depth of the `frames` stack.
     recursion_limit: usize,
 }
@@ -215,12 +215,12 @@ impl CallStack {
         }
     }
 
-    /// Pushes another [`FunctionFrame`] to the [`CallStack`].
+    /// Pushes another [`FuncFrame`] to the [`CallStack`].
     ///
     /// # Errors
     ///
-    /// If the [`FunctionFrame`] is at the set recursion limit.
-    pub fn push(&mut self, frame: FunctionFrame) -> Result<(), TrapCode> {
+    /// If the [`FuncFrame`] is at the set recursion limit.
+    pub fn push(&mut self, frame: FuncFrame) -> Result<(), TrapCode> {
         if self.len() == self.recursion_limit {
             return Err(TrapCode::StackOverflow);
         }
@@ -228,8 +228,8 @@ impl CallStack {
         Ok(())
     }
 
-    /// Pops the last [`FunctionFrame`] from the [`CallStack`] if any.
-    pub fn pop(&mut self) -> Option<FunctionFrame> {
+    /// Pops the last [`FuncFrame`] from the [`CallStack`] if any.
+    pub fn pop(&mut self) -> Option<FuncFrame> {
         self.frames.pop()
     }
 

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -75,7 +75,7 @@ impl FuncFrame {
     }
 
     /// Creates a new [`FuncFrame`].
-    pub fn new2(func: Func, func_body: FuncBody, instance: Instance) -> Self {
+    pub fn new(func: Func, func_body: FuncBody, instance: Instance) -> Self {
         Self {
             func,
             func_body,
@@ -191,7 +191,7 @@ impl CallStack {
             return Err(err_stack_overflow());
         }
         let next_ref = self.next_frame_ref();
-        let frame = FuncFrame::new2(func, wasm_func.func_body(), wasm_func.instance());
+        let frame = FuncFrame::new(func, wasm_func.func_body(), wasm_func.instance());
         self.frames.push(frame);
         Ok(next_ref)
     }

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -132,6 +132,7 @@ impl FuncFrame {
         self.instance
     }
 
+    /// Returns a reference to the instructions of the [`FuncFrame`].
     pub(super) fn iref(&self) -> InstructionsRef {
         self.iref
     }

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -65,12 +65,12 @@ pub struct FuncFrame {
 
 impl FuncFrame {
     /// Returns the program counter.
-    pub(crate) fn pc(&self) -> usize {
+    pub fn pc(&self) -> usize {
         self.pc
     }
 
     /// Updates the program counter.
-    pub(crate) fn update_pc(&mut self, new_pc: usize) {
+    pub fn update_pc(&mut self, new_pc: usize) {
         self.pc = new_pc;
     }
 

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -1,8 +1,9 @@
 //! Data structures to represent the Wasm call stack during execution.
 
+use super::DEFAULT_MAX_RECURSION_DEPTH;
 use crate::{
     core::TrapCode,
-    engine::{ResolvedFuncBody, ValueStack, DEFAULT_CALL_STACK_LIMIT},
+    engine::{ResolvedFuncBody, ValueStack},
     func::WasmFuncEntity,
     module::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX},
     AsContext,
@@ -201,7 +202,7 @@ pub struct CallStack {
 
 impl Default for CallStack {
     fn default() -> Self {
-        Self::new(DEFAULT_CALL_STACK_LIMIT)
+        Self::new(DEFAULT_MAX_RECURSION_DEPTH)
     }
 }
 

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -196,7 +196,7 @@ impl CallStack {
     }
 
     /// Returns the amount of function frames on the [`CallStack`].
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.frames.len()
     }
 

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 
-/// A function frame of a function in the call stack.
+/// A function frame of a function on the call stack.
 #[derive(Debug, Copy, Clone)]
 pub struct FuncFrame {
     /// Is `true` if the function frame has already been instantiated.

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -1,23 +1,17 @@
 //! Data structures to represent the Wasm call stack during execution.
 
-use super::{
-    super::{
-        func::WasmFuncEntity,
-        AsContext,
-        Func,
-        FuncBody,
-        FuncEntityInternal,
-        Instance,
-        Memory,
-        Table,
-    },
-    ResolvedFuncBody,
-    ValueStack,
-    DEFAULT_CALL_STACK_LIMIT,
-};
 use crate::{
     core::TrapCode,
+    engine::{ResolvedFuncBody, ValueStack, DEFAULT_CALL_STACK_LIMIT},
+    func::WasmFuncEntity,
     module::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX},
+    AsContext,
+    Func,
+    FuncBody,
+    FuncEntityInternal,
+    Instance,
+    Memory,
+    Table,
 };
 use alloc::vec::Vec;
 
@@ -90,17 +84,17 @@ impl FunctionFrame {
     }
 
     /// Returns the program counter.
-    pub(super) fn pc(&self) -> usize {
+    pub(crate) fn pc(&self) -> usize {
         self.pc
     }
 
     /// Updates the program counter.
-    pub(super) fn update_pc(&mut self, new_pc: usize) {
+    pub(crate) fn update_pc(&mut self, new_pc: usize) {
         self.pc = new_pc;
     }
 
     /// Creates a new [`FunctionFrame`] from the given Wasm function entity.
-    pub(super) fn new_wasm(func: Func, wasm_func: &WasmFuncEntity) -> Self {
+    pub(crate) fn new_wasm(func: Func, wasm_func: &WasmFuncEntity) -> Self {
         let instance = wasm_func.instance();
         let func_body = wasm_func.func_body();
         Self {

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -16,7 +16,6 @@ use crate::{
     func::{HostFuncEntity, WasmFuncEntity},
     AsContext,
     AsContextMut,
-    Func,
     Instance,
 };
 use core::{
@@ -136,26 +135,24 @@ impl Stack {
     /// Initializes the [`Stack`] for the given Wasm root function call.
     pub(crate) fn call_wasm_root(
         &mut self,
-        func: Func,
         wasm_func: &WasmFuncEntity,
         code_map: &CodeMap,
     ) -> Result<FuncFrame, TrapCode> {
         let iref = self.call_wasm_impl(wasm_func, code_map)?;
         let instance = wasm_func.instance();
-        Ok(self.frames.init(func, iref, instance))
+        Ok(self.frames.init(iref, instance))
     }
 
     /// Prepares the [`Stack`] for the given Wasm function call.
     pub(crate) fn call_wasm<'engine>(
         &mut self,
         caller: &mut FuncFrame,
-        func: Func,
         wasm_func: &WasmFuncEntity,
         code_map: &'engine CodeMap,
     ) -> Result<FuncFrame, TrapCode> {
         let iref = self.call_wasm_impl(wasm_func, code_map)?;
         let instance = wasm_func.instance();
-        let frame = self.frames.push(caller, func, iref, instance)?;
+        let frame = self.frames.push(caller, iref, instance)?;
         Ok(frame)
     }
 

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -155,7 +155,7 @@ impl Stack {
     /// Prepares the [`Stack`] for the given Wasm function call.
     pub(crate) fn call_wasm<'engine>(
         &mut self,
-        caller: FuncFrame,
+        caller: &mut FuncFrame,
         func: Func,
         wasm_func: &WasmFuncEntity,
         code_map: &'engine CodeMap,

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -123,6 +123,7 @@ impl Stack {
     }
 
     /// Returns a [`FunctionExecutor`] for the referenced [`FuncFrame`].
+    #[inline(always)]
     pub fn executor<'engine>(
         &'engine mut self,
         frame: &'engine mut FuncFrame,

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -172,14 +172,14 @@ impl Stack {
         wasm_func: &WasmFuncEntity,
         code_map: &'engine CodeMap,
     ) -> Result<InstructionsRef, TrapCode> {
-        let func_body = code_map.resolve(wasm_func.func_body());
-        let max_stack_height = func_body.max_stack_height();
+        let header = code_map.header(wasm_func.func_body());
+        let max_stack_height = header.max_stack_height();
         self.values.reserve(max_stack_height)?;
-        let len_locals = func_body.len_locals();
+        let len_locals = header.len_locals();
         self.values
             .extend_zeros(len_locals)
             .expect("stack overflow is unexpected due to previous stack reserve");
-        let iref = func_body.iref();
+        let iref = header.iref();
         Ok(iref)
     }
 

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -6,7 +6,7 @@ pub use self::{
     values::ValueStack,
 };
 use super::{
-    code_map::{CodeMap, Instructions, InstructionsRef},
+    code_map::{CodeMap, InstructionsRef},
     exec_context::FunctionExecutor,
     func_types::FuncTypeRegistry,
     FuncParams,
@@ -110,13 +110,6 @@ pub struct Stack {
     pub(crate) values: ValueStack,
     /// The frame stack.
     frames: CallStack,
-}
-
-/// A resolved [`FuncFrame`] for execution.
-#[derive(Debug)]
-pub struct ResolvedFuncFrame<'engine> {
-    pub frame: FuncFrame,
-    pub insts: Instructions<'engine>,
 }
 
 impl Stack {

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -180,7 +180,6 @@ impl Stack {
     }
 
     /// Executes the given host function called by a Wasm function.
-    #[inline(never)]
     pub(crate) fn call_host<C>(
         &mut self,
         ctx: C,

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -39,14 +39,14 @@ fn err_stack_overflow() -> TrapCode {
     TrapCode::StackOverflow
 }
 
-/// The configured limits of the [`Stack`].
+/// The configured limits of the Wasm stack.
 #[derive(Debug, Copy, Clone)]
 pub struct StackLimits {
-    /// The initial value stack height that the [`Stack`] prepares.
+    /// The initial value stack height that the Wasm stack prepares.
     initial_value_stack_height: usize,
-    /// The maximum value stack height in use that the [`Stack`] allows.
+    /// The maximum value stack height in use that the Wasm stack allows.
     maximum_value_stack_height: usize,
-    /// The maximum number of nested calls that the [`Stack`] allows.
+    /// The maximum number of nested calls that the Wasm stack allows.
     maximum_recursion_depth: usize,
 }
 
@@ -113,6 +113,8 @@ pub struct Stack {
 
 impl Stack {
     /// Creates a new [`Stack`] given the [`Config`].
+    ///
+    /// [`Config`]: [`crate::Config`]
     pub fn new(limits: StackLimits) -> Self {
         let frames = CallStack::new(limits.maximum_recursion_depth);
         let values = ValueStack::new(

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -2,7 +2,7 @@ mod frames;
 mod values;
 
 pub use self::{
-    frames::{CallStack, FunctionFrame},
+    frames::{CallStack, FuncFrame},
     values::ValueStack,
 };
 use crate::core::UntypedValue;

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -1,3 +1,7 @@
+mod frames;
 mod values;
 
-pub use self::values::ValueStack;
+pub use self::{
+    frames::{CallStack, FunctionFrame},
+    values::ValueStack,
+};

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -5,3 +5,107 @@ pub use self::{
     frames::{CallStack, FunctionFrame},
     values::ValueStack,
 };
+use crate::core::UntypedValue;
+use core::{
+    fmt::{self, Display},
+    mem::size_of,
+};
+
+/// Default value for initial value stack heihgt in bytes.
+const DEFAULT_MIN_VALUE_STACK_HEIGHT: usize = 1024;
+
+/// Default value for maximum value stack heihgt in bytes.
+const DEFAULT_MAX_VALUE_STACK_HEIGHT: usize = 1024 * DEFAULT_MIN_VALUE_STACK_HEIGHT;
+
+/// Default value for maximum recursion depth.
+const DEFAULT_MAX_RECURSION_DEPTH: usize = 64 * 1024;
+
+/// The configured limits of the [`Stack`].
+#[derive(Debug, Copy, Clone)]
+pub struct StackLimits {
+    /// The initial value stack height that the [`Stack`] prepares.
+    initial_value_stack_height: usize,
+    /// The maximum value stack height in use that the [`Stack`] allows.
+    maximum_value_stack_height: usize,
+    /// The maximum number of nested calls that the [`Stack`] allows.
+    maximum_recursion_depth: usize,
+}
+
+/// An error that may occur when configuring [`StackLimits`].
+#[derive(Debug)]
+pub enum LimitsError {
+    /// The initial value stack height exceeds the maximum value stack height.
+    InitialValueStackExceedsMaximum,
+}
+
+impl Display for LimitsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LimitsError::InitialValueStackExceedsMaximum => {
+                write!(f, "initial value stack heihgt exceeds maximum stack height")
+            }
+        }
+    }
+}
+
+impl StackLimits {
+    /// Creates a new [`StackLimits`] configuration.
+    ///
+    /// # Errors
+    ///
+    /// If the `initial_value_stack_height` exceeds `maximum_value_stack_height`.
+    pub fn new(
+        initial_value_stack_height: usize,
+        maximum_value_stack_height: usize,
+        maximum_recursion_depth: usize,
+    ) -> Result<Self, LimitsError> {
+        if initial_value_stack_height > maximum_value_stack_height {
+            return Err(LimitsError::InitialValueStackExceedsMaximum);
+        }
+        Ok(Self {
+            initial_value_stack_height,
+            maximum_value_stack_height,
+            maximum_recursion_depth,
+        })
+    }
+}
+
+impl Default for StackLimits {
+    fn default() -> Self {
+        let register_len = size_of::<UntypedValue>();
+        let initial_value_stack_height = DEFAULT_MIN_VALUE_STACK_HEIGHT / register_len;
+        let maximum_value_stack_height = DEFAULT_MAX_VALUE_STACK_HEIGHT / register_len;
+        Self {
+            initial_value_stack_height,
+            maximum_value_stack_height,
+            maximum_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
+        }
+    }
+}
+
+/// Data structure that combines both value stack and call stack.
+#[derive(Debug, Default)]
+pub struct Stack {
+    /// The value stack.
+    pub(super) values: ValueStack,
+    /// The frame stack.
+    pub(super) frames: CallStack,
+}
+
+impl Stack {
+    /// Creates a new [`Stack`] given the [`Config`].
+    pub fn new(limits: StackLimits) -> Self {
+        let frames = CallStack::new(limits.maximum_recursion_depth);
+        let values = ValueStack::new(
+            limits.initial_value_stack_height,
+            limits.maximum_value_stack_height,
+        );
+        Self { frames, values }
+    }
+
+    /// Clears both value and call stacks.
+    pub fn clear(&mut self) {
+        self.values.clear();
+        self.frames.clear();
+    }
+}

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -6,7 +6,7 @@ pub use self::{
     values::ValueStack,
 };
 use super::{
-    code_map::CodeMap,
+    code_map::{CodeMap, Instructions},
     exec_context::FunctionExecutor,
     func_types::FuncTypeRegistry,
     FuncParams,
@@ -112,6 +112,13 @@ pub struct Stack {
     frames: CallStack,
 }
 
+/// A resolved [`FuncFrame`] for execution.
+#[derive(Debug)]
+pub struct ResolvedFuncFrame<'engine> {
+    pub frame: FuncFrame,
+    pub insts: Instructions<'engine>,
+}
+
 impl Stack {
     /// Creates a new [`Stack`] given the [`Config`].
     pub fn new(limits: StackLimits) -> Self {
@@ -126,11 +133,19 @@ impl Stack {
     /// Returns a [`FunctionExecutor`] for the referenced [`FuncFrame`].
     pub fn executor<'engine>(
         &'engine mut self,
-        frame: &'engine mut FuncFrame,
-        codemap: &'engine CodeMap,
+        func: &'engine mut ResolvedFuncFrame,
     ) -> FunctionExecutor {
-        let func_body = codemap.resolve(frame.func_body);
-        FunctionExecutor::new(frame, func_body, &mut self.values)
+        FunctionExecutor::new(&mut func.frame, func.insts, &mut self.values)
+    }
+
+    /// Resolves a [`FuncFrame`] for execution.
+    pub fn resolve<'engine>(
+        &mut self,
+        frame: FuncFrame,
+        codemap: &'engine CodeMap,
+    ) -> ResolvedFuncFrame<'engine> {
+        let insts = codemap.resolve(frame.func_body).insts();
+        ResolvedFuncFrame { frame, insts }
     }
 
     /// Initializes the [`Stack`] for the given Wasm root function call.
@@ -142,16 +157,17 @@ impl Stack {
     ) -> Result<FuncFrame, TrapCode> {
         let frame = self.frames.init(func, wasm_func);
         self.call_wasm_impl(frame, code_map)
+            .map(|resolved| resolved.frame)
     }
 
     /// Prepares the [`Stack`] for the given Wasm function call.
-    pub(crate) fn call_wasm(
+    pub(crate) fn call_wasm<'engine>(
         &mut self,
         caller: FuncFrame,
         func: Func,
         wasm_func: &WasmFuncEntity,
-        code_map: &CodeMap,
-    ) -> Result<FuncFrame, TrapCode> {
+        code_map: &'engine CodeMap,
+    ) -> Result<ResolvedFuncFrame<'engine>, TrapCode> {
         let frame = self.frames.push(caller, func, wasm_func)?;
         self.call_wasm_impl(frame, code_map)
     }
@@ -163,26 +179,33 @@ impl Stack {
     /// This does not actually execute any instructions but prepares
     /// the call and value stacks for the instruction execution.
     #[inline(always)]
-    fn call_wasm_impl(
+    fn call_wasm_impl<'engine>(
         &mut self,
         frame: FuncFrame,
-        code_map: &CodeMap,
-    ) -> Result<FuncFrame, TrapCode> {
+        code_map: &'engine CodeMap,
+    ) -> Result<ResolvedFuncFrame<'engine>, TrapCode> {
         let func_body = code_map.resolve(frame.func_body());
         let max_stack_height = func_body.max_stack_height();
         self.values.reserve(max_stack_height)?;
         let len_locals = func_body.len_locals();
+        let insts = func_body.insts();
         self.values
             .extend_zeros(len_locals)
             .expect("stack overflow is unexpected due to previous stack reserve");
-        Ok(frame)
+        Ok(ResolvedFuncFrame { frame, insts })
     }
 
     /// Signals the [`Stack`] to return the last Wasm function call.
     ///
     /// Returns the next function on the call stack if any.
-    pub fn return_wasm(&mut self) -> Option<FuncFrame> {
-        self.frames.pop()
+    pub fn return_wasm<'engine>(
+        &mut self,
+        codemap: &'engine CodeMap,
+    ) -> Option<ResolvedFuncFrame<'engine>> {
+        self.frames.pop().map(|frame| {
+            let insts = codemap.resolve(frame.func_body()).insts();
+            ResolvedFuncFrame { frame, insts }
+        })
     }
 
     /// Executes the given host function as root.
@@ -202,14 +225,14 @@ impl Stack {
     pub(crate) fn call_host<C>(
         &mut self,
         ctx: C,
-        caller: &FuncFrame,
+        caller: &ResolvedFuncFrame,
         host_func: HostFuncEntity<<C as AsContext>::UserState>,
         func_types: &FuncTypeRegistry,
     ) -> Result<(), Trap>
     where
         C: AsContextMut,
     {
-        let instance = caller.instance();
+        let instance = caller.frame.instance();
         self.call_host_impl(ctx, host_func, Some(instance), func_types)
     }
 

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -18,7 +18,7 @@ const DEFAULT_MIN_VALUE_STACK_HEIGHT: usize = 1024;
 const DEFAULT_MAX_VALUE_STACK_HEIGHT: usize = 1024 * DEFAULT_MIN_VALUE_STACK_HEIGHT;
 
 /// Default value for maximum recursion depth.
-const DEFAULT_MAX_RECURSION_DEPTH: usize = 64 * 1024;
+const DEFAULT_MAX_RECURSION_DEPTH: usize = 1024;
 
 /// The configured limits of the [`Stack`].
 #[derive(Debug, Copy, Clone)]

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -1,0 +1,3 @@
+mod values;
+
+pub use self::values::ValueStack;

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -2,15 +2,28 @@ mod frames;
 mod values;
 
 pub use self::{
-    frames::{CallStack, FuncFrame},
+    frames::{CallStack, FuncFrame, FuncFrameRef},
     values::ValueStack,
 };
-use crate::core::UntypedValue;
+use super::{
+    code_map::CodeMap,
+    exec_context::FunctionExecutor,
+    func_types::FuncTypeRegistry,
+    FuncParams,
+};
+use crate::{
+    core::UntypedValue,
+    func::{HostFuncEntity, WasmFuncEntity},
+    AsContext,
+    AsContextMut,
+    Func,
+    Instance,
+};
 use core::{
     fmt::{self, Display},
     mem::size_of,
 };
-use wasmi_core::TrapCode;
+use wasmi_core::{Trap, TrapCode};
 
 /// Default value for initial value stack heihgt in bytes.
 const DEFAULT_MIN_VALUE_STACK_HEIGHT: usize = 1024;
@@ -94,9 +107,9 @@ impl Default for StackLimits {
 #[derive(Debug, Default)]
 pub struct Stack {
     /// The value stack.
-    pub(super) values: ValueStack,
+    pub(crate) values: ValueStack,
     /// The frame stack.
-    pub(super) frames: CallStack,
+    frames: CallStack,
 }
 
 impl Stack {
@@ -108,6 +121,131 @@ impl Stack {
             limits.maximum_value_stack_height,
         );
         Self { frames, values }
+    }
+
+    /// Returns a [`FunctionExecutor`] for the referenced [`FuncFrame`].
+    pub fn executor<'engine>(
+        &'engine mut self,
+        fref: FuncFrameRef,
+        codemap: &'engine CodeMap,
+    ) -> FunctionExecutor {
+        let frame = self.frames.frame_at_mut(fref);
+        let func_body = codemap.resolve(frame.func_body);
+        FunctionExecutor::new(frame, func_body, &mut self.values)
+    }
+
+    /// Prepares the [`Stack`] for the given Wasm function call.
+    ///
+    /// # Note
+    ///
+    /// This does not actually execute any instructions but prepares
+    /// the call and value stacks for the instruction execution.
+    pub(crate) fn call_wasm(
+        &mut self,
+        func: Func,
+        wasm_func: &WasmFuncEntity,
+        code_map: &CodeMap,
+    ) -> Result<FuncFrameRef, TrapCode> {
+        let fref = self.frames.push_wasm(func, wasm_func)?;
+        let func_body = code_map.resolve(wasm_func.func_body());
+        let max_stack_height = func_body.max_stack_height();
+        self.values.reserve(max_stack_height)?;
+        let len_locals = func_body.len_locals();
+        self.values
+            .extend_zeros(len_locals)
+            .unwrap_or_else(|error| {
+                panic!("encountered stack overflow while pushing locals: {}", error)
+            });
+        Ok(fref)
+    }
+
+    /// Signals the [`Stack`] to return the last Wasm function call.
+    ///
+    /// Returns the next function on the call stack if any.
+    pub fn return_wasm(&mut self) -> Option<FuncFrameRef> {
+        self.frames.pop_ref()
+    }
+
+    /// Executes the given host function as root.
+    pub(crate) fn call_host_root<C>(
+        &mut self,
+        ctx: C,
+        host_func: HostFuncEntity<<C as AsContext>::UserState>,
+        func_types: &FuncTypeRegistry,
+    ) -> Result<(), Trap>
+    where
+        C: AsContextMut,
+    {
+        self.call_host_impl(ctx, host_func, None, func_types)
+    }
+
+    /// Executes the given host function called by a Wasm function.
+    #[inline(never)]
+    pub(crate) fn call_host<C>(
+        &mut self,
+        ctx: C,
+        caller: FuncFrameRef,
+        host_func: HostFuncEntity<<C as AsContext>::UserState>,
+        func_types: &FuncTypeRegistry,
+    ) -> Result<(), Trap>
+    where
+        C: AsContextMut,
+    {
+        let instance = self.frames.frame_at(caller).instance();
+        self.call_host_impl(ctx, host_func, Some(instance), func_types)
+    }
+
+    /// Executes the given host function.
+    ///
+    /// # Errors
+    ///
+    /// - If the host function returns a host side error or trap.
+    /// - If the value stack overflowed upon pushing parameters or results.
+    #[inline(never)]
+    fn call_host_impl<C>(
+        &mut self,
+        mut ctx: C,
+        host_func: HostFuncEntity<<C as AsContext>::UserState>,
+        instance: Option<Instance>,
+        func_types: &FuncTypeRegistry,
+    ) -> Result<(), Trap>
+    where
+        C: AsContextMut,
+    {
+        // The host function signature is required for properly
+        // adjusting, inspecting and manipulating the value stack.
+        let (input_types, output_types) = func_types
+            .resolve_func_type(host_func.signature())
+            .params_results();
+        // In case the host function returns more values than it takes
+        // we are required to extend the value stack.
+        let len_inputs = input_types.len();
+        let len_outputs = output_types.len();
+        let max_inout = len_inputs.max(len_outputs);
+        self.values.reserve(max_inout)?;
+        if len_outputs > len_inputs {
+            let delta = len_outputs - len_inputs;
+            self.values.extend_zeros(delta)?;
+        }
+        let params_results = FuncParams::new(
+            self.values.peek_as_slice_mut(max_inout),
+            len_inputs,
+            len_outputs,
+        );
+        // Now we are ready to perform the host function call.
+        // Note: We need to clone the host function due to some borrowing issues.
+        //       This should not be a big deal since host functions usually are cheap to clone.
+        host_func.call(&mut ctx, instance, params_results)?;
+        // If the host functions returns fewer results than it receives parameters
+        // the value stack needs to be shrinked for the delta.
+        if len_outputs < len_inputs {
+            let delta = len_inputs - len_outputs;
+            self.values.drop(delta);
+        }
+        // At this point the host function has been called and has directly
+        // written its results into the value stack so that the last entries
+        // in the value stack are the result values of the host function call.
+        Ok(())
     }
 
     /// Clears both value and call stacks.

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -177,7 +177,7 @@ impl Stack {
     /// Signals the [`Stack`] to return the last Wasm function call.
     ///
     /// Returns the next function on the call stack if any.
-    pub fn return_wasm<'engine>(&mut self) -> Option<FuncFrame> {
+    pub fn return_wasm(&mut self) -> Option<FuncFrame> {
         self.frames.pop()
     }
 

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -10,6 +10,7 @@ use core::{
     fmt::{self, Display},
     mem::size_of,
 };
+use wasmi_core::TrapCode;
 
 /// Default value for initial value stack heihgt in bytes.
 const DEFAULT_MIN_VALUE_STACK_HEIGHT: usize = 1024;
@@ -19,6 +20,12 @@ const DEFAULT_MAX_VALUE_STACK_HEIGHT: usize = 1024 * DEFAULT_MIN_VALUE_STACK_HEI
 
 /// Default value for maximum recursion depth.
 const DEFAULT_MAX_RECURSION_DEPTH: usize = 1024;
+
+/// Returns a [`TrapCode`] signalling a stack overflow.
+#[cold]
+fn err_stack_overflow() -> TrapCode {
+    TrapCode::StackOverflow
+}
 
 /// The configured limits of the [`Stack`].
 #[derive(Debug, Copy, Clone)]

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -85,11 +85,16 @@ impl ValueStack {
     ///
     /// # Panics
     ///
-    /// If the `initial_len` is zero.
+    /// - If the `initial_len` is zero.
+    /// - If the `initial_len` is greater than `maximum_len`.
     pub fn new(initial_len: usize, maximum_len: usize) -> Self {
         assert!(
             initial_len > 0,
-            "cannot initialize the value stack with zero length"
+            "cannot initialize the value stack with zero length",
+        );
+        assert!(
+            initial_len <= maximum_len,
+            "initial value stack length is greater than maximum value stack length",
         );
         let entries = vec![UntypedValue::default(); initial_len];
         Self {

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -1,11 +1,12 @@
 //! Data structures to represent the Wasm value stack during execution.
 
+use super::{DEFAULT_MIN_VALUE_STACK_HEIGHT, DEFAULT_MAX_VALUE_STACK_HEIGHT};
 use crate::{
     core::TrapCode,
-    engine::{DropKeep, DEFAULT_VALUE_STACK_LIMIT},
+    engine::{DropKeep},
 };
 use alloc::vec::Vec;
-use core::{fmt, fmt::Debug, iter, mem};
+use core::{fmt, fmt::Debug, iter, mem::size_of};
 use wasmi_core::UntypedValue;
 
 /// The value stack that is used to execute Wasm bytecode.
@@ -49,9 +50,10 @@ impl Eq for ValueStack {}
 
 impl Default for ValueStack {
     fn default() -> Self {
+        let register_len = size_of::<UntypedValue>();
         Self::new(
-            DEFAULT_VALUE_STACK_LIMIT / mem::size_of::<UntypedValue>(),
-            1024 * DEFAULT_VALUE_STACK_LIMIT / mem::size_of::<UntypedValue>(),
+            DEFAULT_MIN_VALUE_STACK_HEIGHT / register_len,
+            DEFAULT_MAX_VALUE_STACK_HEIGHT / register_len,
         )
     }
 }

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -1,10 +1,7 @@
 //! Data structures to represent the Wasm value stack during execution.
 
-use super::{DEFAULT_MIN_VALUE_STACK_HEIGHT, DEFAULT_MAX_VALUE_STACK_HEIGHT};
-use crate::{
-    core::TrapCode,
-    engine::{DropKeep},
-};
+use super::{DEFAULT_MAX_VALUE_STACK_HEIGHT, DEFAULT_MIN_VALUE_STACK_HEIGHT};
+use crate::{core::TrapCode, engine::DropKeep};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Debug, iter, mem::size_of};
 use wasmi_core::UntypedValue;

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -1,7 +1,9 @@
 //! Data structures to represent the Wasm value stack during execution.
 
-use crate::core::TrapCode;
-use crate::engine::{DropKeep, DEFAULT_VALUE_STACK_LIMIT};
+use crate::{
+    core::TrapCode,
+    engine::{DropKeep, DEFAULT_VALUE_STACK_LIMIT},
+};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Debug, iter, mem};
 use wasmi_core::UntypedValue;

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -119,7 +119,7 @@ impl ValueStack {
     ///
     /// If the `index` is out of bounds.
     fn get_release_unchecked(&self, index: usize) -> UntypedValue {
-        debug_assert!(index < self.entries.len());
+        debug_assert!(index < self.capacity());
         // Safety: This is safe since all wasmi bytecode has been validated
         //         during translation and therefore cannot result in out of
         //         bounds accesses.
@@ -143,7 +143,7 @@ impl ValueStack {
     ///
     /// If the `index` is out of bounds.
     fn get_release_unchecked_mut(&mut self, index: usize) -> &mut UntypedValue {
-        debug_assert!(index < self.entries.len());
+        debug_assert!(index < self.capacity());
         // Safety: This is safe since all wasmi bytecode has been validated
         //         during translation and therefore cannot result in out of
         //         bounds accesses.

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -1,7 +1,6 @@
 //! Data structures to represent the Wasm value stack during execution.
 
-use super::err_stack_overflow;
-use super::{DEFAULT_MAX_VALUE_STACK_HEIGHT, DEFAULT_MIN_VALUE_STACK_HEIGHT};
+use super::{err_stack_overflow, DEFAULT_MAX_VALUE_STACK_HEIGHT, DEFAULT_MIN_VALUE_STACK_HEIGHT};
 use crate::{core::TrapCode, engine::DropKeep};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Debug, iter, mem::size_of};

--- a/wasmi_v1/src/engine/stack/values.rs
+++ b/wasmi_v1/src/engine/stack/values.rs
@@ -1,7 +1,7 @@
 //! Data structures to represent the Wasm value stack during execution.
 
-use super::{DropKeep, DEFAULT_VALUE_STACK_LIMIT};
 use crate::core::TrapCode;
+use crate::engine::{DropKeep, DEFAULT_VALUE_STACK_LIMIT};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Debug, iter, mem};
 use wasmi_core::UntypedValue;

--- a/wasmi_v1/src/engine/value_stack.rs
+++ b/wasmi_v1/src/engine/value_stack.rs
@@ -30,8 +30,8 @@ pub struct ValueStack {
 impl Debug for ValueStack {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ValueStack")
-            .field("entries", &&self.entries[..self.stack_ptr])
             .field("stack_ptr", &self.stack_ptr)
+            .field("entries", &&self.entries[..self.stack_ptr])
             .finish()
     }
 }

--- a/wasmi_v1/src/instance.rs
+++ b/wasmi_v1/src/instance.rs
@@ -225,7 +225,7 @@ impl Deref for InstanceEntityBuilder {
 }
 
 /// A Wasm module instance reference.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Instance(Stored<InstanceIdx>);
 

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -113,7 +113,6 @@ pub mod errors {
 
 use self::{
     arena::{GuardedEntity, Index},
-    engine::FuncBody,
     func::{FuncEntity, FuncIdx},
     global::{GlobalEntity, GlobalIdx},
     instance::{InstanceEntity, InstanceEntityBuilder, InstanceIdx},

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -114,7 +114,7 @@ pub mod errors {
 use self::{
     arena::{GuardedEntity, Index},
     engine::FuncBody,
-    func::{FuncEntity, FuncEntityInternal, FuncIdx},
+    func::{FuncEntity, FuncIdx},
     global::{GlobalEntity, GlobalIdx},
     instance::{InstanceEntity, InstanceEntityBuilder, InstanceIdx},
     memory::{MemoryEntity, MemoryIdx},

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -122,7 +122,7 @@ use self::{
     table::{TableEntity, TableIdx},
 };
 pub use self::{
-    engine::{Config, Engine},
+    engine::{Config, Engine, StackLimits},
     error::Error,
     external::Extern,
     func::{Caller, Func, TypedFunc, WasmParams, WasmResults},

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -73,24 +73,7 @@ impl<'engine> ModuleParser<'engine> {
 
     /// Returns the Wasm features supported by `wasmi`.
     fn features(engine: &Engine) -> WasmFeatures {
-        WasmFeatures {
-            reference_types: false,
-            multi_value: engine.config().get_multi_value(),
-            bulk_memory: false,
-            module_linking: false,
-            simd: false,
-            relaxed_simd: false,
-            threads: false,
-            tail_call: false,
-            deterministic_only: true,
-            multi_memory: false,
-            exceptions: false,
-            memory64: false,
-            extended_const: false,
-            mutable_global: engine.config().get_mutable_global(),
-            saturating_float_to_int: engine.config().get_saturating_float_to_int(),
-            sign_extension: engine.config().get_sign_extension(),
-        }
+        engine.config().wasm_features()
     }
 
     /// Starts parsing and validating the Wasm bytecode stream.

--- a/wasmi_v1/src/module/parser.rs
+++ b/wasmi_v1/src/module/parser.rs
@@ -75,7 +75,7 @@ impl<'engine> ModuleParser<'engine> {
     fn features(engine: &Engine) -> WasmFeatures {
         WasmFeatures {
             reference_types: false,
-            multi_value: engine.config().multi_value(),
+            multi_value: engine.config().get_multi_value(),
             bulk_memory: false,
             module_linking: false,
             simd: false,
@@ -87,9 +87,9 @@ impl<'engine> ModuleParser<'engine> {
             exceptions: false,
             memory64: false,
             extended_const: false,
-            mutable_global: engine.config().mutable_global(),
-            saturating_float_to_int: engine.config().saturating_float_to_int(),
-            sign_extension: engine.config().sign_extension(),
+            mutable_global: engine.config().get_mutable_global(),
+            saturating_float_to_int: engine.config().get_saturating_float_to_int(),
+            sign_extension: engine.config().get_sign_extension(),
         }
     }
 

--- a/wasmi_v1/tests/spec/mod.rs
+++ b/wasmi_v1/tests/spec/mod.rs
@@ -15,7 +15,8 @@ use wasmi::Config;
 /// Creates the proper [`Config`] for testing.
 fn mvp_config() -> Config {
     let mut config = Config::default();
-    config.wasm_mutable_global(false)
+    config
+        .wasm_mutable_global(false)
         .wasm_saturating_float_to_int(false)
         .wasm_sign_extension(false)
         .wasm_multi_value(false);

--- a/wasmi_v1/tests/spec/mod.rs
+++ b/wasmi_v1/tests/spec/mod.rs
@@ -12,13 +12,24 @@ use self::{
 };
 use wasmi::Config;
 
+/// Creates the proper [`Config`] for testing.
+fn mvp_config() -> Config {
+    let mut config = Config::default();
+    config.wasm_mutable_global(false)
+        .wasm_saturating_float_to_int(false)
+        .wasm_sign_extension(false)
+        .wasm_multi_value(false);
+    config
+}
+
 /// Run Wasm spec test suite using MVP `wasmi` configuration.
 ///
 /// # Note
 ///
 /// The Wasm MVP has no Wasm proposals enabled.
 fn run_wasm_spec_test(file_name: &str) {
-    let config = Config::mvp().enable_mutable_global(true);
+    let mut config = mvp_config();
+    config.wasm_mutable_global(true);
     self::run::run_wasm_spec_test(file_name, config)
 }
 
@@ -35,11 +46,11 @@ macro_rules! define_local_tests {
 }
 
 mod missing_features {
-    use super::Config;
+    use super::mvp_config;
 
     /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
     fn run_wasm_spec_test(file_name: &str) {
-        super::run::run_wasm_spec_test(file_name, Config::mvp())
+        super::run::run_wasm_spec_test(file_name, mvp_config())
     }
 
     define_local_tests! {
@@ -62,11 +73,12 @@ macro_rules! define_spec_tests {
 }
 
 mod saturating_float_to_int {
-    use super::Config;
+    use super::mvp_config;
 
     /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
     fn run_wasm_spec_test(file_name: &str) {
-        let config = Config::mvp().enable_saturating_float_to_int(true);
+        let mut config = mvp_config();
+        config.wasm_saturating_float_to_int(true);
         super::run::run_wasm_spec_test(file_name, config)
     }
 
@@ -76,11 +88,12 @@ mod saturating_float_to_int {
 }
 
 mod sign_extension_ops {
-    use super::Config;
+    use super::mvp_config;
 
     /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
     fn run_wasm_spec_test(file_name: &str) {
-        let config = Config::mvp().enable_sign_extension(true);
+        let mut config = mvp_config();
+        config.wasm_sign_extension(true);
         super::run::run_wasm_spec_test(file_name, config)
     }
 
@@ -91,11 +104,12 @@ mod sign_extension_ops {
 }
 
 mod multi_value {
-    use super::Config;
+    use super::mvp_config;
 
     /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
     fn run_wasm_spec_test(file_name: &str) {
-        let config = Config::mvp().enable_multi_value(true);
+        let mut config = mvp_config();
+        config.wasm_multi_value(true);
         super::run::run_wasm_spec_test(file_name, config)
     }
 


### PR DESCRIPTION
This PR heavily refactors the `v1` `wasmi` engine.

Greatly reorganizes the engine codebase and cleans up some older parts.
This results in up to 16% performance wins for call intense workloads.
Also the call stack now demands less memory for the same amount of nested calls.
Caching of instance related data now works across function call boundaries.
