### PR TITLE
CI: cleanup wasm32 target dir before pr benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,7 @@ wasmtime-benchmark:
     - wasmtime run --dir=. ../../target/ci/benches-master.wasm -- --bench --save-baseline master-wasm | tee ../../target/ci/wasmtime-master
     - popd
     - git submodule deinit --all -f
+    - rm -rf target/wasm32-wasi
 
     # `wasmtime` Branch: `pr`
     - git checkout $CI_COMMIT_SHA


### PR DESCRIPTION
Cleanup `target/wasm32-wasi` dir before benchmarking PR branch to prevent artifact copying errors.