### PR TITLE
Optimize float-to-int Wasm trunc instructions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi_core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 [dependencies]
 memory_units = "0.4.0"
 libm = "0.2.1"
-num-rational = { version = "0.4", default-features = false, features = ["num-bigint"] }
 num-traits = { version = "0.2.8", default-features = false }
 downcast-rs = { version = "1.2", default-features = false }
 
@@ -24,8 +23,6 @@ rand = "0.8.2"
 default = ["std"]
 # Use `no-default-features` for a `no_std` build.
 std = [
-    "num-rational/std",
-    "num-rational/num-bigint-std",
     "num-traits/std",
     "downcast-rs/std",
 ]

--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [ "tests/*", "benches/*" ]
 
 [dependencies]
 wasmparser = { version = "0.90", package = "wasmparser-nostd", default-features = false }
-wasmi_core = { version = "0.3", path = "../core", default-features = false }
+wasmi_core = { version = "0.4", path = "../core", default-features = false }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]

--- a/wasmi_v1/benches/wat/trunc_f2i.wat
+++ b/wasmi_v1/benches/wat/trunc_f2i.wat
@@ -1,5 +1,5 @@
 (module
-    (func $trunc_i32_f32 (export "trunc_f2i") (param $n i32) (param $input32 f32) (param $input64 f64) (result)
+    (func (export "trunc_f2i") (param $n i32) (param $input32 f32) (param $input64 f64) (result)
         (local $i i32)
         (block $exit
             (if

--- a/wasmi_v1/benches/wat/trunc_f2i.wat
+++ b/wasmi_v1/benches/wat/trunc_f2i.wat
@@ -1,0 +1,45 @@
+(module
+    (func $trunc_i32_f32 (export "trunc_f2i") (param $n i32) (param $input32 f32) (param $input64 f64) (result)
+        (local $i i32)
+        (block $exit
+            (if
+                (i32.le_u
+                    (local.get $n)
+                    (i32.const 0)
+                )
+                (unreachable) ;; trap if $n <= 0
+            )
+            (local.set $i (local.get $n)) ;; i = n
+            (loop $continue
+                (drop
+                    (i32.trunc_f32_s (local.get $input32)) ;; <- under test
+                )
+                (drop
+                    (i32.trunc_f32_u (local.get $input32)) ;; <- under test
+                )
+                (drop
+                    (i64.trunc_f32_s (local.get $input32)) ;; <- under test
+                )
+                (drop
+                    (i64.trunc_f64_u (local.get $input64)) ;; <- under test
+                )
+                (drop
+                    (i32.trunc_f64_s (local.get $input64)) ;; <- under test
+                )
+                (drop
+                    (i32.trunc_f64_u (local.get $input64)) ;; <- under test
+                )
+                (drop
+                    (i64.trunc_f64_s (local.get $input64)) ;; <- under test
+                )
+                (drop
+                    (i64.trunc_f64_u (local.get $input64)) ;; <- under test
+                )
+                (local.set $i ;; i -= 1
+                    (i32.sub (local.get $i) (i32.const 1))
+                )
+                (br_if $continue (local.get $i)) ;; continue if i != 0
+            )
+        )
+    )
+)


### PR DESCRIPTION
![2022-09-13-180708_1330x100_scrot](https://user-images.githubusercontent.com/8193155/189951803-dca402c0-a8a3-4e03-b293-ce429dc97b99.png)

According to our new benchmarks this optimization improves performance of all 8 float to int Wasm truncation instructions by roughly 6000% (a.k.a. 60 times faster).
This also gets us rid of the `num-rational` crate dependency from `wasmi_core` which reduces `wasmi` fresh release build time by roughly 23% and reduces Wasm file size of `wasmi_core` crate by roughly 5%.

Nuff said ...
