### PR TITLE
Optimize `global.get` and `global.set` execution

### DIFF
--- a/wasmi_v1/benches/benches.rs
+++ b/wasmi_v1/benches/benches.rs
@@ -46,6 +46,7 @@ criterion_group! {
         bench_execute_rev_comp_v1,
         bench_execute_regex_redux_v1,
         bench_execute_count_until_v1,
+        bench_execute_global_bump,
         bench_execute_fac_recursive_v1,
         bench_execute_fac_opt_v1,
         bench_execute_recursive_ok_v1,
@@ -233,9 +234,8 @@ fn bench_execute_regex_redux_v1(c: &mut Criterion) {
     });
 }
 
-const COUNT_UNTIL: i32 = 100_000;
-
 fn bench_execute_count_until_v1(c: &mut Criterion) {
+    const COUNT_UNTIL: i32 = 100_000;
     c.bench_function("execute/count_until/v1", |b| {
         let (mut store, instance) =
             load_instance_from_wat_v1(include_bytes!("wat/count_until.wat"));
@@ -250,6 +250,26 @@ fn bench_execute_count_until_v1(c: &mut Criterion) {
                 .call(&mut store, &[Value::I32(COUNT_UNTIL)], &mut result)
                 .unwrap();
             assert_eq!(result, [Value::I32(COUNT_UNTIL)]);
+        })
+    });
+}
+
+fn bench_execute_global_bump(c: &mut Criterion) {
+    const BUMP_AMOUNT: i32 = 100_000;
+    c.bench_function("execute/global_bump/v1", |b| {
+        let (mut store, instance) =
+            load_instance_from_wat_v1(include_bytes!("wat/global_bump.wat"));
+        let count_until = instance
+            .get_export(&store, "bump")
+            .and_then(v1::Extern::into_func)
+            .unwrap();
+        let mut result = [Value::I32(0)];
+
+        b.iter(|| {
+            count_until
+                .call(&mut store, &[Value::I32(BUMP_AMOUNT)], &mut result)
+                .unwrap();
+            assert_eq!(result, [Value::I32(BUMP_AMOUNT)]);
         })
     });
 }

--- a/wasmi_v1/benches/wat/global_bump.wat
+++ b/wasmi_v1/benches/wat/global_bump.wat
@@ -1,0 +1,27 @@
+;; Exports a function `bump` that takes an input `n`.
+;; The exported function bumps a global variable `n` times and then returns it.
+(module
+    (global $g (mut i32) (i32.const 0))
+    (func $bump (export "bump") (param $n i32) (result i32)
+        (global.set $g (i32.const 0))
+        (block $break
+            (loop $continue
+                (br_if ;; if $g == $n then break
+                    $break
+                    (i32.eq
+                        (global.get $g)
+                        (local.get $n)
+                    )
+                )
+                (global.set $g ;; $g += 1
+                    (i32.add
+                        (global.get $g)
+                        (i32.const 1)
+                    )
+                )
+                (br $continue)
+            )
+        )
+        (return (global.get $g))
+    )
+)

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -611,20 +611,15 @@ where
     }
 
     fn visit_get_global(&mut self, global_index: GlobalIdx) -> Result<(), Trap> {
-        let global_value = self.global(global_index).get(self.ctx.as_context());
+        let global_value = self.global(global_index).get_untyped(self.ctx.as_context());
         self.value_stack.push(global_value);
         self.next_instr()
     }
 
     fn visit_set_global(&mut self, global_index: GlobalIdx) -> Result<(), Trap> {
         let global = self.global(global_index);
-        let new_value = self
-            .value_stack
-            .pop()
-            .with_type(global.value_type(self.ctx.as_context()));
-        global
-            .set(self.ctx.as_context_mut(), new_value)
-            .unwrap_or_else(|error| panic!("encountered type mismatch upon global_set: {}", error));
+        let new_value = self.value_stack.pop();
+        global.set_untyped(self.ctx.as_context_mut(), new_value);
         self.next_instr()
     }
 

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -143,7 +143,7 @@ impl GlobalEntity {
                 encountered: new_value.value_type(),
             });
         }
-        self.value = new_value.into();
+        self.set_untyped(new_value.into());
         Ok(())
     }
 
