### PR TITLE
Attempt #2: Make Executor handle calls and returns

### DIFF
--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -8,7 +8,7 @@ use super::{
     DropKeep,
     FuncFrame,
     Target,
-    ValueStack,
+    stack::Stack,
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
@@ -33,7 +33,7 @@ pub fn execute_frame<'engine>(
     frame: &mut FuncFrame,
     cache: &mut InstanceCache,
     insts: Instructions<'engine>,
-    value_stack: &'engine mut ValueStack,
+    value_stack: &'engine mut Stack,
 ) -> Result<CallOutcome, Trap> {
     Executor::new(ctx, frame, cache, insts, value_stack).execute()
 }
@@ -44,7 +44,7 @@ struct Executor<'engine, 'func, Ctx> {
     /// The program counter.
     pc: usize,
     /// Stores the value stack of live values on the Wasm stack.
-    value_stack: &'engine mut ValueStack,
+    value_stack: &'engine mut Stack,
     /// The function frame that is being executed.
     frame: &'func mut FuncFrame,
     /// Stores frequently used instance related data.
@@ -68,7 +68,7 @@ where
         frame: &'func mut FuncFrame,
         cache: &'engine mut InstanceCache,
         insts: Instructions<'engine>,
-        value_stack: &'engine mut ValueStack,
+        value_stack: &'engine mut Stack,
     ) -> Self {
         cache.update_instance(frame.instance());
         let pc = frame.pc();

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -58,6 +58,8 @@ struct Executor<'ctx, 'engine, 'func, HostData> {
     ctx: StoreContextMut<'ctx, HostData>,
     /// The instructions of the executed function frame.
     insts: Instructions<'engine>,
+    /// The engine resources immutable during function execution.
+    res: &'engine EngineResources,
 }
 
 impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
@@ -80,6 +82,7 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
             cache,
             ctx,
             insts,
+            res,
         }
     }
 

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -3,16 +3,19 @@ use super::{
     bytecode::{FuncIdx, GlobalIdx, Instruction, LocalDepth, Offset, SignatureIdx},
     cache::InstanceCache,
     code_map::Instructions,
+    stack::Stack,
     AsContextMut,
     CallOutcome,
     DropKeep,
+    EngineResources,
     FuncFrame,
     Target,
-    stack::Stack, EngineResources,
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
-    Func, StoreContextMut, AsContext,
+    AsContext,
+    Func,
+    StoreContextMut,
 };
 use core::cmp;
 use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedValue, WrapInto};

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -35,10 +35,10 @@ pub fn execute_frame<'engine>(
     mut ctx: impl AsContextMut,
     frame: &mut FuncFrame,
     cache: &mut InstanceCache,
