### PR TITLE
CI: add `miri` check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,6 +124,23 @@ jobs:
           command: audit
           args: ''
 
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+      - name: Clippy (default features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --lib --workspace
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to use of `unsafe` Rust it is useful to have `miri` testing for the `wasmi` workspace.
Unfortunately this does not (yet) test the extensive Wasm spec test suite but runs only the library unit tests of the entire workspace.
We might be required to either refactor how the Wasm spec test suite works or add some execution unit tests.