### PR TITLE
Cleanup some test code

### DIFF
--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -93,7 +93,58 @@ mod tests {
     use super::*;
     use core::borrow::Borrow;
 
-    fn assert_func_type(func_type: impl Borrow<FuncType>, expected: &str) {
+    #[test]
+    fn new_empty_works() {
+        let ft = FuncType::new([], []);
+        assert!(ft.params().is_empty());
+        assert!(ft.results().is_empty());
+        assert_eq!(ft.params(), ft.params_results().0);
+        assert_eq!(ft.results(), ft.params_results().1);
+    }
+
+    #[test]
+    fn new_works() {
+        let types = [
+            &[ValueType::I32][..],
+            &[ValueType::I64][..],
+            &[ValueType::F32][..],
+            &[ValueType::F64][..],
+            &[ValueType::I32, ValueType::I32][..],
+            &[ValueType::I32, ValueType::I32, ValueType::I32][..],
+            &[
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+            ][..],
+            &[
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+                ValueType::I32,
+            ][..],
+            &[
+                ValueType::I32,
+                ValueType::I64,
+                ValueType::F32,
+                ValueType::F64,
+            ][..],
+        ];
+        for params in types {
+            for results in types {
+                let ft = FuncType::new(params.iter().copied(), results.iter().copied());
+                assert_eq!(ft.params(), params);
+                assert_eq!(ft.results(), results);
+                assert_eq!(ft.params(), ft.params_results().0);
+                assert_eq!(ft.results(), ft.params_results().1);
+            }
+        }
+    }
+
     fn assert_display(func_type: impl Borrow<FuncType>, expected: &str) {
         assert_eq!(format!("{}", func_type.borrow()), String::from(expected),);
     }

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -3,6 +3,10 @@ use alloc::{sync::Arc, vec::Vec};
 use core::fmt::{self, Display};
 
 /// A function type representing a function's parameter and result types.
+///
+/// # Note
+///
+/// Can be cloned cheaply.
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct FuncType {
     /// The number of function parameters.

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -57,18 +57,18 @@ impl Display for FuncType {
 }
 
 impl FuncType {
-    /// Creates a new function signature.
-    pub fn new<I, O>(inputs: I, outputs: O) -> Self
+    /// Creates a new [`FuncType`].
+    pub fn new<P, R>(params: P, results: R) -> Self
     where
-        I: IntoIterator<Item = ValueType>,
-        O: IntoIterator<Item = ValueType>,
+        P: IntoIterator<Item = ValueType>,
+        R: IntoIterator<Item = ValueType>,
     {
-        let mut inputs_outputs = inputs.into_iter().collect::<Vec<_>>();
-        let len_inputs = inputs_outputs.len();
-        inputs_outputs.extend(outputs);
+        let mut params_results = params.into_iter().collect::<Vec<_>>();
+        let len_params = params_results.len();
+        params_results.extend(results);
         Self {
-            params_results: inputs_outputs.into(),
-            len_params: len_inputs,
+            params_results: params_results.into(),
+            len_params,
         }
     }
 

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -91,72 +91,85 @@ impl FuncType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::borrow::Borrow;
+
+    fn assert_func_type(func_type: impl Borrow<FuncType>, expected: &str) {
+        assert_eq!(format!("{}", func_type.borrow()), String::from(expected),);
+    }
 
     #[test]
     fn display_0in_0out() {
-        let func_type = FuncType::new([], []);
-        assert_eq!(format!("{func_type}"), String::from("fn()"),);
+        assert_func_type(FuncType::new([], []), "fn()");
+    }
+
+    #[test]
+    fn display_1in_0out() {
+        assert_func_type(FuncType::new([ValueType::I32], []), "fn(i32)");
+    }
+
+    #[test]
+    fn display_0in_1out() {
+        assert_func_type(FuncType::new([], [ValueType::I32]), "fn() -> i32");
     }
 
     #[test]
     fn display_1in_1out() {
-        let func_type = FuncType::new([ValueType::I32], [ValueType::I32]);
-        assert_eq!(format!("{func_type}"), String::from("fn(i32) -> i32"),);
+        assert_func_type(
+            FuncType::new([ValueType::I32], [ValueType::I32]),
+            "fn(i32) -> i32",
+        );
     }
 
     #[test]
     fn display_4in_0out() {
-        let func_type = FuncType::new(
-            [
-                ValueType::I32,
-                ValueType::I64,
-                ValueType::F32,
-                ValueType::F64,
-            ],
-            [],
-        );
-        assert_eq!(
-            format!("{func_type}"),
-            String::from("fn(i32, i64, f32, f64)"),
+        assert_func_type(
+            FuncType::new(
+                [
+                    ValueType::I32,
+                    ValueType::I64,
+                    ValueType::F32,
+                    ValueType::F64,
+                ],
+                [],
+            ),
+            "fn(i32, i64, f32, f64)",
         );
     }
 
     #[test]
     fn display_0in_4out() {
-        let func_type = FuncType::new(
-            [],
-            [
-                ValueType::I32,
-                ValueType::I64,
-                ValueType::F32,
-                ValueType::F64,
-            ],
-        );
-        assert_eq!(
-            format!("{func_type}"),
-            String::from("fn() -> (i32, i64, f32, f64)"),
+        assert_func_type(
+            FuncType::new(
+                [],
+                [
+                    ValueType::I32,
+                    ValueType::I64,
+                    ValueType::F32,
+                    ValueType::F64,
+                ],
+            ),
+            "fn() -> (i32, i64, f32, f64)",
         );
     }
 
     #[test]
     fn display_4in_4out() {
-        let func_type = FuncType::new(
-            [
-                ValueType::I32,
-                ValueType::I64,
-                ValueType::F32,
-                ValueType::F64,
-            ],
-            [
-                ValueType::I32,
-                ValueType::I64,
-                ValueType::F32,
-                ValueType::F64,
-            ],
-        );
-        assert_eq!(
-            format!("{func_type}"),
-            String::from("fn(i32, i64, f32, f64) -> (i32, i64, f32, f64)"),
+        assert_func_type(
+            FuncType::new(
+                [
+                    ValueType::I32,
+                    ValueType::I64,
+                    ValueType::F32,
+                    ValueType::F64,
+                ],
+                [
+                    ValueType::I32,
+                    ValueType::I64,
+                    ValueType::F32,
+                    ValueType::F64,
+                ],
+            ),
+            "fn(i32, i64, f32, f64) -> (i32, i64, f32, f64)",
         );
     }
 }

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -77,10 +77,6 @@ impl FuncType {
         &self.params_results[..self.len_params]
     }
 
-    // pub fn into_params(self) -> impl ExactSizeIterator<Item = ValueType> + 'static {
-    //     self.params_results[..self.len_params].iter().copied()
-    // }
-
     /// Returns the result types of the function type.
     pub fn results(&self) -> &[ValueType] {
         &self.params_results[self.len_params..]

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -23,20 +23,6 @@ pub struct FuncType {
     params_results: Arc<[ValueType]>,
 }
 
-/// Writes the elements of a `slice` separated by the `separator`.
-fn write_slice<T>(f: &mut fmt::Formatter, slice: &[T], separator: &str) -> fmt::Result
-where
-    T: Display,
-{
-    if let Some((first, rest)) = slice.split_first() {
-        write!(f, "{first}")?;
-        for param in rest {
-            write!(f, "{separator} {param}")?;
-        }
-    }
-    Ok(())
-}
-
 impl Display for FuncType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "fn(")?;
@@ -58,6 +44,20 @@ impl Display for FuncType {
         }
         Ok(())
     }
+}
+
+/// Writes the elements of a `slice` separated by the `separator`.
+fn write_slice<T>(f: &mut fmt::Formatter, slice: &[T], separator: &str) -> fmt::Result
+where
+    T: Display,
+{
+    if let Some((first, rest)) = slice.split_first() {
+        write!(f, "{first}")?;
+        for param in rest {
+            write!(f, "{separator} {param}")?;
+        }
+    }
+    Ok(())
 }
 
 impl FuncType {

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -19,16 +19,25 @@ pub struct FuncType {
     params_results: Arc<[ValueType]>,
 }
 
+/// Writes the elements of a `slice` separated by the `separator`.
+fn write_slice<T>(f: &mut fmt::Formatter, slice: &[T], separator: &str) -> fmt::Result
+where
+    T: Display,
+{
+    if let Some((first, rest)) = slice.split_first() {
+        write!(f, "{first}")?;
+        for param in rest {
+            write!(f, "{separator} {param}")?;
+        }
+    }
+    Ok(())
+}
+
 impl Display for FuncType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "fn(")?;
         let (params, results) = self.params_results();
-        if let Some((first, rest)) = params.split_first() {
-            write!(f, "{first}")?;
-            for param in rest {
-                write!(f, ", {param}")?;
-            }
-        }
+        write_slice(f, params, ",")?;
         write!(f, ")")?;
         if let Some((first, rest)) = results.split_first() {
             write!(f, " -> ")?;

--- a/crates/wasmi/src/func_type.rs
+++ b/crates/wasmi/src/func_type.rs
@@ -94,27 +94,28 @@ mod tests {
     use core::borrow::Borrow;
 
     fn assert_func_type(func_type: impl Borrow<FuncType>, expected: &str) {
+    fn assert_display(func_type: impl Borrow<FuncType>, expected: &str) {
         assert_eq!(format!("{}", func_type.borrow()), String::from(expected),);
     }
 
     #[test]
     fn display_0in_0out() {
-        assert_func_type(FuncType::new([], []), "fn()");
+        assert_display(FuncType::new([], []), "fn()");
     }
 
     #[test]
     fn display_1in_0out() {
-        assert_func_type(FuncType::new([ValueType::I32], []), "fn(i32)");
+        assert_display(FuncType::new([ValueType::I32], []), "fn(i32)");
     }
 
     #[test]
     fn display_0in_1out() {
-        assert_func_type(FuncType::new([], [ValueType::I32]), "fn() -> i32");
+        assert_display(FuncType::new([], [ValueType::I32]), "fn() -> i32");
     }
 
     #[test]
     fn display_1in_1out() {
-        assert_func_type(
+        assert_display(
             FuncType::new([ValueType::I32], [ValueType::I32]),
             "fn(i32) -> i32",
         );
@@ -122,7 +123,7 @@ mod tests {
 
     #[test]
     fn display_4in_0out() {
-        assert_func_type(
+        assert_display(
             FuncType::new(
                 [
                     ValueType::I32,
@@ -138,7 +139,7 @@ mod tests {
 
     #[test]
     fn display_0in_4out() {
-        assert_func_type(
+        assert_display(
             FuncType::new(
                 [],
                 [
@@ -154,7 +155,7 @@ mod tests {
 
     #[test]
     fn display_4in_4out() {
-        assert_func_type(
+        assert_display(
             FuncType::new(
                 [
                     ValueType::I32,


### PR DESCRIPTION
We might also want to move the `FuncType` definition into the `wasmi_core` crate for reusability once we split up the workspace into many more smaller crates.