### PR TITLE
rename some wasmi instructions

### DIFF
--- a/wasmi_v1/src/engine/bytecode/mod.rs
+++ b/wasmi_v1/src/engine/bytecode/mod.rs
@@ -18,9 +18,9 @@ use wasmi_core::UntypedValue;
 /// each representing either the `BrTable` head or one of its branching targets.
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum Instruction {
-    GetLocal { local_depth: LocalIdx },
-    SetLocal { local_depth: LocalIdx },
-    TeeLocal { local_depth: LocalIdx },
+    LocalGet { local_depth: LocalIdx },
+    LocalSet { local_depth: LocalIdx },
+    LocalTee { local_depth: LocalIdx },
     Br(Target),
     BrIfEqz(Target),
     BrIfNez(Target),
@@ -32,8 +32,8 @@ pub enum Instruction {
     CallIndirect(SignatureIdx),
     Drop,
     Select,
-    GetGlobal(GlobalIdx),
-    SetGlobal(GlobalIdx),
+    GlobalGet(GlobalIdx),
+    GlobalSet(GlobalIdx),
     I32Load(Offset),
     I64Load(Offset),
     F32Load(Offset),
@@ -57,8 +57,8 @@ pub enum Instruction {
     I64Store8(Offset),
     I64Store16(Offset),
     I64Store32(Offset),
-    CurrentMemory,
-    GrowMemory,
+    MemorySize,
+    MemoryGrow,
     Const(UntypedValue),
     I32Eqz,
     I32Eq,
@@ -209,21 +209,21 @@ impl Instruction {
 
     /// Creates a new `local.get` instruction from the given local depth.
     pub fn local_get(local_depth: u32) -> Self {
-        Self::GetLocal {
+        Self::LocalGet {
             local_depth: LocalIdx::from(local_depth),
         }
     }
 
     /// Creates a new `local.set` instruction from the given local depth.
     pub fn local_set(local_depth: u32) -> Self {
-        Self::SetLocal {
+        Self::LocalSet {
             local_depth: LocalIdx::from(local_depth),
         }
     }
 
     /// Creates a new `local.tee` instruction from the given local depth.
     pub fn local_tee(local_depth: u32) -> Self {
-        Self::TeeLocal {
+        Self::LocalTee {
             local_depth: LocalIdx::from(local_depth),
         }
     }

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -63,9 +63,9 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 self.insts.get_release_unchecked(exec_ctx.pc)
             };
             match instr {
-                Instr::GetLocal { local_depth } => { exec_ctx.visit_get_local(*local_depth)?; }
-                Instr::SetLocal { local_depth } => { exec_ctx.visit_set_local(*local_depth)?; }
-                Instr::TeeLocal { local_depth } => { exec_ctx.visit_tee_local(*local_depth)?; }
+                Instr::LocalGet { local_depth } => { exec_ctx.visit_get_local(*local_depth)?; }
+                Instr::LocalSet { local_depth } => { exec_ctx.visit_set_local(*local_depth)?; }
+                Instr::LocalTee { local_depth } => { exec_ctx.visit_tee_local(*local_depth)?; }
                 Instr::Br(target) => { exec_ctx.visit_br(*target)?; }
                 Instr::BrIfEqz(target) => { exec_ctx.visit_br_if_eqz(*target)?; }
                 Instr::BrIfNez(target) => { exec_ctx.visit_br_if_nez(*target)?; }
@@ -90,8 +90,8 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 }
                 Instr::Drop => { exec_ctx.visit_drop()?; }
                 Instr::Select => { exec_ctx.visit_select()?; }
-                Instr::GetGlobal(global_idx)  => { exec_ctx.visit_get_global(*global_idx)?; }
-                Instr::SetGlobal(global_idx)  => { exec_ctx.visit_set_global(*global_idx)?; }
+                Instr::GlobalGet(global_idx)  => { exec_ctx.visit_get_global(*global_idx)?; }
+                Instr::GlobalSet(global_idx)  => { exec_ctx.visit_set_global(*global_idx)?; }
                 Instr::I32Load(offset)  => { exec_ctx.visit_i32_load(*offset)?; }
                 Instr::I64Load(offset)  => { exec_ctx.visit_i64_load(*offset)?; }
                 Instr::F32Load(offset)  => { exec_ctx.visit_f32_load(*offset)?; }
@@ -115,8 +115,8 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 Instr::I64Store8(offset)  => { exec_ctx.visit_i64_store_8(*offset)?; }
                 Instr::I64Store16(offset)  => { exec_ctx.visit_i64_store_16(*offset)?; }
                 Instr::I64Store32(offset)  => { exec_ctx.visit_i64_store_32(*offset)?; }
-                Instr::CurrentMemory => { exec_ctx.visit_current_memory()?; }
-                Instr::GrowMemory => { exec_ctx.visit_grow_memory()?; }
+                Instr::MemorySize => { exec_ctx.visit_current_memory()?; }
+                Instr::MemoryGrow => { exec_ctx.visit_grow_memory()?; }
                 Instr::Const(bytes)  => { exec_ctx.visit_const(*bytes)?; }
                 Instr::I32Eqz => { exec_ctx.visit_i32_eqz()?; }
                 Instr::I32Eq => { exec_ctx.visit_i32_eq()?; }

--- a/wasmi_v1/src/engine/func_builder/mod.rs
+++ b/wasmi_v1/src/engine/func_builder/mod.rs
@@ -792,7 +792,7 @@ impl<'alloc, 'parser> FuncBuilder<'alloc, 'parser> {
             let global_idx = global_idx.into_u32().into();
             builder
                 .inst_builder
-                .push_inst(Instruction::GetGlobal(global_idx));
+                .push_inst(Instruction::GlobalGet(global_idx));
             Ok(())
         })
     }
@@ -808,7 +808,7 @@ impl<'alloc, 'parser> FuncBuilder<'alloc, 'parser> {
             let global_idx = global_idx.into_u32().into();
             builder
                 .inst_builder
-                .push_inst(Instruction::SetGlobal(global_idx));
+                .push_inst(Instruction::GlobalSet(global_idx));
             Ok(())
         })
     }
@@ -1096,7 +1096,7 @@ impl<'alloc, 'parser> FuncBuilder<'alloc, 'parser> {
         self.translate_if_reachable(|builder| {
             debug_assert_eq!(memory_idx.into_u32(), DEFAULT_MEMORY_INDEX);
             builder.value_stack.push(ValueType::I32);
-            builder.inst_builder.push_inst(Instruction::CurrentMemory);
+            builder.inst_builder.push_inst(Instruction::MemorySize);
             Ok(())
         })
     }
@@ -1106,7 +1106,7 @@ impl<'alloc, 'parser> FuncBuilder<'alloc, 'parser> {
         self.translate_if_reachable(|builder| {
             debug_assert_eq!(memory_idx.into_u32(), DEFAULT_MEMORY_INDEX);
             debug_assert_eq!(builder.value_stack.top(), ValueType::I32);
-            builder.inst_builder.push_inst(Instruction::GrowMemory);
+            builder.inst_builder.push_inst(Instruction::MemoryGrow);
             Ok(())
         })
     }


### PR DESCRIPTION
- `GetLocal` -> `LocalGet`
- `SetLocal` -> `LocalSet`
- `TeeLocal` -> `LocalTee`
- `GetGlobal` -> `GlobalGet`
- `SetGlobal` -> `GlobalSet`
- `CurrentMemory` -> `MemorySize`
- `GrowMemory` -> `MemoryGrow`