### PR TITLE
Refactor, cleanup and optimize Wasm module instantiation

### DIFF
--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -36,9 +36,9 @@ pub enum GlobalError {
     },
     /// Occurs when a global type does not satisfy the constraints of another.
     UnsatisfyingGlobalType {
-        /// The unsatisfying [`TableType`].
+        /// The unsatisfying [`GlobalType`].
         unsatisfying: GlobalType,
-        /// The required [`TableType`].
+        /// The required [`GlobalType`].
         required: GlobalType,
     },
 }
@@ -107,12 +107,12 @@ impl GlobalType {
         self.mutability
     }
 
-    /// Checks if `self` satisfies the given `MemoryType`.
+    /// Checks if `self` satisfies the given `GlobalType`.
     ///
     /// # Errors
     ///
-    /// - If the initial limits of the `required` [`MemoryType`] are greater than `self`.
-    /// - If the maximum limits of the `required` [`MemoryType`] are greater than `self`.
+    /// - If the initial limits of the `required` [`GlobalType`] are greater than `self`.
+    /// - If the maximum limits of the `required` [`GlobalType`] are greater than `self`.
     pub(crate) fn satisfies(&self, required: &GlobalType) -> Result<(), GlobalError> {
         if self != required {
             return Err(GlobalError::UnsatisfyingGlobalType {

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -34,6 +34,13 @@ pub enum GlobalError {
         /// The type of the new value that mismatches the type of the global variable.
         encountered: ValueType,
     },
+    /// Occurs when a global type does not satisfy the constraints of another.
+    UnsatisfyingGlobalType {
+        /// The unsatisfying [`TableType`].
+        unsatisfying: GlobalType,
+        /// The required [`TableType`].
+        required: GlobalType,
+    },
 }
 
 impl Display for GlobalError {
@@ -48,6 +55,16 @@ impl Display for GlobalError {
                     f,
                     "type mismatch upon writing global variable. expected {} but encountered {}.",
                     expected, encountered,
+                )
+            }
+            Self::UnsatisfyingGlobalType {
+                unsatisfying,
+                required,
+            } => {
+                write!(
+                    f,
+                    "global type {:?} does not satisfy requirements of {:?}",
+                    unsatisfying, required,
                 )
             }
         }
@@ -88,6 +105,22 @@ impl GlobalType {
     /// Returns the [`Mutability`] of the global variable.
     pub fn mutability(&self) -> Mutability {
         self.mutability
+    }
+
+    /// Checks if `self` satisfies the given `MemoryType`.
+    ///
+    /// # Errors
+    ///
+    /// - If the initial limits of the `required` [`MemoryType`] are greater than `self`.
+    /// - If the maximum limits of the `required` [`MemoryType`] are greater than `self`.
+    pub(crate) fn satisfies(&self, required: &GlobalType) -> Result<(), GlobalError> {
+        if self != required {
+            return Err(GlobalError::UnsatisfyingGlobalType {
+                unsatisfying: *self,
+                required: *required,
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -11,7 +11,6 @@ use super::{
 };
 use alloc::{
     collections::{btree_map, BTreeMap},
-    string::{String, ToString},
     vec::Vec,
 };
 use core::iter::FusedIterator;
@@ -43,7 +42,7 @@ pub struct InstanceEntity {
     funcs: Box<[Func]>,
     memories: Box<[Memory]>,
     globals: Box<[Global]>,
-    exports: BTreeMap<String, Extern>,
+    exports: BTreeMap<Box<str>, Extern>,
 }
 
 impl InstanceEntity {
@@ -111,18 +110,18 @@ impl InstanceEntity {
 /// An iterator over the [`Extern`] declarations of an [`Instance`].
 #[derive(Debug)]
 pub struct ExportsIter<'a> {
-    iter: btree_map::Iter<'a, String, Extern>,
+    iter: btree_map::Iter<'a, Box<str>, Extern>,
 }
 
 impl<'a> ExportsIter<'a> {
     /// Creates a new [`ExportsIter`].
-    fn new(iter: btree_map::Iter<'a, String, Extern>) -> Self {
+    fn new(iter: btree_map::Iter<'a, Box<str>, Extern>) -> Self {
         Self { iter }
     }
 
     /// Prepares an item to match the expected iterator `Item` signature.
-    fn convert_item((name, export): (&'a String, &'a Extern)) -> (&'a str, &'a Extern) {
-        (name.as_str(), export)
+    fn convert_item((name, export): (&'a Box<str>, &'a Extern)) -> (&'a str, &'a Extern) {
+        (&*name, export)
     }
 }
 
@@ -156,7 +155,7 @@ pub struct InstanceEntityBuilder {
     funcs: Vec<Func>,
     memories: Vec<Memory>,
     globals: Vec<Global>,
-    exports: BTreeMap<String, Extern>,
+    exports: BTreeMap<Box<str>, Extern>,
 }
 
 impl InstanceEntityBuilder {
@@ -232,7 +231,7 @@ impl InstanceEntityBuilder {
                 new_value, name, old_value,
             )
         }
-        self.exports.insert(name.to_string(), new_value);
+        self.exports.insert(name.into(), new_value);
     }
 
     /// Finishes constructing the [`InstanceEntity`].

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -12,6 +12,7 @@ use super::{
 };
 use crate::module::{FuncIdx, ModuleImportType};
 use alloc::{
+    boxed::Box,
     collections::{btree_map, BTreeMap},
     sync::Arc,
     vec::Vec,

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -10,6 +10,7 @@ use super::{
     Stored,
     Table,
 };
+use alloc::sync::Arc;
 use crate::module::{FuncIdx, ModuleImportType};
 use alloc::{
     collections::{btree_map, BTreeMap},
@@ -39,7 +40,7 @@ impl Index for InstanceIdx {
 #[derive(Debug)]
 pub struct InstanceEntity {
     initialized: bool,
-    func_types: Box<[DedupFuncType]>,
+    func_types: Arc<[DedupFuncType]>,
     tables: Box<[Table]>,
     funcs: Box<[Func]>,
     memories: Box<[Memory]>,
@@ -52,7 +53,7 @@ impl InstanceEntity {
     pub(crate) fn uninitialized() -> InstanceEntity {
         Self {
             initialized: false,
-            func_types: [].into(),
+            func_types: Arc::new([]),
             tables: [].into(),
             funcs: [].into(),
             memories: [].into(),
@@ -156,7 +157,7 @@ impl FusedIterator for ExportsIter<'_> {}
 /// A module instance entity builder.
 #[derive(Debug)]
 pub struct InstanceEntityBuilder {
-    func_types: Vec<DedupFuncType>,
+    func_types: Arc<[DedupFuncType]>,
     tables: Vec<Table>,
     funcs: Vec<Func>,
     memories: Vec<Memory>,
@@ -189,7 +190,7 @@ impl InstanceEntityBuilder {
             }
         }
         Self {
-            func_types: Vec::new(),
+            func_types: Arc::new([]),
             tables: Vec::with_capacity(len_tables),
             funcs: Vec::with_capacity(len_funcs),
             memories: Vec::with_capacity(len_memories),
@@ -290,8 +291,8 @@ impl InstanceEntityBuilder {
     /// under construction.
     ///
     /// [`FuncType`]: [`crate::FuncType`]
-    pub fn push_func_type(&mut self, func_type: DedupFuncType) {
-        self.func_types.push(func_type);
+    pub fn set_func_types(&mut self, func_types: &Arc<[DedupFuncType]>) {
+        self.func_types = func_types.clone();
     }
 
     /// Pushes a new [`Extern`] under the given `name` to the [`InstanceEntity`] under construction.

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -10,10 +10,10 @@ use super::{
     Stored,
     Table,
 };
-use alloc::sync::Arc;
 use crate::module::{FuncIdx, ModuleImportType};
 use alloc::{
     collections::{btree_map, BTreeMap},
+    sync::Arc,
     vec::Vec,
 };
 use core::iter::FusedIterator;

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -9,6 +9,7 @@ use super::{
     Stored,
     Table,
 };
+use crate::module::FuncIdx;
 use alloc::{
     collections::{btree_map, BTreeMap},
     vec::Vec,
@@ -159,12 +160,30 @@ pub struct InstanceEntityBuilder {
     funcs: Vec<Func>,
     memories: Vec<Memory>,
     globals: Vec<Global>,
+    start_fn: Option<FuncIdx>,
     exports: BTreeMap<Box<str>, Extern>,
 }
 
 impl InstanceEntityBuilder {
-    /// Returns the linear memory at the `index` if any.
-    pub(crate) fn get_memory(&self, index: u32) -> Memory {
+    /// Sets the start function of the built instance.
+    ///
+    /// # Panics
+    ///
+    /// If the start function has already been set.
+    pub fn set_start(&mut self, start_fn: FuncIdx) {
+        match &mut self.start_fn {
+            Some(_) => panic!("already set start function"),
+            None => {
+                self.start_fn = Some(start_fn);
+            }
+        }
+    }
+
+    /// Returns the optional start function index.
+    pub fn get_start(&self) -> Option<FuncIdx> {
+        self.start_fn
+    }
+
         self.memories
             .get(index as usize)
             .copied()

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -189,12 +189,17 @@ impl InstanceEntityBuilder {
                 }
             }
         }
+        fn vec_with_capacity_exact<T>(capacity: usize) -> Vec<T> {
+            let mut v = Vec::new();
+            v.reserve_exact(capacity);
+            v
+        }
         Self {
             func_types: Arc::new([]),
-            tables: Vec::with_capacity(len_tables),
-            funcs: Vec::with_capacity(len_funcs),
-            memories: Vec::with_capacity(len_memories),
-            globals: Vec::with_capacity(len_globals),
+            tables: vec_with_capacity_exact(len_tables),
+            funcs: vec_with_capacity_exact(len_funcs),
+            memories: vec_with_capacity_exact(len_memories),
+            globals: vec_with_capacity_exact(len_globals),
             start_fn: None,
             exports: BTreeMap::default(),
         }

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -128,6 +128,10 @@ impl<'a> ExportsIter<'a> {
 impl<'a> Iterator for ExportsIter<'a> {
     type Item = (&'a str, &'a Extern);
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(Self::convert_item)
     }

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -184,30 +184,48 @@ impl InstanceEntityBuilder {
         self.start_fn
     }
 
+    /// Returns the linear memory at the `index`.
+    ///
+    /// # Panics
+    ///
+    /// If there is no linear memory at the given `index.
+    pub fn get_memory(&self, index: u32) -> Memory {
         self.memories
             .get(index as usize)
             .copied()
             .unwrap_or_else(|| panic!("missing `Memory` at index: {index}"))
     }
 
-    /// Returns the table at the `index` if any.
-    pub(crate) fn get_table(&self, index: u32) -> Table {
+    /// Returns the table at the `index`.
+    ///
+    /// # Panics
+    ///
+    /// If there is no table at the given `index.
+    pub fn get_table(&self, index: u32) -> Table {
         self.tables
             .get(index as usize)
             .copied()
             .unwrap_or_else(|| panic!("missing `Table` at index: {index}"))
     }
 
-    /// Returns the global variable at the `index` if any.
-    pub(crate) fn get_global(&self, index: u32) -> Global {
+    /// Returns the global variable at the `index`.
+    ///
+    /// # Panics
+    ///
+    /// If there is no global variable at the given `index.
+    pub fn get_global(&self, index: u32) -> Global {
         self.globals
             .get(index as usize)
             .copied()
             .unwrap_or_else(|| panic!("missing `Global` at index: {index}"))
     }
 
-    /// Returns the function at the `index` if any.
-    pub(crate) fn get_func(&self, index: u32) -> Func {
+    /// Returns the function at the `index`.
+    ///
+    /// # Panics
+    ///
+    /// If there is no function at the given `index.
+    pub fn get_func(&self, index: u32) -> Func {
         self.funcs
             .get(index as usize)
             .copied()

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -124,8 +124,9 @@ impl<'a> ExportsIter<'a> {
     }
 
     /// Prepares an item to match the expected iterator `Item` signature.
+    #[allow(clippy::borrowed_box)]
     fn convert_item((name, export): (&'a Box<str>, &'a Extern)) -> (&'a str, &'a Extern) {
-        (&*name, export)
+        (&**name, export)
     }
 }
 
@@ -170,6 +171,11 @@ pub struct InstanceEntityBuilder {
 impl InstanceEntityBuilder {
     /// Creates a new [`InstanceEntityBuilder`] optimized for the [`Module`].
     pub fn new(module: &Module) -> Self {
+        fn vec_with_capacity_exact<T>(capacity: usize) -> Vec<T> {
+            let mut v = Vec::new();
+            v.reserve_exact(capacity);
+            v
+        }
         let mut len_funcs = module.len_funcs();
         let mut len_globals = module.len_globals();
         let mut len_tables = module.len_tables();
@@ -189,11 +195,6 @@ impl InstanceEntityBuilder {
                     len_globals += 1;
                 }
             }
-        }
-        fn vec_with_capacity_exact<T>(capacity: usize) -> Vec<T> {
-            let mut v = Vec::new();
-            v.reserve_exact(capacity);
-            v
         }
         Self {
             func_types: Arc::new([]),
@@ -320,7 +321,7 @@ impl InstanceEntityBuilder {
     pub fn finish(self) -> InstanceEntity {
         InstanceEntity {
             initialized: true,
-            func_types: self.func_types.into(),
+            func_types: self.func_types,
             tables: self.tables.into(),
             funcs: self.funcs.into(),
             memories: self.memories.into(),

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -352,10 +352,10 @@ impl<T> Linker<T> {
     ///
     /// - If the linker does not define imports of the instantiated [`Module`].
     /// - If any imported item does not satisfy its type requirements.
-    pub fn instantiate<'a>(
+    pub fn instantiate(
         &self,
         mut context: impl AsContextMut,
-        module: &'a Module,
+        module: &Module,
     ) -> Result<InstancePre, Error> {
         let externals = module
             .imports()

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -356,7 +356,7 @@ impl<T> Linker<T> {
         &self,
         mut context: impl AsContextMut,
         module: &'a Module,
-    ) -> Result<InstancePre<'a>, Error> {
+    ) -> Result<InstancePre, Error> {
         let externals = module
             .imports()
             .map(|import| self.process_import(&mut context, import))

--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -2,8 +2,8 @@ use super::ModuleImportType;
 use crate::{
     engine::DedupFuncType,
     errors::{MemoryError, TableError},
+    global::GlobalError,
     Extern,
-    GlobalType,
     Table,
 };
 use core::{fmt, fmt::Display};
@@ -33,13 +33,8 @@ pub enum InstantiationError {
     Table(TableError),
     /// Occurs when an imported memory does not satisfy the required memory type.
     Memory(MemoryError),
-    /// Caused when a global variable has a mismatching global variable type and mutability.
-    GlobalTypeMismatch {
-        /// The expected global type for the global variable import.
-        expected: GlobalType,
-        /// The actual global type found for the global variable import.
-        actual: GlobalType,
-    },
+    /// Occurs when an imported global variable does not satisfy the required global type.
+    Global(GlobalError),
     /// Caused when an element segment does not fit into the specified table instance.
     ElementSegmentDoesNotFit {
         /// The table of the element segment.
@@ -78,11 +73,6 @@ impl Display for InstantiationError {
                     expected, actual
                 )
             }
-            Self::GlobalTypeMismatch { expected, actual } => write!(
-                f,
-                "expected {:?} global type but found {:?} value type",
-                expected, actual,
-            ),
             Self::ElementSegmentDoesNotFit {
                 table,
                 offset,
@@ -97,6 +87,7 @@ impl Display for InstantiationError {
             }
             Self::Table(error) => Display::fmt(error, f),
             Self::Memory(error) => Display::fmt(error, f),
+            Self::Global(error) => Display::fmt(error, f),
         }
     }
 }
@@ -110,5 +101,11 @@ impl From<TableError> for InstantiationError {
 impl From<MemoryError> for InstantiationError {
     fn from(error: MemoryError) -> Self {
         Self::Memory(error)
+    }
+}
+
+impl From<GlobalError> for InstantiationError {
+    fn from(error: GlobalError) -> Self {
+        Self::Global(error)
     }
 }

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -251,14 +251,7 @@ impl Module {
         match operands[0] {
             InitExprOperand::Const(value) => value,
             InitExprOperand::GlobalGet(global_index) => {
-                let global = builder
-                    .get_global(global_index.into_u32())
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "encountered missing global at index {:?} for initializer expression evaluation",
-                            global_index
-                        )
-                    });
+                let global = builder.get_global(global_index.into_u32());
                 global.get(context)
             }
         }
@@ -271,42 +264,22 @@ impl Module {
             let external = match export.external() {
                 export::External::Func(func_index) => {
                     let func_index = func_index.into_u32();
-                    let func = builder.get_func(func_index).unwrap_or_else(|| {
-                        panic!(
-                            "encountered missing function at index {:?} upon element initialization",
-                            func_index,
-                        )
-                    });
+                    let func = builder.get_func(func_index);
                     Extern::Func(func)
                 }
                 export::External::Table(table_index) => {
                     let table_index = table_index.into_u32();
-                    let table = builder.get_table(table_index).unwrap_or_else(|| {
-                        panic!(
-                            "encountered missing table at index {:?} upon element initialization",
-                            table_index,
-                        )
-                    });
+                    let table = builder.get_table(table_index);
                     Extern::Table(table)
                 }
                 export::External::Memory(memory_index) => {
                     let memory_index = memory_index.into_u32();
-                    let memory = builder.get_memory(memory_index).unwrap_or_else(|| {
-                        panic!(
-                            "encountered missing memory at index {:?} upon element initialization",
-                            memory_index,
-                        )
-                    });
+                    let memory = builder.get_memory(memory_index);
                     Extern::Memory(memory)
                 }
                 export::External::Global(global_index) => {
                     let global_index = global_index.into_u32();
-                    let global = builder.get_global(global_index).unwrap_or_else(|| {
-                        panic!(
-                            "encountered missing global at index {:?} upon element initialization",
-                            global_index,
-                        )
-                    });
+                    let global = builder.get_global(global_index);
                     Extern::Global(global)
                 }
             };
@@ -330,12 +303,7 @@ impl Module {
                     offset_expr,
                 )
                 }) as usize;
-            let table = builder.get_table(DEFAULT_TABLE_INDEX).unwrap_or_else(|| {
-                panic!(
-                    "expected default table at index {} but found none",
-                    DEFAULT_TABLE_INDEX
-                )
-            });
+            let table = builder.get_table(DEFAULT_TABLE_INDEX);
             // Note: This checks not only that the elements in the element segments properly
             //       fit into the table at the given offset but also that the element segment
             //       consists of at least 1 element member.
@@ -352,12 +320,7 @@ impl Module {
             // Finally do the actual initialization of the table elements.
             for (i, func_index) in element_segment.items().iter().enumerate() {
                 let func_index = func_index.into_u32();
-                let func = builder.get_func(func_index).unwrap_or_else(|| {
-                    panic!(
-                        "encountered missing function at index {} upon element initialization",
-                        func_index
-                    )
-                });
+                let func = builder.get_func(func_index);
                 table.set(context.as_context_mut(), offset + i, Some(func))?;
             }
         }
@@ -380,12 +343,7 @@ impl Module {
                     offset_expr,
                 )
                 }) as usize;
-            let memory = builder.get_memory(DEFAULT_MEMORY_INDEX).unwrap_or_else(|| {
-                panic!(
-                    "expected default memory at index {} but found none",
-                    DEFAULT_MEMORY_INDEX
-                )
-            });
+            let memory = builder.get_memory(DEFAULT_MEMORY_INDEX);
             memory.write(context.as_context_mut(), offset, data_segment.data())?;
         }
         Ok(())

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -78,9 +78,7 @@ impl Module {
         _context: &mut impl AsContextMut,
         builder: &mut InstanceEntityBuilder,
     ) {
-        for func_type in self.func_types() {
-            builder.push_func_type(*func_type);
-        }
+        builder.set_func_types(&self.func_types);
     }
 
     /// Extract the Wasm imports from the module and zips them with the given external values.

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -55,13 +55,14 @@ impl Module {
         self.extract_memories(&mut context, &mut builder);
         self.extract_globals(&mut context, &mut builder);
         self.extract_exports(&mut builder);
+        self.extract_start_fn(&mut builder);
 
         self.initialize_table_elements(&mut context, &mut builder)?;
         self.initialize_memory_data(&mut context, &mut builder)?;
 
         // At this point the module instantiation is nearly done.
         // The only thing that is missing is to run the `start` function.
-        Ok(InstancePre::new(handle, self, builder))
+        Ok(InstancePre::new(handle, builder))
     }
 
     /// Extracts the Wasm function signatures from the
@@ -284,6 +285,13 @@ impl Module {
                 }
             };
             builder.push_export(field, external);
+        }
+    }
+
+    /// Extracts the optional start function for the build instance.
+    fn extract_start_fn(&self, builder: &mut InstanceEntityBuilder) {
+        if let Some(start_fn) = self.start {
+            builder.set_start(start_fn)
         }
     }
 

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -46,7 +46,7 @@ impl Module {
         I: IntoIterator<Item = Extern>,
     {
         let handle = context.as_context_mut().store.alloc_instance();
-        let mut builder = InstanceEntity::build();
+        let mut builder = InstanceEntity::build(self);
 
         self.extract_func_types(&mut context, &mut builder);
         self.extract_imports(&mut context, &mut builder, externals)?;

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -145,12 +145,9 @@ impl Module {
                     imported.satisfies(required)?;
                     builder.push_memory(memory);
                 }
-                (ModuleImportType::Global(expected), Extern::Global(global)) => {
-                    let expected = *expected;
-                    let actual = global.global_type(&context);
-                    if expected != actual {
-                        return Err(InstantiationError::GlobalTypeMismatch { expected, actual });
-                    }
+                (ModuleImportType::Global(required), Extern::Global(global)) => {
+                    let imported = global.global_type(context.as_context());
+                    imported.satisfies(required)?;
                     builder.push_global(global);
                 }
                 (expected_import, actual_extern_val) => {

--- a/crates/wasmi/src/module/instantiate/pre.rs
+++ b/crates/wasmi/src/module/instantiate/pre.rs
@@ -1,4 +1,4 @@
-use super::{InstantiationError, Module};
+use super::InstantiationError;
 use crate::{module::FuncIdx, AsContextMut, Error, Instance, InstanceEntityBuilder};
 
 /// A partially instantiated [`Instance`] where the `start` function has not yet been executed.
@@ -9,31 +9,22 @@ use crate::{module::FuncIdx, AsContextMut, Error, Instance, InstanceEntityBuilde
 /// conformant module instantiation. This API provides control over the precise instantiation
 /// process with regard to this need.
 #[derive(Debug)]
-pub struct InstancePre<'a> {
+pub struct InstancePre {
     handle: Instance,
-    module: &'a Module,
     builder: InstanceEntityBuilder,
 }
 
-impl<'a> InstancePre<'a> {
+impl InstancePre {
     /// Creates a new [`InstancePre`].
-    pub(super) fn new(
-        handle: Instance,
-        module: &'a Module,
-        builder: InstanceEntityBuilder,
-    ) -> Self {
-        Self {
-            handle,
-            module,
-            builder,
-        }
+    pub(super) fn new(handle: Instance, builder: InstanceEntityBuilder) -> Self {
+        Self { handle, builder }
     }
 
     /// Returns the index of the `start` function if any.
     ///
     /// Returns `None` if the [`Module`] does not have a `start` function.
     fn start_fn(&self) -> Option<u32> {
-        self.module.start.map(FuncIdx::into_u32)
+        self.builder.get_start().map(FuncIdx::into_u32)
     }
 
     /// Runs the `start` function of the [`Instance`] and returns its handle.

--- a/crates/wasmi/src/module/instantiate/pre.rs
+++ b/crates/wasmi/src/module/instantiate/pre.rs
@@ -22,7 +22,7 @@ impl InstancePre {
 
     /// Returns the index of the `start` function if any.
     ///
-    /// Returns `None` if the [`Module`] does not have a `start` function.
+    /// Returns `None` if the Wasm module does not have a `start` function.
     fn start_fn(&self) -> Option<u32> {
         self.builder.get_start().map(FuncIdx::into_u32)
     }

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -160,6 +160,23 @@ impl Module {
         }
     }
 
+    /// Returns the number of non-imported functions of the [`Module`].
+    pub(crate) fn len_funcs(&self) -> usize {
+        self.funcs.len()
+    }
+    /// Returns the number of non-imported tables of the [`Module`].
+    pub(crate) fn len_tables(&self) -> usize {
+        self.tables.len()
+    }
+    /// Returns the number of non-imported linear memories of the [`Module`].
+    pub(crate) fn len_memories(&self) -> usize {
+        self.memories.len()
+    }
+    /// Returns the number of non-imported global variables of the [`Module`].
+    pub(crate) fn len_globals(&self) -> usize {
+        self.memories.len()
+    }
+
     /// Returns a slice over the [`FuncType`] of the [`Module`].
     ///
     /// [`FuncType`]: struct.FuncType.html

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -43,9 +43,8 @@ use crate::{
     MemoryType,
     TableType,
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{iter, slice::Iter as SliceIter};
-use alloc::sync::Arc;
 
 /// A parsed and validated WebAssembly module.
 #[derive(Debug)]

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -45,12 +45,13 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::{iter, slice::Iter as SliceIter};
+use alloc::sync::Arc;
 
 /// A parsed and validated WebAssembly module.
 #[derive(Debug)]
 pub struct Module {
     engine: Engine,
-    func_types: Box<[DedupFuncType]>,
+    func_types: Arc<[DedupFuncType]>,
     imports: ModuleImports,
     funcs: Box<[DedupFuncType]>,
     tables: Box<[TableType]>,
@@ -175,13 +176,6 @@ impl Module {
     /// Returns the number of non-imported global variables of the [`Module`].
     pub(crate) fn len_globals(&self) -> usize {
         self.memories.len()
-    }
-
-    /// Returns a slice over the [`FuncType`] of the [`Module`].
-    ///
-    /// [`FuncType`]: struct.FuncType.html
-    fn func_types(&self) -> &[DedupFuncType] {
-        &self.func_types[..]
     }
 
     /// Returns an iterator over the imports of the [`Module`].


### PR DESCRIPTION
- Preallocates buffers upon Module instantiation to reduce amount of copying and reallocations.
- Uses more dense data structures for `Instance`, e.g. `Box<[T]>` instead of `Vec<T>` or `Box<str>` instead of `String`.
- Removes lifetime parameter from `InstancePre`.
- No longer copies over the contents of the `Module`'s `func_types` upon instantiation but efficiently clones via ref counting.