### PR TITLE
Optimize for common `drop_keep` cases in `wasmi` executor

### DIFF
--- a/crates/wasmi/src/engine/stack/values/vref.rs
+++ b/crates/wasmi/src/engine/stack/values/vref.rs
@@ -113,15 +113,18 @@ impl<'a> ValueStackRef<'a> {
         let keep = drop_keep.keep();
         if keep == 0 {
             // Bail out early when there are no values to keep.
-            self.stack_ptr -= drop;
-            return;
-        }
-        // Copy kept values over to their new place on the stack.
-        // Note: We cannot use `memcpy` since the slices may overlap.
-        let src = self.stack_ptr - keep;
-        let dst = self.stack_ptr - keep - drop;
-        for i in 0..keep {
-            *self.get_release_unchecked_mut(dst + i) = self.get_release_unchecked(src + i);
+        } else if keep == 1 {
+            // Bail out early when there is only one value to copy.
+            *self.get_release_unchecked_mut(self.stack_ptr - 1 - drop) =
+                self.get_release_unchecked(self.stack_ptr - 1);
+        } else {
+            // Copy kept values over to their new place on the stack.
+            // Note: We cannot use `memcpy` since the slices may overlap.
+            let src = self.stack_ptr - keep;
+            let dst = self.stack_ptr - keep - drop;
+            for i in 0..keep {
+                *self.get_release_unchecked_mut(dst + i) = self.get_release_unchecked(src + i);
+            }
         }
         self.stack_ptr -= drop;
     }

--- a/crates/wasmi/src/engine/stack/values/vref.rs
+++ b/crates/wasmi/src/engine/stack/values/vref.rs
@@ -111,6 +111,11 @@ impl<'a> ValueStackRef<'a> {
             return;
         }
         let keep = drop_keep.keep();
+        if keep == 0 {
+            // Bail out early when there are no values to keep.
+            self.stack_ptr -= drop;
+            return;
+        }
         // Copy kept values over to their new place on the stack.
         // Note: We cannot use `memcpy` since the slices may overlap.
         let src = self.stack_ptr - keep;


### PR DESCRIPTION
This is a result of an observation that we could speed-up execution of branch and return instructions that keep no values or just a single value upon jump. Especially in the Wasm MVP those two cases are the common ones.

This is take 2 after the first experiment yielded really bad results: https://github.com/paritytech/wasmi/pull/492