-    value_stack: &'engine mut Stack,
+    stack: &'engine mut Stack,
     res: &'engine EngineResources,
 ) -> Result<(), Trap> {
-    Executor::new(ctx.as_context_mut(), frame, cache, value_stack, res).execute()
+    Executor::new(ctx.as_context_mut(), frame, cache, stack, res).execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.
@@ -69,7 +69,7 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
         ctx: StoreContextMut<'ctx, HostData>,
         frame: &'func mut FuncFrame,
         cache: &'engine mut InstanceCache,
-        value_stack: &'engine mut Stack,
+        stack: &'engine mut Stack,
         res: &'engine EngineResources,
     ) -> Self {
         cache.update_instance(frame.instance());
@@ -77,7 +77,7 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
         let pc = frame.pc();
         Self {
             pc,
-            stack: value_stack,
+            stack,
             frame,
             cache,
             ctx,

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -8,7 +8,7 @@ use super::{
     DropKeep,
     FuncFrame,
     Target,
-    stack::Stack,
+    stack::Stack, EngineResources,
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
@@ -32,10 +32,10 @@ pub fn execute_frame<'engine>(
     mut ctx: impl AsContextMut,
     frame: &mut FuncFrame,
     cache: &mut InstanceCache,
-    insts: Instructions<'engine>,
     value_stack: &'engine mut Stack,
+    res: &'engine EngineResources,
 ) -> Result<CallOutcome, Trap> {
-    Executor::new(ctx.as_context_mut(), frame, cache, insts, value_stack).execute()
+    Executor::new(ctx.as_context_mut(), frame, cache, value_stack, res).execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.
@@ -64,10 +64,11 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
         ctx: StoreContextMut<'ctx, HostData>,
         frame: &'func mut FuncFrame,
         cache: &'engine mut InstanceCache,
-        insts: Instructions<'engine>,
         value_stack: &'engine mut Stack,
+        res: &'engine EngineResources,
     ) -> Self {
         cache.update_instance(frame.instance());
+        let insts = res.code_map.insts(frame.iref());
         let pc = frame.pc();
         Self {
             pc,

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -90,7 +90,7 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
     #[inline(always)]
     fn execute(mut self) -> Result<(), Trap> {
         use Instruction as Instr;
-        'next: loop {
+        loop {
             match *self.instr() {
                 Instr::LocalGet { local_depth } => self.visit_local_get(local_depth),
                 Instr::LocalSet { local_depth } => self.visit_local_set(local_depth),
@@ -105,10 +105,11 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
                 }
                 Instr::BrTable { len_targets } => self.visit_br_table(len_targets),
                 Instr::Unreachable => self.visit_unreachable()?,
-                Instr::Return(drop_keep) => match self.visit_ret(drop_keep) {
-                    MaybeReturn::Return => return Ok(()),
-                    MaybeReturn::Continue => continue 'next,
-                },
+                Instr::Return(drop_keep) => {
+                    if let MaybeReturn::Return = self.visit_ret(drop_keep) {
+                        return Ok(());
+                    }
+                }
                 Instr::Call(func) => self.visit_call(func)?,
                 Instr::CallIndirect(signature) => self.visit_call_indirect(signature)?,
                 Instr::Drop => self.visit_drop(),

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -420,7 +420,6 @@ impl EngineInner {
         frame: &mut FuncFrame,
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
-        let insts = self.res.code_map.insts(frame.iref());
-        execute_frame(ctx, frame, cache, insts, &mut self.stack)
+        execute_frame(ctx, frame, cache, &mut self.stack, &self.res)
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -47,13 +47,6 @@ use core::sync::atomic::{AtomicU32, Ordering};
 pub use func_types::DedupFuncType;
 use spin::mutex::Mutex;
 
-/// The outcome of a `wasmi` function execution.
-#[derive(Debug, Copy, Clone)]
-pub enum CallOutcome {
-    /// The function has returned.
-    Return,
-}
-
 /// A unique engine index.
 ///
 /// # Note
@@ -377,35 +370,10 @@ impl EngineInner {
     /// - When a called host function trapped.
     fn execute_wasm_func(
         &mut self,
-        mut ctx: impl AsContextMut,
-        frame: &mut FuncFrame,
-        cache: &mut InstanceCache,
-    ) -> Result<(), Trap> {
-        'outer: loop {
-            match self.execute_frame(ctx.as_context_mut(), frame, cache)? {
-                CallOutcome::Return => match self.stack.return_wasm() {
-                    Some(caller) => {
-                        *frame = caller;
-                        continue 'outer;
-                    }
-                    None => return Ok(()),
-                },
-            }
-        }
-    }
-
-    /// Executes the given function `frame` and returns the result.
-    ///
-    /// # Errors
-    ///
-    /// - If the execution of the function `frame` trapped.
-    #[inline(always)]
-    fn execute_frame(
-        &mut self,
         ctx: impl AsContextMut,
         frame: &mut FuncFrame,
         cache: &mut InstanceCache,
-    ) -> Result<CallOutcome, Trap> {
+    ) -> Result<(), Trap> {
         execute_frame(ctx, frame, cache, &mut self.stack, &self.res)
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -141,7 +141,12 @@ impl Engine {
         F: FnOnce(&FuncType) -> R,
     {
         // Note: The clone operation on FuncType is intentionally cheap.
-        f(self.inner.lock().res.func_types.resolve_func_type(func_type))
+        f(self
+            .inner
+            .lock()
+            .res
+            .func_types
+            .resolve_func_type(func_type))
     }
 
     /// Allocates the instructions of a Wasm function body to the [`Engine`].

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -52,8 +52,6 @@ use spin::mutex::Mutex;
 pub enum CallOutcome {
     /// The function has returned.
     Return,
-    /// The function called another function.
-    NestedCall(Func),
 }
 
 /// A unique engine index.
@@ -392,23 +390,6 @@ impl EngineInner {
                     }
                     None => return Ok(()),
                 },
-                CallOutcome::NestedCall(called_func) => {
-                    match called_func.as_internal(ctx.as_context()) {
-                        FuncEntityInternal::Wasm(wasm_func) => {
-                            self.stack.call_wasm(frame, wasm_func, &self.res.code_map)?;
-                        }
-                        FuncEntityInternal::Host(host_func) => {
-                            cache.reset_default_memory_bytes();
-                            let host_func = host_func.clone();
-                            self.stack.call_host(
-                                ctx.as_context_mut(),
-                                frame,
-                                host_func,
-                                &self.res.func_types,
-                            )?;
-                        }
-                    }
-                }
             }
         }
     }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -18,7 +18,7 @@ use self::{
     code_map::CodeMap,
     executor::execute_frame,
     func_types::FuncTypeRegistry,
-    stack::{FuncFrame, Stack, ValueStack},
+    stack::{FuncFrame, Stack},
 };
 pub use self::{
     bytecode::{DropKeep, Target},
@@ -405,6 +405,6 @@ impl EngineInner {
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
         let insts = self.code_map.insts(frame.iref());
-        execute_frame(ctx, frame, cache, insts, &mut self.stack.values)
+        execute_frame(ctx, frame, cache, insts, &mut self.stack)
     }
 }

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use core::{
     fmt::{self, Display},
-    mem::size_of,
+    mem::size_of, ops::{Deref, DerefMut},
 };
 use wasmi_core::{Trap, TrapCode};
 
@@ -108,6 +108,22 @@ pub struct Stack {
     pub(crate) values: ValueStack,
     /// The frame stack.
     frames: CallStack,
+}
+
+impl Deref for Stack {
+    type Target = ValueStack;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl DerefMut for Stack {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values
+    }
 }
 
 impl Stack {

--- a/wasmi_v1/src/engine/stack/mod.rs
+++ b/wasmi_v1/src/engine/stack/mod.rs
@@ -19,7 +19,8 @@ use crate::{
 };
 use core::{
     fmt::{self, Display},
-    mem::size_of, ops::{Deref, DerefMut},
+    mem::size_of,
+    ops::{Deref, DerefMut},
 };
 use wasmi_core::{Trap, TrapCode};
 


### PR DESCRIPTION
https://github.com/paritytech/wasmi/pull/451 was crafted in a way that made it hard to see where the regressions happened. While this PR experiences the same regressions we now know where.
My initial suspicion is that LLVM or Rust or both are no longer able to properly optimize the `loop + match` construct in the `Executor`. Before this PR the code gets optimized to the best possible form for us where the call to query the next item is distributed amonst all match arms for better branch predictability.
Flamegraph outputs suggest that this is no longer the case but I am baffled to understand why that is ...

The commit that introduces the major regression is this:
https://github.com/paritytech/wasmi/pull/456/commits/3dc45f3ac994fdfd81f739ee1c483741c81afa3a