### PR TITLE
CI: retry CI twice on every type of failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,10 +7,6 @@ stages:
 default:
   retry:
     max: 2
-    when:
-      - runner_system_failure
-      - unknown_failure
-      - api_failure
 
 .docker-env:                       &docker-env
   image:                           "paritytech/ci-linux:staging"


### PR DESCRIPTION
Sometimes CI fails due to ad hoc network issues like here https://gitlab.parity.io/parity/mirrors/wasmi/-/jobs/1940274 which can be fixed just by restarting job. And we have such setting in place - [`retry`](https://docs.gitlab.com/ee/ci/yaml/#retry) block, but for some reason GitLab fails to match above mentioned events to `when` rules `runner_system_failure`, `unknown_failure`, `api_failure`

This PR introduces functionality to make 2 additional attempts in case if CI job fails. Use default `when: always` implicitly.