### PR TITLE
Compare benchmarks between `rustc` stable and nightly channels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ criterion-benchmark:
     - git submodule update --init --recursive
     - mkdir -p ./target/ci
     - pushd ./crates/wasmi/
-    - cargo bench --bench benches -- --noplot --save-baseline master | tee ../../target/ci/bench-master
+    - cargo +stable bench --bench benches -- --noplot --save-baseline master | tee ../../target/ci/bench-master
     - popd
     - git submodule deinit --all -f
 
@@ -51,7 +51,7 @@ criterion-benchmark:
     - git checkout $CI_COMMIT_SHA
     - git submodule update --init --recursive
     - pushd ./crates/wasmi/
-    - cargo bench --bench benches -- --noplot --baseline master | tee ../../target/ci/bench-pr
+    - cargo +nightly bench --bench benches -- --noplot --baseline master | tee ../../target/ci/bench-pr
     - popd
 
     # Save benchmark report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,7 @@ wasmtime-benchmark:
     - git pull
     - git submodule update --init --recursive
     - mkdir -p ./target/ci
-    - cargo wasi build --profile bench --bench benches --verbose
+    - cargo +stable wasi build --profile bench --bench benches --verbose
     - cp `ls -t target/wasm32-wasi/release/deps/*wasi.wasm` target/ci/benches-master.wasm
     - pushd ./crates/wasmi/
     - wasmtime run --dir=. ../../target/ci/benches-master.wasm -- --bench --save-baseline master-wasm | tee ../../target/ci/wasmtime-master
@@ -92,7 +92,7 @@ wasmtime-benchmark:
     - git checkout $CI_COMMIT_SHA
     - git submodule update --init --recursive
     - mkdir -p ./target/ci
-    - cargo wasi build --profile bench --bench benches --verbose
+    - cargo +beta wasi build --profile bench --bench benches --verbose
     - cp `ls -t target/wasm32-wasi/release/deps/*wasi.wasm` target/ci/benches-pr.wasm
     - pushd ./crates/wasmi/
     - wasmtime run --dir=. ../../target/ci/benches-pr.wasm -- --bench --baseline master-wasm | tee ../../target/ci/wasmtime-pr

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ wasmtime-benchmark:
     - git checkout $CI_COMMIT_SHA
     - git submodule update --init --recursive
     - mkdir -p ./target/ci
-    - cargo +beta wasi build --profile bench --bench benches --verbose
+    - cargo +nightly wasi build --profile bench --bench benches --verbose
     - cp `ls -t target/wasm32-wasi/release/deps/*wasi.wasm` target/ci/benches-pr.wasm
     - pushd ./crates/wasmi/
     - wasmtime run --dir=. ../../target/ci/benches-pr.wasm -- --bench --baseline master-wasm | tee ../../target/ci/wasmtime-pr


### PR DESCRIPTION
I got suspicious after I saw huge regressions in the ballpark of 30-80% on my local development platform so I just wanted to make sure that it is not my local environment by running those same benchmarks on the CI runners.

**edit:** Those regressions are very real ...