### PR TITLE
fix(pc): should keep one pc and make frame pc being latest pc

### DIFF
--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -41,8 +41,6 @@ pub fn execute_frame<'engine>(
 /// An execution context for executing a `wasmi` function frame.
 #[derive(Debug)]
 struct Executor<'engine, 'func, Ctx> {
-    /// The program counter.
-    pc: usize,
     /// Stores the value stack of live values on the Wasm stack.
     value_stack: &'engine mut ValueStack,
     /// The function frame that is being executed.
@@ -71,9 +69,7 @@ where
         value_stack: &'engine mut ValueStack,
     ) -> Self {
         cache.update_instance(frame.instance());
-        let pc = frame.pc();
         Self {
-            pc,
             value_stack,
             frame,
             cache,
@@ -280,7 +276,7 @@ where
         // # Safety
         //
         // Properly constructed `wasmi` bytecode can never produce invalid `pc`.
-        unsafe { self.insts.get_release_unchecked(self.pc) }
+        unsafe { self.insts.get_release_unchecked(self.frame.pc()) }
     }
 
     /// Returns the default linear memory.
@@ -478,22 +474,21 @@ where
     }
 
     fn try_next_instr(&mut self) -> Result<(), Trap> {
-        self.pc += 1;
+        self.next_instr();
         Ok(())
     }
 
     fn next_instr(&mut self) {
-        self.pc += 1;
+        self.frame.update_pc(self.frame.pc() + 1)
     }
 
     fn branch_to(&mut self, target: Target) {
         self.value_stack.drop_keep(target.drop_keep());
-        self.pc = target.destination_pc().into_usize();
+        self.frame.update_pc(target.destination_pc().into_usize());
     }
 
     fn call_func(&mut self, func: Func) -> Result<CallOutcome, Trap> {
-        self.pc += 1;
-        self.frame.update_pc(self.pc);
+        self.next_instr();
         Ok(CallOutcome::NestedCall(func))
     }
 
@@ -556,7 +551,7 @@ where
         // A normalized index will always yield a target without panicking.
         let normalized_index = cmp::min(index as usize, max_index);
         // Update `pc`:
-        self.pc += normalized_index + 1;
+        self.frame.update_pc(self.frame.pc() + normalized_index + 1);
     }
 
     fn visit_ret(&mut self, drop_keep: DropKeep) -> Result<CallOutcome, Trap> {

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -478,6 +478,7 @@ where
         Ok(())
     }
 
+    #[inline(always)]
     fn next_instr(&mut self) {
         self.frame.update_pc(self.frame.pc() + 1)
     }

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -29,11 +29,13 @@ pub struct FuncFrame {
 
 impl FuncFrame {
     /// Returns the program counter.
+    #[inline]
     pub fn pc(&self) -> usize {
         self.pc
     }
 
     /// Updates the program counter.
+    #[inline]
     pub fn update_pc(&mut self, new_pc: usize) {
         self.pc = new_pc;
     }

--- a/wasmi_v1/src/engine/stack/frames.rs
+++ b/wasmi_v1/src/engine/stack/frames.rs
@@ -29,13 +29,13 @@ pub struct FuncFrame {
 
 impl FuncFrame {
     /// Returns the program counter.
-    #[inline]
+    #[inline(always)]
     pub fn pc(&self) -> usize {
         self.pc
     }
 
     /// Updates the program counter.
-    #[inline]
+    #[inline(always)]
     pub fn update_pc(&mut self, new_pc: usize) {
         self.pc = new_pc;
     }


### PR DESCRIPTION
I think the `pc` in Executor is useless and the frame pc should be updated every round.
Now the `FuncFrame` could not be used more than once when `execute_frame` because its pc has been updated.