### PR TITLE
Make Executor handle function calls and returns by itself

### DIFF
--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -3,6 +3,7 @@ use super::{
     bytecode::{FuncIdx, GlobalIdx, Instruction, LocalDepth, Offset, SignatureIdx},
     cache::InstanceCache,
     code_map::{CodeMap, Instructions},
+    func_types::FuncTypeRegistry,
     stack::Stack,
     CallOutcome,
     DropKeep,
@@ -37,8 +38,18 @@ pub fn execute_frame<'engine>(
     instrs: Instructions<'engine>,
     stack: &'engine mut Stack,
     code_map: &'engine CodeMap,
+    func_types: &'engine FuncTypeRegistry,
 ) -> Result<CallOutcome, Trap> {
-    Executor::new(ctx.as_context_mut(), frame, cache, instrs, stack, code_map).execute()
+    Executor::new(
+        ctx.as_context_mut(),
+        frame,
+        cache,
+        instrs,
+        stack,
+        code_map,
+        func_types,
+    )
+    .execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.
@@ -62,6 +73,8 @@ struct Executor<'ctx, 'engine, HostData> {
     instrs: Instructions<'engine>,
     /// The codemap that stores the instructions of all compiled Wasm functions.
     code_map: &'engine CodeMap,
+    /// The function type registry.
+    func_types: &'engine FuncTypeRegistry,
 }
 
 impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
@@ -74,6 +87,7 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
         instrs: Instructions<'engine>,
         value_stack: &'engine mut Stack,
         code_map: &'engine CodeMap,
+        func_types: &'engine FuncTypeRegistry,
     ) -> Self {
         cache.update_instance(frame.instance());
         Self {
@@ -83,6 +97,7 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
             ctx,
             instrs,
             code_map,
+            func_types,
         }
     }
 

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -30,7 +30,6 @@ use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedVa
 /// # Errors
 ///
 /// - If the execution of the function `frame` trapped.
-#[inline(always)]
 pub fn execute_frame<'engine>(
     mut ctx: impl AsContextMut,
     frame: FuncFrame,
