### PR TITLE
Cache default linear memory bytes

### DIFF
--- a/wasmi_v1/src/engine/cache.rs
+++ b/wasmi_v1/src/engine/cache.rs
@@ -91,7 +91,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a default linear memory.
-    pub fn default_memory(&mut self, ctx: impl AsContext, _instance: Instance) -> Memory {
+    pub fn default_memory(&mut self, ctx: impl AsContext) -> Memory {
         match self.default_memory {
             Some(default_memory) => default_memory,
             None => self.load_default_memory(ctx),
@@ -103,7 +103,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a default table.
-    pub fn default_table(&mut self, ctx: impl AsContext, _instance: Instance) -> Table {
+    pub fn default_table(&mut self, ctx: impl AsContext) -> Table {
         match self.default_table {
             Some(default_table) => default_table,
             None => self.load_default_table(ctx),
@@ -134,7 +134,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a [`Func`] at the index.
-    pub fn get_func(&mut self, ctx: impl AsContext, _instance: Instance, func_idx: u32) -> Func {
+    pub fn get_func(&mut self, ctx: impl AsContext, func_idx: u32) -> Func {
         match self.last_func {
             Some((index, func)) if index == func_idx => func,
             _ => self.load_func_at(ctx, func_idx),

--- a/wasmi_v1/src/engine/cache.rs
+++ b/wasmi_v1/src/engine/cache.rs
@@ -193,7 +193,7 @@ pub struct CachedMemoryBytes {
 }
 
 impl CachedMemoryBytes {
-    /// Creates a new [`CachedMemory`] from the given [`Memory`].
+    /// Creates a new [`CachedMemoryBytes`] from the given [`Memory`].
     #[inline]
     pub fn new(mut ctx: impl AsContextMut, memory: Memory) -> Self {
         Self {

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -268,7 +268,7 @@ struct ExecutionContext<'engine, 'func, Ctx> {
     value_stack: &'engine mut ValueStack,
     /// The function frame that is being executed.
     frame: &'func mut FuncFrame,
-    /// Cached default linear memory.
+    /// Stores frequently used instance related data.
     cache: &'engine mut InstanceCache,
     /// A mutable [`Store`] context.
     ///

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -363,12 +363,13 @@ where
         UntypedValue: From<T>,
         T: LittleEndianConvert,
     {
-        let memory = self.cache.default_memory_bytes(self.ctx.as_context_mut());
         let entry = self.value_stack.last_mut();
         let raw_address = u32::from(*entry);
         let address = Self::effective_address(offset, raw_address)?;
         let mut bytes = <<T as LittleEndianConvert>::Bytes as Default>::default();
-        memory.read(address, bytes.as_mut())?;
+        self.cache
+            .default_memory_bytes(self.ctx.as_context_mut())
+            .read(address, bytes.as_mut())?;
         let value = <T as LittleEndianConvert>::from_le_bytes(bytes);
         *entry = value.into();
         self.next_instr()
@@ -395,12 +396,13 @@ where
         T: ExtendInto<U> + LittleEndianConvert,
         UntypedValue: From<U>,
     {
-        let memory = self.cache.default_memory_bytes(self.ctx.as_context_mut());
         let entry = self.value_stack.last_mut();
         let raw_address = u32::from(*entry);
         let address = Self::effective_address(offset, raw_address)?;
         let mut bytes = <<T as LittleEndianConvert>::Bytes as Default>::default();
-        memory.read(address, bytes.as_mut())?;
+        self.cache
+            .default_memory_bytes(self.ctx.as_context_mut())
+            .read(address, bytes.as_mut())?;
         let extended = <T as LittleEndianConvert>::from_le_bytes(bytes).extend_into();
         *entry = extended.into();
         self.next_instr()
@@ -423,9 +425,10 @@ where
         let stack_value = self.value_stack.pop_as::<T>();
         let raw_address = self.value_stack.pop_as::<u32>();
         let address = Self::effective_address(offset, raw_address)?;
-        let memory = self.cache.default_memory_bytes(self.ctx.as_context_mut());
         let bytes = <T as LittleEndianConvert>::into_le_bytes(stack_value);
-        memory.write(address, bytes.as_ref())?;
+        self.cache
+            .default_memory_bytes(self.ctx.as_context_mut())
+            .write(address, bytes.as_ref())?;
         self.next_instr()
     }
 
@@ -448,9 +451,10 @@ where
         let wrapped_value = self.value_stack.pop_as::<T>().wrap_into();
         let raw_address = self.value_stack.pop_as::<u32>();
         let address = Self::effective_address(offset, raw_address)?;
-        let memory = self.cache.default_memory_bytes(self.ctx.as_context_mut());
         let bytes = <U as LittleEndianConvert>::into_le_bytes(wrapped_value);
-        memory.write(address, bytes.as_ref())?;
+        self.cache
+            .default_memory_bytes(self.ctx.as_context_mut())
+            .write(address, bytes.as_ref())?;
         self.next_instr()
     }
 

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -378,6 +378,7 @@ impl EngineInner {
                         self.stack.call_wasm(frame, wasm_func, &self.code_map)?;
                     }
                     FuncEntityInternal::Host(host_func) => {
+                        cache.reset_default_memory_bytes();
                         let host_func = host_func.clone();
                         self.stack
                             .call_host(&mut ctx, frame, host_func, &self.func_types)?;


### PR DESCRIPTION
This PR improves the existing `InstanceCache` to also cache the underlying bytes of the default linear memory to avoid an indirection for every consecutive `load` and `store` operation. Special care must be taken when the linear memory might be invalidated through host calls or `memory.grow` operations.

According to our benchmarks this yields a performance improvement in many benchmarks between 5-8%, especially for the memory intense work loads.
A few call intense work loads slightly regressed in the range of 2-3%.