### PR TITLE
Fix `IntoFunc` API

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -263,7 +263,7 @@ fn bench_execute_trunc_f2i(c: &mut Criterion) {
             .get_export(&store, "trunc_f2i")
             .and_then(v1::Extern::into_func)
             .unwrap();
-        let count_until = count_until.typed::<(i32, F32, F64), (), _>(&store).unwrap();
+        let count_until = count_until.typed::<(i32, F32, F64), ()>(&store).unwrap();
 
         b.iter(|| {
             count_until

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -102,6 +102,7 @@ where
 {
     type Ok = T1;
 
+    #[inline]
     fn into_fallible(self) -> Result<Self::Ok, Trap> {
         Ok(self)
     }
@@ -113,6 +114,7 @@ where
 {
     type Ok = T1;
 
+    #[inline]
     fn into_fallible(self) -> Result<<Self as WasmResults>::Ok, Trap> {
         self
     }
@@ -128,6 +130,7 @@ macro_rules! impl_wasm_return_type {
         {
             type Ok = ($($tuple,)*);
 
+            #[inline]
             fn into_fallible(self) -> Result<Self::Ok, Trap> {
                 Ok(self)
             }
@@ -141,6 +144,7 @@ macro_rules! impl_wasm_return_type {
         {
             type Ok = ($($tuple,)*);
 
+            #[inline]
             fn into_fallible(self) -> Result<<Self as WasmResults>::Ok, Trap> {
                 self
             }
@@ -159,6 +163,7 @@ macro_rules! impl_wasm_type {
     ( $( type $rust_type:ty = $wasmi_type:ident );* $(;)? ) => {
         $(
             impl WasmType for $rust_type {
+                #[inline]
                 fn value_type() -> ValueType {
                     ValueType::$wasmi_type
                 }
@@ -230,10 +235,12 @@ where
     type Values = [Value; 1];
     type ValuesIter = array::IntoIter<Value, 1>;
 
+    #[inline]
     fn value_types() -> Self::Types {
         [<T1 as WasmType>::value_type()]
     }
 
+    #[inline]
     fn values(self) -> Self::Values {
         [<T1 as Into<Value>>::into(self)]
     }

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -107,6 +107,17 @@ where
     }
 }
 
+impl<T1> WasmResults for Result<T1, Trap>
+where
+    T1: WasmType,
+{
+    type Ok = T1;
+
+    fn into_fallible(self) -> Result<<Self as WasmResults>::Ok, Trap> {
+        self
+    }
+}
+
 macro_rules! impl_wasm_return_type {
     ( $n:literal $( $tuple:ident )* ) => {
         impl<$($tuple),*> WasmResults for ($($tuple,)*)

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -6,7 +6,7 @@ mod typed_func;
 pub use self::{
     caller::Caller,
     error::FuncError,
-    into_func::IntoFunc,
+    into_func::{IntoFunc, WasmRet, WasmType},
     typed_func::{TypedFunc, WasmParams, WasmResults},
 };
 use super::{

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -324,7 +324,10 @@ impl Func {
     ///
     /// If the function signature of `self` does not match `Params` and `Results`
     /// as parameter types and result types respectively.
-    pub fn typed<Params, Results>(&self, ctx: impl AsContext) -> Result<TypedFunc<Params, Results>, Error>
+    pub fn typed<Params, Results>(
+        &self,
+        ctx: impl AsContext,
+    ) -> Result<TypedFunc<Params, Results>, Error>
     where
         Params: WasmParams,
         Results: WasmResults,

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -324,11 +324,10 @@ impl Func {
     ///
     /// If the function signature of `self` does not match `Params` and `Results`
     /// as parameter types and result types respectively.
-    pub fn typed<Params, Results, S>(&self, ctx: S) -> Result<TypedFunc<Params, Results>, Error>
+    pub fn typed<Params, Results>(&self, ctx: impl AsContext) -> Result<TypedFunc<Params, Results>, Error>
     where
         Params: WasmParams,
         Results: WasmResults,
-        S: AsContext,
     {
         TypedFunc::new(ctx, *self)
     }

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -125,7 +125,7 @@ pub use self::{
     engine::{Config, Engine, StackLimits},
     error::Error,
     external::Extern,
-    func::{Caller, Func, TypedFunc, WasmParams, WasmResults},
+    func::{Caller, Func, IntoFunc, TypedFunc, WasmParams, WasmResults, WasmRet, WasmType},
     func_type::FuncType,
     global::{Global, GlobalType, Mutability},
     instance::{ExportsIter, Instance},

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -60,7 +60,7 @@
 //!         .get_export(&store, "hello")
 //!         .and_then(Extern::into_func)
 //!         .ok_or_else(|| anyhow!("could not find function \"hello\""))?
-//!         .typed::<(), (), _>(&mut store)?;
+//!         .typed::<(), ()>(&mut store)?;
 //!
 //!     // And finally we can call the wasm!
 //!     hello.call(&mut store, ())?;

--- a/crates/wasmi/tests/e2e/v1/func.rs
+++ b/crates/wasmi/tests/e2e/v1/func.rs
@@ -44,7 +44,7 @@ fn dynamic_add2_works() {
 #[test]
 fn static_add2_works() {
     let (mut store, add2) = setup_add2();
-    let typed_add2 = add2.typed::<(i32, i32), i32, _>(&mut store).unwrap();
+    let typed_add2 = add2.typed::<(i32, i32), i32>(&mut store).unwrap();
     let result = typed_add2.call(&mut store, (1, 2)).unwrap();
     assert_eq!(result, 3);
 }
@@ -75,7 +75,7 @@ fn dynamic_add3_works() {
 #[test]
 fn static_add3_works() {
     let (mut store, add3) = setup_add3();
-    let typed_add3 = add3.typed::<(i32, i32, i32), i32, _>(&mut store).unwrap();
+    let typed_add3 = add3.typed::<(i32, i32, i32), i32>(&mut store).unwrap();
     let result = typed_add3.call(&mut store, (1, 2, 3)).unwrap();
     assert_eq!(result, 6);
 }
@@ -103,7 +103,7 @@ fn dynamic_duplicate_works() {
 #[test]
 fn static_duplicate_works() {
     let (mut store, duplicate) = setup_duplicate();
-    let typed_duplicate = duplicate.typed::<i32, (i32, i32), _>(&mut store).unwrap();
+    let typed_duplicate = duplicate.typed::<i32, (i32, i32)>(&mut store).unwrap();
     let result = typed_duplicate.call(&mut store, 10).unwrap();
     assert_eq!(result, (10, 10));
 }
@@ -190,7 +190,7 @@ fn dynamic_many_params_works() {
 #[test]
 fn static_many_params_works() {
     let (mut store, func) = setup_many_params();
-    let typed_func = func.typed::<I32x16, (), _>(&mut store).unwrap();
+    let typed_func = func.typed::<I32x16, ()>(&mut store).unwrap();
     let inputs = ascending_tuple();
     let result = typed_func.call(&mut store, inputs);
     assert_matches!(result, Ok(()));
@@ -220,7 +220,7 @@ fn dynamic_many_results_works() {
 #[test]
 fn static_many_results_works() {
     let (mut store, func) = setup_many_results();
-    let typed_func = func.typed::<(), I32x16, _>(&mut store).unwrap();
+    let typed_func = func.typed::<(), I32x16>(&mut store).unwrap();
     let result = typed_func.call(&mut store, ()).unwrap();
     let expected = ascending_tuple();
     assert_eq_tuple!(result, expected; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -284,7 +284,7 @@ fn dynamic_many_params_many_results_works() {
 #[test]
 fn static_many_params_many_results_works() {
     let (mut store, func) = setup_many_params_many_results();
-    let typed_func = func.typed::<I32x16, I32x16, _>(&mut store).unwrap();
+    let typed_func = func.typed::<I32x16, I32x16>(&mut store).unwrap();
     let inputs = ascending_tuple();
     let result = typed_func.call(&mut store, inputs).unwrap();
     assert_eq_tuple!(result, inputs; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -320,7 +320,7 @@ fn static_many_types_works() {
         |v0: i32, v1: u32, v2: i64, v3: u64, v4: F32, v5: F64| (v0, v1, v2, v3, v4, v5),
     );
     let typed_func = func
-        .typed::<(i32, u32, i64, u64, F32, F64), (i32, u32, i64, u64, F32, F64), _>(&mut store)
+        .typed::<(i32, u32, i64, u64, F32, F64), (i32, u32, i64, u64, F32, F64)>(&mut store)
         .unwrap();
     let inputs = (0, 1, 2, 3, 4.0.into(), 5.0.into());
     let result = typed_func.call(&mut store, inputs).unwrap();
@@ -390,32 +390,32 @@ fn static_type_check_works() {
     let identity = Func::wrap(&mut store, |value: i32| value);
     // Case: Too few inputs given to function.
     assert_matches!(
-        identity.typed::<(), i32, _>(&mut store),
+        identity.typed::<(), i32>(&mut store),
         Err(Error::Func(FuncError::MismatchingParameters { .. }))
     );
     // Case: Too many inputs given to function.
     assert_matches!(
-        identity.typed::<(i32, i32), i32, _>(&mut store),
+        identity.typed::<(i32, i32), i32>(&mut store),
         Err(Error::Func(FuncError::MismatchingParameters { .. }))
     );
     // Case: Too few results given to function.
     assert_matches!(
-        identity.typed::<i32, (), _>(&mut store),
+        identity.typed::<i32, ()>(&mut store),
         Err(Error::Func(FuncError::MismatchingResults { .. }))
     );
     // Case: Too many results given to function.
     assert_matches!(
-        identity.typed::<i32, (i32, i32), _>(&mut store),
+        identity.typed::<i32, (i32, i32)>(&mut store),
         Err(Error::Func(FuncError::MismatchingResults { .. }))
     );
     // Case: Mismatching type given as input to function.
     assert_matches!(
-        identity.typed::<i64, i32, _>(&mut store),
+        identity.typed::<i64, i32>(&mut store),
         Err(Error::Func(FuncError::MismatchingParameters { .. }))
     );
     // Case: Mismatching type given as output of function.
     assert_matches!(
-        identity.typed::<i32, i64, _>(&mut store),
+        identity.typed::<i32, i64>(&mut store),
         Err(Error::Func(FuncError::MismatchingResults { .. }))
     );
 }


### PR DESCRIPTION
- Makes `IntoFunc`, `WasmType` and `WasmRet` public.
- Removes generic `ctx: S` parameter from `Func::typed` constructor.
- Adds missing `Result<T, Trap>: WasmRet` impl.
    - Also adds unit tests to assert that those impls exist.
- Added `#[inline]` to some trivial method impls.