### PR TITLE
Optimize `global.get` and `global.set` by caching global variable value pointer

### DIFF
--- a/wasmi_v1/src/engine/cache.rs
+++ b/wasmi_v1/src/engine/cache.rs
@@ -8,7 +8,7 @@ use crate::{
     Table,
 };
 use core::ptr::NonNull;
-use wasmi_core::TrapCode;
+use wasmi_core::{TrapCode, UntypedValue};
 
 /// A cache for frequently used entities of an [`Instance`].
 #[derive(Debug)]
@@ -21,6 +21,8 @@ pub struct InstanceCache {
     default_table: Option<Table>,
     /// The last accessed function of the currently used [`Instance`].
     last_func: Option<(u32, Func)>,
+    /// The last accessed global variable value of the currently used [`Instance`].
+    last_global: Option<(u32, NonNull<UntypedValue>)>,
     /// The bytes of a default linear memory of the currently used [`Instance`].
     default_memory_bytes: Option<CachedMemoryBytes>,
 }
@@ -32,6 +34,7 @@ impl From<Instance> for InstanceCache {
             default_memory: None,
             default_table: None,
             last_func: None,
+            last_global: None,
             default_memory_bytes: None,
         }
     }
@@ -49,6 +52,7 @@ impl InstanceCache {
         self.default_memory = None;
         self.default_table = None;
         self.last_func = None;
+        self.last_global = None;
         self.default_memory_bytes = None;
     }
 
@@ -182,6 +186,42 @@ impl InstanceCache {
             Some((index, func)) if index == func_idx => func,
             _ => self.load_func_at(ctx, func_idx),
         }
+    }
+
+    /// Loads the [`Global`] at `index` of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a default table.
+    fn load_global_at(&mut self, ctx: impl AsContextMut, index: u32) -> NonNull<UntypedValue> {
+        let global = self
+            .instance()
+            .get_global(ctx.as_context(), index)
+            .map(|g| g.get_untyped_ptr(ctx))
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing global variable at index {index} for instance: {:?}",
+                    self.instance
+                )
+            });
+        self.last_global = Some((index, global));
+        global
+    }
+
+    /// Loads the [`Global`] at `index` of the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If the currently used [`Instance`] does not have a [`Func`] at the index.
+    pub fn get_global(&mut self, ctx: impl AsContextMut, global_idx: u32) -> &mut UntypedValue {
+        let mut ptr = match self.last_global {
+            Some((index, global)) if index == global_idx => global,
+            _ => self.load_global_at(ctx, global_idx),
+        };
+        // SAFETY: This deref is safe since we only hold this pointer
+        //         as long as we are sure that nothing else can manipulate
+        //         the global in a way that would invalidate the pointer.
+        unsafe { ptr.as_mut() }
     }
 }
 

--- a/wasmi_v1/src/engine/cache.rs
+++ b/wasmi_v1/src/engine/cache.rs
@@ -188,7 +188,8 @@ impl InstanceCache {
         }
     }
 
-    /// Loads the [`Global`] at `index` of the currently used [`Instance`].
+    /// Loads the pointer to the value of the global variable at `index`
+    /// of the currently used [`Instance`].
     ///
     /// # Panics
     ///
@@ -208,7 +209,8 @@ impl InstanceCache {
         global
     }
 
-    /// Loads the [`Global`] at `index` of the currently used [`Instance`].
+    /// Returns a pointer to the value of the global variable at `index`
+    /// of the currently used [`Instance`].
     ///
     /// # Panics
     ///

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -88,9 +88,9 @@ where
         use Instruction as Instr;
         loop {
             match *self.instr() {
-                Instr::LocalGet { local_depth } => self.visit_get_local(local_depth),
-                Instr::LocalSet { local_depth } => self.visit_set_local(local_depth),
-                Instr::LocalTee { local_depth } => self.visit_tee_local(local_depth),
+                Instr::LocalGet { local_depth } => self.visit_local_get(local_depth),
+                Instr::LocalSet { local_depth } => self.visit_local_set(local_depth),
+                Instr::LocalTee { local_depth } => self.visit_local_tee(local_depth),
                 Instr::Br(target) => self.visit_br(target),
                 Instr::BrIfEqz(target) => self.visit_br_if_eqz(target),
                 Instr::BrIfNez(target) => self.visit_br_if_nez(target),
@@ -106,8 +106,8 @@ where
                 Instr::CallIndirect(signature) => return self.visit_call_indirect(signature),
                 Instr::Drop => self.visit_drop(),
                 Instr::Select => self.visit_select(),
-                Instr::GlobalGet(global_idx) => self.visit_get_global(global_idx),
-                Instr::GlobalSet(global_idx) => self.visit_set_global(global_idx),
+                Instr::GlobalGet(global_idx) => self.visit_global_get(global_idx),
+                Instr::GlobalSet(global_idx) => self.visit_global_set(global_idx),
                 Instr::I32Load(offset) => self.visit_i32_load(offset)?,
                 Instr::I64Load(offset) => self.visit_i64_load(offset)?,
                 Instr::F32Load(offset) => self.visit_f32_load(offset)?,
@@ -566,31 +566,31 @@ where
         Ok(CallOutcome::Return)
     }
 
-    fn visit_get_local(&mut self, local_depth: LocalDepth) {
+    fn visit_local_get(&mut self, local_depth: LocalDepth) {
         let value = self.value_stack.peek(local_depth.into_inner());
         self.value_stack.push(value);
         self.next_instr()
     }
 
-    fn visit_set_local(&mut self, local_depth: LocalDepth) {
+    fn visit_local_set(&mut self, local_depth: LocalDepth) {
         let new_value = self.value_stack.pop();
         *self.value_stack.peek_mut(local_depth.into_inner()) = new_value;
         self.next_instr()
     }
 
-    fn visit_tee_local(&mut self, local_depth: LocalDepth) {
+    fn visit_local_tee(&mut self, local_depth: LocalDepth) {
         let new_value = self.value_stack.last();
         *self.value_stack.peek_mut(local_depth.into_inner()) = new_value;
         self.next_instr()
     }
 
-    fn visit_get_global(&mut self, global_index: GlobalIdx) {
+    fn visit_global_get(&mut self, global_index: GlobalIdx) {
         let global_value = self.global(global_index).get_untyped(self.ctx.as_context());
         self.value_stack.push(global_value);
         self.next_instr()
     }
 
-    fn visit_set_global(&mut self, global_index: GlobalIdx) {
+    fn visit_global_set(&mut self, global_index: GlobalIdx) {
         let global = self.global(global_index);
         let new_value = self.value_stack.pop();
         global.set_untyped(self.ctx.as_context_mut(), new_value);


### PR DESCRIPTION
The `global_bump` benchmark shows an 25% performance improvement with this optimization.