### PR TITLE
Fix potential UB

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,11 +135,16 @@ jobs:
           toolchain: nightly
           override: true
           components: miri
-      - name: Clippy (default features)
+      - name: Clippy (--lib)
         uses: actions-rs/cargo@v1
         with:
           command: miri
           args: test --lib --workspace
+      - name: Clippy (--doc)
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --doc --workspace
 
   clippy:
     name: Clippy

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -101,7 +101,7 @@ impl CodeMap {
     /// Returns an [`InstructionPtr`] to the instruction at [`InstructionsRef`].
     #[inline]
     pub fn instr_ptr(&self, iref: InstructionsRef) -> InstructionPtr {
-        InstructionPtr::new(&self.insts[iref.start])
+        InstructionPtr::new(&self.insts[iref.start..])
     }
 
     /// Returns the [`FuncHeader`] of the [`FuncBody`].
@@ -142,8 +142,8 @@ pub struct InstructionPtr {
 impl InstructionPtr {
     /// Creates a new [`InstructionPtr`] for `instr`.
     #[inline]
-    pub fn new(instr: &Instruction) -> Self {
-        Self { ptr: instr }
+    pub fn new(instr: &[Instruction]) -> Self {
+        Self { ptr: instr.as_ptr() }
     }
 
     /// Offset the [`InstructionPtr`] by the given value.

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -143,7 +143,9 @@ impl InstructionPtr {
     /// Creates a new [`InstructionPtr`] for `instr`.
     #[inline]
     pub fn new(instr: &[Instruction]) -> Self {
-        Self { ptr: instr.as_ptr() }
+        Self {
+            ptr: instr.as_ptr(),
+        }
     }
 
     /// Offset the [`InstructionPtr`] by the given value.

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -101,7 +101,7 @@ impl CodeMap {
     /// Returns an [`InstructionPtr`] to the instruction at [`InstructionsRef`].
     #[inline]
     pub fn instr_ptr(&self, iref: InstructionsRef) -> InstructionPtr {
-        InstructionPtr::new(&self.insts[iref.start..])
+        InstructionPtr::new(self.insts[iref.start..].as_ptr())
     }
 
     /// Returns the [`FuncHeader`] of the [`FuncBody`].
@@ -142,10 +142,8 @@ pub struct InstructionPtr {
 impl InstructionPtr {
     /// Creates a new [`InstructionPtr`] for `instr`.
     #[inline]
-    pub fn new(instr: &[Instruction]) -> Self {
-        Self {
-            ptr: instr.as_ptr(),
-        }
+    pub fn new(ptr: *const Instruction) -> Self {
+        Self { ptr }
     }
 
     /// Offset the [`InstructionPtr`] by the given value.

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -2,7 +2,6 @@
 
 use super::Instruction;
 use alloc::vec::Vec;
-use core::ptr::NonNull;
 use wasmi_arena::Index;
 
 /// A reference to a Wasm function body stored in the [`CodeMap`].
@@ -137,15 +136,14 @@ impl CodeMap {
 #[derive(Debug, Copy, Clone)]
 pub struct InstructionPtr {
     /// The pointer to the instruction.
-    ptr: NonNull<Instruction>,
+    ptr: *const Instruction,
 }
 
 impl InstructionPtr {
     /// Creates a new [`InstructionPtr`] for `instr`.
+    #[inline]
     pub fn new(instr: &Instruction) -> Self {
-        Self {
-            ptr: NonNull::from(instr),
-        }
+        Self { ptr: instr }
     }
 
     /// Offset the [`InstructionPtr`] by the given value.
@@ -157,8 +155,7 @@ impl InstructionPtr {
     /// bounds of the instructions of the same compiled Wasm function.
     #[inline(always)]
     pub unsafe fn offset(&mut self, by: isize) {
-        let new_ptr = &*self.ptr.as_ptr().offset(by);
-        self.ptr = NonNull::from(new_ptr);
+        self.ptr = self.ptr.offset(by);
     }
 
     /// Returns a shared reference to the currently pointed at [`Instruction`].
@@ -170,6 +167,6 @@ impl InstructionPtr {
     /// the boundaries of its associated compiled Wasm function.
     #[inline(always)]
     pub unsafe fn get(&self) -> &Instruction {
-        self.ptr.as_ref()
+        &*self.ptr
     }
 }


### PR DESCRIPTION
- As reported by `miri` when testing for `--doc` tests.
- We cannot use `NonNull` there since `NonNull` is missing the respective `offset` method, yet, as discussed and requested here: https://github.com/rust-lang/rust/issues/72429
- This PR also adds a `miri --doc` CI test run since that is how we discovered this potential UB.