@@ -77,7 +76,6 @@ struct Executor<'ctx, 'engine, HostData> {
 
 impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
     /// Creates a new [`Executor`] for executing a `wasmi` function frame.
-    #[inline(always)]
     pub fn new(
         ctx: StoreContextMut<'ctx, HostData>,
         frame: FuncFrame,
@@ -100,7 +98,6 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
     }
 
     /// Executes the function frame until it returns or traps.
-    #[inline(always)]
     fn execute(mut self) -> Result<(), Trap> {
         use Instruction as Instr;
         'next: loop {

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -30,7 +30,7 @@ use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedVa
 #[inline(always)]
 pub fn execute_frame<'engine>(
     ctx: impl AsContextMut,
-    frame: &mut FuncFrame,
+    frame: FuncFrame,
     cache: &mut InstanceCache,
     insts: Instructions<'engine>,
     value_stack: &'engine mut ValueStack,
@@ -40,13 +40,13 @@ pub fn execute_frame<'engine>(
 
 /// An execution context for executing a `wasmi` function frame.
 #[derive(Debug)]
-struct Executor<'engine, 'func, Ctx> {
+struct Executor<'engine, Ctx> {
     /// The program counter.
     pc: usize,
     /// Stores the value stack of live values on the Wasm stack.
     value_stack: &'engine mut ValueStack,
     /// The function frame that is being executed.
-    frame: &'func mut FuncFrame,
+    frame: FuncFrame,
     /// Stores frequently used instance related data.
     cache: &'engine mut InstanceCache,
     /// A mutable [`Store`] context.
@@ -57,7 +57,7 @@ struct Executor<'engine, 'func, Ctx> {
     insts: Instructions<'engine>,
 }
 
-impl<'engine, 'func, Ctx> Executor<'engine, 'func, Ctx>
+impl<'engine, Ctx> Executor<'engine, Ctx>
 where
     Ctx: AsContextMut,
 {
@@ -65,7 +65,7 @@ where
     #[inline(always)]
     pub fn new(
         ctx: Ctx,
-        frame: &'func mut FuncFrame,
+        frame: FuncFrame,
         cache: &'engine mut InstanceCache,
         insts: Instructions<'engine>,
         value_stack: &'engine mut ValueStack,
@@ -508,7 +508,7 @@ pub enum MaybeReturn {
     Continue,
 }
 
-impl<'engine, 'func, Ctx> Executor<'engine, 'func, Ctx>
+impl<'engine, Ctx> Executor<'engine, Ctx>
 where
     Ctx: AsContextMut,
 {

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -504,7 +504,7 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
             FuncEntityInternal::Wasm(wasm_func) => {
                 self.frame = self
                     .stack
-                    .call_wasm(&mut self.frame, wasm_func, self.code_map)?;
+                    .call_wasm(self.frame, wasm_func, self.code_map)?;
                 self.instrs = self.code_map.insts(self.frame.iref());
                 self.cache.update_instance(self.frame.instance());
             }

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -57,7 +57,7 @@ struct Executor<'engine, Ctx> {
     /// [`Store`]: [`crate::v1::Store`]
     ctx: Ctx,
     /// The instructions of the executed function frame.
-    insts: Instructions<'engine>,
+    instrs: Instructions<'engine>,
 }
 
 impl<'engine, Ctx> Executor<'engine, Ctx>
@@ -70,7 +70,7 @@ where
         ctx: Ctx,
         frame: FuncFrame,
         cache: &'engine mut InstanceCache,
-        insts: Instructions<'engine>,
+        instrs: Instructions<'engine>,
         value_stack: &'engine mut ValueStack,
     ) -> Self {
         cache.update_instance(frame.instance());
@@ -79,7 +79,7 @@ where
             frame,
             cache,
             ctx,
-            insts,
+            instrs,
         }
     }
 
@@ -281,7 +281,7 @@ where
         // # Safety
         //
         // Properly constructed `wasmi` bytecode can never produce invalid `pc`.
-        unsafe { self.insts.get_release_unchecked(self.frame.pc()) }
+        unsafe { self.instrs.get_release_unchecked(self.frame.pc()) }
     }
 
     /// Returns the default linear memory.

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -43,8 +43,12 @@ pub fn execute_frame<'engine>(
 #[derive(Debug)]
 struct Executor<'engine, Ctx> {
     /// The function frame that is being executed.
+    ///
+    /// This frequently changes when calling a function or returning from one.
     frame: FuncFrame,
-    /// Stores the value stack of live values on the Wasm stack.
+    /// The stack required for driving the execution.
+    ///
+    /// This hosts the value stack as well as the call stack.
     value_stack: &'engine mut ValueStack,
     /// Stores frequently used instance related data.
     cache: &'engine mut InstanceCache,

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -3,12 +3,13 @@ use super::{
     bytecode::{FuncIdx, GlobalIdx, Instruction, LocalDepth, Offset, SignatureIdx},
     cache::InstanceCache,
     code_map::Instructions,
+    stack::Stack,
     AsContextMut,
     CallOutcome,
     DropKeep,
     FuncFrame,
     Target,
-    ValueStack, stack::Stack,
+    ValueStack,
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -67,6 +67,7 @@ struct Executor<'ctx, 'engine, HostData> {
 
 impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
     /// Creates a new [`Executor`] for executing a `wasmi` function frame.
+    #[inline(always)]
     pub fn new(
         ctx: StoreContextMut<'ctx, HostData>,
         frame: FuncFrame,
@@ -88,6 +89,7 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
     }
 
     /// Executes the function frame until it returns or traps.
+    #[inline(always)]
     fn execute(mut self) -> Result<(), Trap> {
         use Instruction as Instr;
         'next: loop {

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -35,7 +35,6 @@ pub fn execute_frame<'engine>(
     mut ctx: impl AsContextMut,
     frame: FuncFrame,
     cache: &mut InstanceCache,
-    instrs: Instructions<'engine>,
     stack: &'engine mut Stack,
     code_map: &'engine CodeMap,
     func_types: &'engine FuncTypeRegistry,
@@ -44,7 +43,6 @@ pub fn execute_frame<'engine>(
         ctx.as_context_mut(),
         frame,
         cache,
-        instrs,
         stack,
         code_map,
         func_types,
@@ -84,12 +82,12 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
         ctx: StoreContextMut<'ctx, HostData>,
         frame: FuncFrame,
         cache: &'engine mut InstanceCache,
-        instrs: Instructions<'engine>,
         value_stack: &'engine mut Stack,
         code_map: &'engine CodeMap,
         func_types: &'engine FuncTypeRegistry,
     ) -> Self {
         cache.update_instance(frame.instance());
+        let instrs = code_map.insts(frame.iref());
         Self {
             stack: value_stack,
             frame,

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -12,6 +12,7 @@ use super::{
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
+    func::FuncEntityInternal,
     AsContext,
     AsContextMut,
     Func,
@@ -121,8 +122,8 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
                 Instr::BrTable { len_targets } => self.visit_br_table(len_targets),
                 Instr::Unreachable => self.visit_unreachable()?,
                 Instr::Return(drop_keep) => return self.visit_ret(drop_keep),
-                Instr::Call(func) => return self.visit_call(func),
-                Instr::CallIndirect(signature) => return self.visit_call_indirect(signature),
+                Instr::Call(func) => self.visit_call(func)?,
+                Instr::CallIndirect(signature) => self.visit_call_indirect(signature)?,
                 Instr::Drop => self.visit_drop(),
                 Instr::Select => self.visit_select(),
                 Instr::GlobalGet(global_idx) => self.visit_global_get(global_idx),
@@ -510,9 +511,27 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
         self.frame.update_pc(target.destination_pc().into_usize());
     }
 
-    fn call_func(&mut self, func: Func) -> Result<CallOutcome, Trap> {
+    fn call_func(&mut self, called_func: Func) -> Result<(), Trap> {
         self.frame.bump_pc();
-        Ok(CallOutcome::NestedCall(func))
+        match called_func.as_internal(self.ctx.as_context()) {
+            FuncEntityInternal::Wasm(wasm_func) => {
+                self.frame = self
+                    .stack
+                    .call_wasm(&mut self.frame, wasm_func, &self.code_map)?;
+                self.cache.update_instance(self.frame.instance());
+            }
+            FuncEntityInternal::Host(host_func) => {
+                self.cache.reset_default_memory_bytes();
+                let host_func = host_func.clone();
+                self.stack.call_host(
+                    self.ctx.as_context_mut(),
+                    &mut self.frame,
+                    host_func,
+                    &self.func_types,
+                )?;
+            }
+        }
+        Ok(())
     }
 
     fn ret(&mut self, drop_keep: DropKeep) {
@@ -609,14 +628,14 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
         self.next_instr()
     }
 
-    fn visit_call(&mut self, func_index: FuncIdx) -> Result<CallOutcome, Trap> {
+    fn visit_call(&mut self, func_index: FuncIdx) -> Result<(), Trap> {
         let callee = self
             .cache
             .get_func(self.ctx.as_context_mut(), func_index.into_inner());
         self.call_func(callee)
     }
 
-    fn visit_call_indirect(&mut self, signature_index: SignatureIdx) -> Result<CallOutcome, Trap> {
+    fn visit_call_indirect(&mut self, signature_index: SignatureIdx) -> Result<(), Trap> {
         let func_index: u32 = self.stack.pop_as();
         let table = self.default_table();
         let func = table

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -519,7 +519,7 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
             FuncEntityInternal::Wasm(wasm_func) => {
                 self.frame = self
                     .stack
-                    .call_wasm(&mut self.frame, wasm_func, &self.code_map)?;
+                    .call_wasm(&mut self.frame, wasm_func, self.code_map)?;
                 self.instrs = self.code_map.insts(self.frame.iref());
                 self.cache.update_instance(self.frame.instance());
             }
@@ -528,9 +528,9 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
                 let host_func = host_func.clone();
                 self.stack.call_host(
                     self.ctx.as_context_mut(),
-                    &mut self.frame,
+                    &self.frame,
                     host_func,
-                    &self.func_types,
+                    self.func_types,
                 )?;
             }
         }

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -8,7 +8,7 @@ use super::{
     DropKeep,
     FuncFrame,
     Target,
-    ValueStack,
+    ValueStack, stack::Stack,
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
@@ -33,7 +33,7 @@ pub fn execute_frame<'engine>(
     frame: FuncFrame,
     cache: &mut InstanceCache,
     insts: Instructions<'engine>,
-    value_stack: &'engine mut ValueStack,
+    value_stack: &'engine mut Stack,
 ) -> Result<CallOutcome, Trap> {
     Executor::new(ctx, frame, cache, insts, value_stack).execute()
 }

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -502,9 +502,7 @@ impl<'ctx, 'engine, HostData> Executor<'ctx, 'engine, HostData> {
         self.frame.bump_pc();
         match called_func.as_internal(self.ctx.as_context()) {
             FuncEntityInternal::Wasm(wasm_func) => {
-                self.frame = self
-                    .stack
-                    .call_wasm(self.frame, wasm_func, self.code_map)?;
+                self.frame = self.stack.call_wasm(self.frame, wasm_func, self.code_map)?;
                 self.instrs = self.code_map.insts(self.frame.iref());
                 self.cache.update_instance(self.frame.instance());
             }

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -32,11 +32,11 @@ pub fn execute_frame<'engine>(
     ctx: impl AsContextMut,
     frame: FuncFrame,
     cache: &mut InstanceCache,
-    insts: Instructions<'engine>,
+    instrs: Instructions<'engine>,
     stack: &'engine mut Stack,
     code_map: &'engine CodeMap,
 ) -> Result<CallOutcome, Trap> {
-    Executor::new(ctx, frame, cache, insts, stack, code_map).execute()
+    Executor::new(ctx, frame, cache, instrs, stack, code_map).execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -2,7 +2,7 @@ use super::{
     super::{Memory, Table},
     bytecode::{FuncIdx, GlobalIdx, Instruction, LocalDepth, Offset, SignatureIdx},
     cache::InstanceCache,
-    code_map::Instructions,
+    code_map::{CodeMap, Instructions},
     stack::Stack,
     AsContextMut,
     CallOutcome,
@@ -34,9 +34,10 @@ pub fn execute_frame<'engine>(
     frame: FuncFrame,
     cache: &mut InstanceCache,
     insts: Instructions<'engine>,
-    value_stack: &'engine mut Stack,
+    stack: &'engine mut Stack,
+    code_map: &'engine CodeMap,
 ) -> Result<CallOutcome, Trap> {
-    Executor::new(ctx, frame, cache, insts, value_stack).execute()
+    Executor::new(ctx, frame, cache, insts, stack, code_map).execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.
@@ -58,6 +59,8 @@ struct Executor<'engine, Ctx> {
     ctx: Ctx,
     /// The instructions of the executed function frame.
     instrs: Instructions<'engine>,
+    /// The codemap that stores the instructions of all compiled Wasm functions.
+    code_map: &'engine CodeMap,
 }
 
 impl<'engine, Ctx> Executor<'engine, Ctx>
@@ -72,6 +75,7 @@ where
         cache: &'engine mut InstanceCache,
         instrs: Instructions<'engine>,
         value_stack: &'engine mut ValueStack,
+        code_map: &'engine CodeMap,
     ) -> Self {
         cache.update_instance(frame.instance());
         Self {
@@ -80,6 +84,7 @@ where
             cache,
             ctx,
             instrs,
+            code_map,
         }
     }
 

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -406,6 +406,14 @@ impl EngineInner {
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
         let insts = self.code_map.insts(frame.iref());
-        execute_frame(ctx, frame, cache, insts, &mut self.stack, &self.code_map)
+        execute_frame(
+            ctx,
+            frame,
+            cache,
+            insts,
+            &mut self.stack,
+            &self.code_map,
+            &self.func_types,
+        )
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -353,12 +353,10 @@ impl EngineInner {
         frame: FuncFrame,
         cache: &mut InstanceCache,
     ) -> Result<(), Trap> {
-        let insts = self.code_map.insts(frame.iref());
         execute_frame(
             ctx,
             frame,
             cache,
-            insts,
             &mut self.stack,
             &self.code_map,
             &self.func_types,

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -374,7 +374,8 @@ impl EngineInner {
                 CallOutcome::NestedCall(called_func) => {
                     match called_func.as_internal(ctx.as_context()) {
                         FuncEntityInternal::Wasm(wasm_func) => {
-                            self.stack.call_wasm(&mut frame, wasm_func, &self.code_map)?;
+                            self.stack
+                                .call_wasm(&mut frame, wasm_func, &self.code_map)?;
                         }
                         FuncEntityInternal::Host(host_func) => {
                             cache.reset_default_memory_bytes();

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -406,6 +406,6 @@ impl EngineInner {
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
         let insts = self.code_map.insts(frame.iref());
-        execute_frame(ctx, frame, cache, insts, &mut self.stack)
+        execute_frame(ctx, frame, cache, insts, &mut self.stack, &self.code_map)
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -405,6 +405,6 @@ impl EngineInner {
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
         let insts = self.code_map.insts(frame.iref());
-        execute_frame(ctx, frame, cache, insts, &mut self.stack.values)
+        execute_frame(ctx, frame, cache, insts, &mut self.stack)
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -52,8 +52,6 @@ use spin::mutex::Mutex;
 pub enum CallOutcome {
     /// The function has returned.
     Return,
-    /// The function called another function.
-    NestedCall(Func),
 }
 
 /// A unique engine index.
@@ -371,24 +369,6 @@ impl EngineInner {
                     }
                     None => return Ok(()),
                 },
-                CallOutcome::NestedCall(called_func) => {
-                    match called_func.as_internal(ctx.as_context()) {
-                        FuncEntityInternal::Wasm(wasm_func) => {
-                            self.stack
-                                .call_wasm(&mut frame, wasm_func, &self.code_map)?;
-                        }
-                        FuncEntityInternal::Host(host_func) => {
-                            cache.reset_default_memory_bytes();
-                            let host_func = host_func.clone();
-                            self.stack.call_host(
-                                ctx.as_context_mut(),
-                                &mut frame,
-                                host_func,
-                                &self.func_types,
-                            )?;
-                        }
-                    }
-                }
             }
         }
     }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -47,13 +47,6 @@ use core::sync::atomic::{AtomicU32, Ordering};
 pub use func_types::DedupFuncType;
 use spin::mutex::Mutex;
 
-/// The outcome of a `wasmi` function execution.
-#[derive(Debug, Copy, Clone)]
-pub enum CallOutcome {
-    /// The function has returned.
-    Return,
-}
-
 /// A unique engine index.
 ///
 /// # Note
@@ -356,35 +349,10 @@ impl EngineInner {
     /// - When a called host function trapped.
     fn execute_wasm_func(
         &mut self,
-        mut ctx: impl AsContextMut,
-        mut frame: FuncFrame,
-        cache: &mut InstanceCache,
-    ) -> Result<(), Trap> {
-        'outer: loop {
-            match self.execute_frame(ctx.as_context_mut(), frame, cache)? {
-                CallOutcome::Return => match self.stack.return_wasm() {
-                    Some(caller) => {
-                        frame = caller;
-                        continue 'outer;
-                    }
-                    None => return Ok(()),
-                },
-            }
-        }
-    }
-
-    /// Executes the given function `frame` and returns the result.
-    ///
-    /// # Errors
-    ///
-    /// - If the execution of the function `frame` trapped.
-    #[inline(always)]
-    fn execute_frame(
-        &mut self,
         ctx: impl AsContextMut,
         frame: FuncFrame,
         cache: &mut InstanceCache,
-    ) -> Result<CallOutcome, Trap> {
+    ) -> Result<(), Trap> {
         let insts = self.code_map.insts(frame.iref());
         execute_frame(
             ctx,
@@ -394,6 +362,7 @@ impl EngineInner {
             &mut self.stack,
             &self.code_map,
             &self.func_types,
-        )
+        )?;
+        Ok(())
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -18,7 +18,7 @@ use self::{
     code_map::CodeMap,
     executor::execute_frame,
     func_types::FuncTypeRegistry,
-    stack::{FuncFrame, Stack, ValueStack},
+    stack::{FuncFrame, Stack},
 };
 pub use self::{
     bytecode::{DropKeep, Target},

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -29,11 +29,25 @@ pub struct FuncFrame {
 
 impl FuncFrame {
     /// Returns the program counter.
+    #[inline]
     pub fn pc(&self) -> usize {
         self.pc
     }
 
+    /// Bumps the program counter.
+    #[inline]
+    pub fn bump_pc(&mut self) {
+        self.bump_pc_by(1)
+    }
+
+    /// Bumps the program counter by an offset.
+    #[inline]
+    pub fn bump_pc_by(&mut self, delta: usize) {
+        self.pc += delta;
+    }
+
     /// Updates the program counter.
+    #[inline]
     pub fn update_pc(&mut self, new_pc: usize) {
         self.pc = new_pc;
     }

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -3,7 +3,6 @@
 use super::{err_stack_overflow, DEFAULT_MAX_RECURSION_DEPTH};
 use crate::{core::TrapCode, engine::code_map::InstructionsRef, Instance};
 use alloc::vec::Vec;
-use core::mem::replace;
 
 /// A function frame of a function on the call stack.
 #[derive(Debug, Copy, Clone)]
@@ -105,7 +104,7 @@ impl CallStack {
     /// Pushes a Wasm function onto the [`CallStack`].
     pub(crate) fn push(
         &mut self,
-        caller: &mut FuncFrame,
+        caller: FuncFrame,
         iref: InstructionsRef,
         instance: Instance,
     ) -> Result<FuncFrame, TrapCode> {
@@ -113,7 +112,6 @@ impl CallStack {
             return Err(err_stack_overflow());
         }
         let frame = FuncFrame::new(iref, instance);
-        let caller = replace(caller, frame);
         self.frames.push(caller);
         Ok(frame)
     }

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -154,7 +154,7 @@ impl Stack {
     /// Prepares the [`Stack`] for the given Wasm function call.
     pub(crate) fn call_wasm<'engine>(
         &mut self,
-        caller: &mut FuncFrame,
+        caller: FuncFrame,
         wasm_func: &WasmFuncEntity,
         code_map: &'engine CodeMap,
     ) -> Result<FuncFrame, TrapCode> {

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -19,7 +19,8 @@ use crate::{
 };
 use core::{
     fmt::{self, Display},
-    mem::size_of, ops::{Deref, DerefMut},
+    mem::size_of,
+    ops::{Deref, DerefMut},
 };
 use wasmi_core::{Trap, TrapCode};
 

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use core::{
     fmt::{self, Display},
-    mem::size_of,
+    mem::size_of, ops::{Deref, DerefMut},
 };
 use wasmi_core::{Trap, TrapCode};
 
@@ -105,9 +105,25 @@ impl Default for StackLimits {
 #[derive(Debug, Default)]
 pub struct Stack {
     /// The value stack.
-    pub(crate) values: ValueStack,
+    pub values: ValueStack,
     /// The frame stack.
     frames: CallStack,
+}
+
+impl Deref for Stack {
+    type Target = ValueStack;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl DerefMut for Stack {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values
+    }
 }
 
 impl Stack {


### PR DESCRIPTION
So far the `wasmi` engine execution facilities were strictly divided into handling function calls and returns as well as executing a particular function until it returns.
This PR merges both divided implementations into the already existing `Executor` type that is now capable of doing everything.

The idea behind this is that this might allow `rustc` to optimize the `wasmi` engine hot path further. Let's see what the benchmarks are telling ...