### PR TITLE
Cleanup Engine

### DIFF
--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -33,7 +33,7 @@ use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedVa
 pub fn execute_frame<'engine>(
     mut ctx: impl AsContextMut,
     frame: &mut FuncFrame,
-    cache: &mut InstanceCache,
+    cache: &'engine mut InstanceCache,
     instrs: Instructions<'engine>,
     value_stack: &'engine mut ValueStack,
 ) -> Result<CallOutcome, Trap> {

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -32,10 +32,10 @@ pub fn execute_frame<'engine>(
     ctx: impl AsContextMut,
     frame: &mut FuncFrame,
     cache: &mut InstanceCache,
-    insts: Instructions<'engine>,
+    instrs: Instructions<'engine>,
     value_stack: &'engine mut ValueStack,
 ) -> Result<CallOutcome, Trap> {
-    Executor::new(ctx, frame, cache, insts, value_stack).execute()
+    Executor::new(ctx, frame, cache, instrs, value_stack).execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.
@@ -54,7 +54,7 @@ struct Executor<'engine, 'func, Ctx> {
     /// [`Store`]: [`crate::v1::Store`]
     ctx: Ctx,
     /// The instructions of the executed function frame.
-    insts: Instructions<'engine>,
+    instrs: Instructions<'engine>,
 }
 
 impl<'engine, 'func, Ctx> Executor<'engine, 'func, Ctx>
@@ -67,7 +67,7 @@ where
         ctx: Ctx,
         frame: &'func mut FuncFrame,
         cache: &'engine mut InstanceCache,
-        insts: Instructions<'engine>,
+        instrs: Instructions<'engine>,
         value_stack: &'engine mut ValueStack,
     ) -> Self {
         cache.update_instance(frame.instance());
@@ -78,7 +78,7 @@ where
             frame,
             cache,
             ctx,
-            insts,
+            instrs,
         }
     }
 
@@ -280,7 +280,7 @@ where
         // # Safety
         //
         // Properly constructed `wasmi` bytecode can never produce invalid `pc`.
-        unsafe { self.insts.get_release_unchecked(self.pc) }
+        unsafe { self.instrs.get_release_unchecked(self.pc) }
     }
 
     /// Returns the default linear memory.

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
-    Func,
+    Func, StoreContextMut, AsContext,
 };
 use core::cmp;
 use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedValue, WrapInto};
@@ -29,18 +29,18 @@ use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedVa
 /// - If the execution of the function `frame` trapped.
 #[inline(always)]
 pub fn execute_frame<'engine>(
-    ctx: impl AsContextMut,
+    mut ctx: impl AsContextMut,
     frame: &mut FuncFrame,
     cache: &mut InstanceCache,
     instrs: Instructions<'engine>,
     value_stack: &'engine mut ValueStack,
 ) -> Result<CallOutcome, Trap> {
-    Executor::new(ctx, frame, cache, instrs, value_stack).execute()
+    Executor::new(ctx.as_context_mut(), frame, cache, instrs, value_stack).execute()
 }
 
 /// An execution context for executing a `wasmi` function frame.
 #[derive(Debug)]
-struct Executor<'engine, 'func, Ctx> {
+struct Executor<'ctx, 'engine, 'func, HostData> {
     /// The program counter.
     pc: usize,
     /// Stores the value stack of live values on the Wasm stack.
@@ -52,19 +52,16 @@ struct Executor<'engine, 'func, Ctx> {
     /// A mutable [`Store`] context.
     ///
     /// [`Store`]: [`crate::v1::Store`]
-    ctx: Ctx,
+    ctx: StoreContextMut<'ctx, HostData>,
     /// The instructions of the executed function frame.
     instrs: Instructions<'engine>,
 }
 
-impl<'engine, 'func, Ctx> Executor<'engine, 'func, Ctx>
-where
-    Ctx: AsContextMut,
-{
+impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
     /// Creates a new [`Executor`] for executing a `wasmi` function frame.
     #[inline(always)]
     pub fn new(
-        ctx: Ctx,
+        ctx: StoreContextMut<'ctx, HostData>,
         frame: &'func mut FuncFrame,
         cache: &'engine mut InstanceCache,
         instrs: Instructions<'engine>,
@@ -508,10 +505,7 @@ pub enum MaybeReturn {
     Continue,
 }
 
-impl<'engine, 'func, Ctx> Executor<'engine, 'func, Ctx>
-where
-    Ctx: AsContextMut,
-{
+impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
     fn visit_unreachable(&mut self) -> Result<(), Trap> {
         Err(TrapCode::Unreachable).map_err(Into::into)
     }

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -597,7 +597,10 @@ impl<'ctx, 'engine, 'func, HostData> Executor<'ctx, 'engine, 'func, HostData> {
         self.call_func(callee)
     }
 
-    fn visit_call_indirect(&mut self, signature_index: SignatureIdx) -> Result<CallOutcome, TrapCode> {
+    fn visit_call_indirect(
+        &mut self,
+        signature_index: SignatureIdx,
+    ) -> Result<CallOutcome, TrapCode> {
         let func_index: u32 = self.value_stack.pop_as();
         let table = self.default_table();
         let func = table

--- a/wasmi_v1/src/engine/executor.rs
+++ b/wasmi_v1/src/engine/executor.rs
@@ -12,7 +12,9 @@ use super::{
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
-    Func, StoreContextMut, AsContext,
+    AsContext,
+    Func,
+    StoreContextMut,
 };
 use core::cmp;
 use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedValue, WrapInto};

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -403,7 +403,7 @@ impl EngineInner {
         frame: &mut FuncFrame,
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
-        let insts = self.code_map.insts(frame.iref());
-        execute_frame(ctx, frame, cache, insts, &mut self.stack.values)
+        let instrs = self.code_map.insts(frame.iref());
+        execute_frame(ctx, &mut self.stack.values, instrs, cache, frame)
     }
 }

--- a/wasmi_v1/src/engine/mod.rs
+++ b/wasmi_v1/src/engine/mod.rs
@@ -286,8 +286,7 @@ impl EngineInner {
             FuncEntityInternal::Wasm(wasm_func) => {
                 let signature = wasm_func.signature();
                 let mut frame = self.stack.call_wasm_root(wasm_func, &self.code_map)?;
-                let instance = wasm_func.instance();
-                let mut cache = InstanceCache::from(instance);
+                let mut cache = InstanceCache::from(frame.instance());
                 self.execute_wasm_func(ctx.as_context_mut(), &mut frame, &mut cache)?;
                 signature
             }


### PR DESCRIPTION
Locally this displayed some slight improvements in some call intense workloads whereas the `global_bump` benchmarks locally showed slight regression. Let's see what our GitLab runners are having to say.

Generally though this PR is not an optimization PR but rather a cleanup of the executor.