### PR TITLE
ci change gitlab runner for benchmarking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ default:
   image:                           "paritytech/ci-linux:production"
   interruptible:                   true
   tags:
-    - linux-docker
+    - linux-docker-benches
 
 # benchmark
 criterion-benchmark:


### PR DESCRIPTION
This PR changes GitLab runners where benchmarks will be executed on. Those `linux-docker-bench` runners specially tuned to have only 1 active job running at a time so must provide more trustworthy results