### PR TITLE
CI: Add wasmtime overhead status to the report

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,7 @@ wasmtime-benchmark:
     - source ~/.profile
 
     # `wasmtime` Branch: `master`
+    - git fetch
     - git checkout master
     - git pull
     - git submodule update --init --recursive

--- a/scripts/ci/benchmarks-report.sh
+++ b/scripts/ci/benchmarks-report.sh
@@ -59,7 +59,7 @@ RESULT=$(for d in */; do
 
             WT_OVERHEAD=$(echo "($WASM_PR_TIME-$PR_TIME)/$PR_TIME*100" | bc -l | xargs printf "%.0f")
 
-            echo -n "<tr><td nowrap><tt>${d::-1}<\/td>"\
+            echo -n "<tr><td nowrap><tt>$(jq .full_id ${d}master/benchmark.json)<\/td>"\
                 "<td nowrap> $(format_time $MASTER_TIME)<\/td>" \
                 "<td nowrap> $(format_time $PR_TIME)<\/td>" \
                 "<td nowrap> $PERF_CHANGE $(echo $DIFF*100 | bc -l | xargs printf "%.2f%%")<\/td>" \

--- a/scripts/ci/benchmarks-report.sh
+++ b/scripts/ci/benchmarks-report.sh
@@ -30,6 +30,17 @@ function get_performance_change_status {
     fi
 }
 
+# Native vs wasmtime overhead status badges
+function wasmtime_overhead_status {
+    if [[ $1 -le 50 ]]
+      then echo ":green_circle: $1%"
+    elif [[ $1 -le 100 ]]
+      then echo ":yellow_circle: $1%"
+    else
+      echo ":red_circle: $1%"
+    fi
+}
+
 PR_COMMENTS_URL="https://api.github.com/repos/paritytech/wasmi/issues/${CI_COMMIT_BRANCH}/comments"
 
 pushd ./target/ci/criterion
@@ -46,13 +57,16 @@ RESULT=$(for d in */; do
             WASM_PERF_CHANGE=$(get_performance_change_status "$(grep -A 3 -e $(echo "${d::-1}" | tr "_" ".") ../wasmtime-pr)")
             WASM_DIFF=$(jq .mean.point_estimate ../wasmtime-criterion/${d}change/estimates.json)
 
-            echo -n "<tr><td><tt>${d::-1}<\/td>"\
-                "<td> $(format_time $MASTER_TIME)<\/td>" \
-                "<td> $(format_time $PR_TIME)<\/td>" \
-                "<td> $PERF_CHANGE $(echo $DIFF*100 | bc -l | xargs printf "%.2f") %<\/td>" \
-                "<td> $(format_time $WASM_MASTER_TIME)<\/td>" \
-                "<td> $(format_time $WASM_PR_TIME)<\/td>" \
-                "<td> $WASM_PERF_CHANGE $(echo $WASM_DIFF*100 | bc -l | xargs printf "%.2f") %<\/td><\/tr>"
+            WT_OVERHEAD=$(echo "($WASM_PR_TIME-$PR_TIME)/$PR_TIME*100" | bc -l | xargs printf "%.0f")
+
+            echo -n "<tr><td nowrap><tt>${d::-1}<\/td>"\
+                "<td nowrap> $(format_time $MASTER_TIME)<\/td>" \
+                "<td nowrap> $(format_time $PR_TIME)<\/td>" \
+                "<td nowrap> $PERF_CHANGE $(echo $DIFF*100 | bc -l | xargs printf "%.2f%%")<\/td>" \
+                "<td nowrap> $(format_time $WASM_MASTER_TIME)<\/td>" \
+                "<td nowrap> $(format_time $WASM_PR_TIME)<\/td>" \
+                "<td nowrap> $WASM_PERF_CHANGE $(echo $WASM_DIFF*100 | bc -l | xargs printf "%.2f%%")<\/td>" \
+                "<td nowrap> $(wasmtime_overhead_status $WT_OVERHEAD)<\/td><\/tr>"
         done)
 
 popd
@@ -85,10 +99,10 @@ curl -X ${REQUEST_TYPE} ${PR_COMMENTS_URL} \
 <table> \
 <thead> \
 <tr> \
-<th><\/th><th colspan=3>NATIVE<\/th><th colspan=3>WASMTIME<\/th> \
+<th><\/th><th colspan=3>NATIVE<\/th><th colspan=3>WASMTIME<\/th><th></th> \
 <\/tr> \
 <tr> \
-<th>BENCHMARK<\/th><th>MASTER<\/th><th>PR<\/th><th>DIFF<\/th><th>MASTER<\/th><th>PR<\/th><th>DIFF<\/th> \
+<th>BENCHMARK<\/th><th>MASTER<\/th><th>PR<\/th><th>DIFF<\/th><th>MASTER<\/th><th>PR<\/th><th>DIFF<\/th><th>WASMTIME OVERHEAD<\/th> \
 <\/tr> \
 <\/thead> \
 <tbody> \

--- a/scripts/ci/benchmarks-report.sh
+++ b/scripts/ci/benchmarks-report.sh
@@ -47,6 +47,8 @@ pushd ./target/ci/criterion
 
 # Format benchmarks details into a table
 RESULT=$(for d in */; do
+            BENCH_ID=$(jq .full_id ${d}master/benchmark.json | tr -d '"')
+
             MASTER_TIME=$(jq .slope.point_estimate ${d}master/estimates.json)
             PR_TIME=$(jq .slope.point_estimate ${d}new/estimates.json)
             PERF_CHANGE=$(get_performance_change_status "$(grep -A 3 -e $(echo "${d::-1}" | tr "_" ".") ../bench-pr)")
@@ -59,7 +61,7 @@ RESULT=$(for d in */; do
 
             WT_OVERHEAD=$(echo "($WASM_PR_TIME-$PR_TIME)/$PR_TIME*100" | bc -l | xargs printf "%.0f")
 
-            echo -n "<tr><td nowrap><tt>$(jq .full_id ${d}master/benchmark.json)<\/td>"\
+            echo -n "<tr><td nowrap><tt>$BENCH_ID<\/td>"\
                 "<td nowrap> $(format_time $MASTER_TIME)<\/td>" \
                 "<td nowrap> $(format_time $PR_TIME)<\/td>" \
                 "<td nowrap> $PERF_CHANGE $(echo $DIFF*100 | bc -l | xargs printf "%.2f%%")<\/td>" \

--- a/scripts/ci/benchmarks-report.sh
+++ b/scripts/ci/benchmarks-report.sh
@@ -9,11 +9,11 @@ set -o pipefail
 # Transform timing details into more readable format
 function format_time {
     if (( $(echo $1'<'1000 | bc -l) ))
-      then printf "%.2f ns" $1
+      then printf "%.2fns" $1
     elif (( $(echo $1'<'1000000 | bc -l) ))
-      then printf "%.2f µs" $(echo $1/1000 | bc -l )
+      then printf "%.2fµs" $(echo $1/1000 | bc -l )
     else
-      printf "%.2f ms" $(echo $1/1000000 | bc -l )
+      printf "%.2fms" $(echo $1/1000000 | bc -l )
     fi
 }
 


### PR DESCRIPTION
Addresses https://github.com/paritytech/wasmi/issues/486

PR adds column to the benchmarks report with details about wasmtime vs native overhead.