@@ -161,7 +161,7 @@ impl GlobalEntity {
 
     /// Returns the current value of the global variable.
     pub fn get(&self) -> Value {
-        self.value.with_type(self.value_type)
+        self.get_untyped().with_type(self.value_type)
     }
 
     /// Returns the current untyped value of the global variable.

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -1,3 +1,5 @@
+use wasmi_core::UntypedValue;
+
 use super::{AsContext, AsContextMut, Index, Stored};
 use crate::core::{Value, ValueType};
 use core::{fmt, fmt::Display};
@@ -93,7 +95,9 @@ impl GlobalType {
 #[derive(Debug)]
 pub struct GlobalEntity {
     /// The current value of the global variable.
-    value: Value,
+    value: UntypedValue,
+    /// The value type of the global variable.
+    value_type: ValueType,
     /// The mutability of the global variable.
     mutability: Mutability,
 }
@@ -102,7 +106,8 @@ impl GlobalEntity {
     /// Creates a new global entity with the given initial value and mutability.
     pub fn new(initial_value: Value, mutability: Mutability) -> Self {
         Self {
-            value: initial_value,
+            value: initial_value.into(),
+            value_type: initial_value.value_type(),
             mutability,
         }
     }
@@ -114,7 +119,7 @@ impl GlobalEntity {
 
     /// Returns the type of the global variable value.
     pub fn value_type(&self) -> ValueType {
-        self.value.value_type()
+        self.value_type
     }
 
     /// Returns the [`GlobalType`] of the global variable.
@@ -138,12 +143,29 @@ impl GlobalEntity {
                 encountered: new_value.value_type(),
             });
         }
-        self.value = new_value;
+        self.value = new_value.into();
         Ok(())
+    }
+
+    /// Sets a new untyped value for the global variable.
+    ///
+    /// # Note
+    ///
+    /// This is an inherently unsafe API and only exists to allow
+    /// for efficient `global.set` through the interpreter which is
+    /// safe since the interpreter only handles validated Wasm code
+    /// where the checks in [`Global::set`] cannot fail.
+    pub(crate) fn set_untyped(&mut self, new_value: UntypedValue) {
+        self.value = new_value;
     }
 
     /// Returns the current value of the global variable.
     pub fn get(&self) -> Value {
+        self.value.with_type(self.value_type)
+    }
+
+    /// Returns the current untyped value of the global variable.
+    pub fn get_untyped(&self) -> UntypedValue {
         self.value
     }
 }
@@ -217,6 +239,25 @@ impl Global {
             .set(new_value)
     }
 
+    /// Sets a new untyped value for the global variable.
+    ///
+    /// # Note
+    ///
+    /// This is an inherently unsafe API and only exists to allow
+    /// for efficient `global.set` through the interpreter which is
+    /// safe since the interpreter only handles validated Wasm code
+    /// where the checks in [`Global::set`] cannot fail.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ctx` does not own this [`Global`].
+    pub(crate) fn set_untyped(&self, mut ctx: impl AsContextMut, new_value: UntypedValue) {
+        ctx.as_context_mut()
+            .store
+            .resolve_global_mut(*self)
+            .set_untyped(new_value)
+    }
+
     /// Returns the current value of the global variable.
     ///
     /// # Panics
@@ -224,5 +265,14 @@ impl Global {
     /// Panics if `ctx` does not own this [`Global`].
     pub fn get(&self, ctx: impl AsContext) -> Value {
         ctx.as_context().store.resolve_global(*self).get()
+    }
+
+    /// Returns the current untyped value of the global variable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ctx` does not own this [`Global`].
+    pub(crate) fn get_untyped(&self, ctx: impl AsContext) -> UntypedValue {
+        ctx.as_context().store.resolve_global(*self).get_untyped()
     }
 }

--- a/wasmi_v1/src/global.rs
+++ b/wasmi_v1/src/global.rs
@@ -165,7 +165,7 @@ impl GlobalEntity {
     }
 
     /// Returns the current untyped value of the global variable.
-    pub fn get_untyped(&self) -> UntypedValue {
+    pub(crate) fn get_untyped(&self) -> UntypedValue {
         self.value
     }
 }


### PR DESCRIPTION
Currently the `global.get` and especially `global.set` perform a lot of unnecessary conversions and checks.
For example `global.set` checks for global variable mutability and checks types even though that has already been done during Wasm validation at the time of `wasmi` bytecode execution.

This also adds a new benchmark to test global variable `set` and `get` performance and shows a roughly 17% performance boost.