### PR TITLE
Refactor `wasmi_core::Trap` and make it more similar to Wasmtime's `Trap`

### DIFF
--- a/crates/core/src/host_error.rs
+++ b/crates/core/src/host_error.rs
@@ -37,7 +37,7 @@ use downcast_rs::{impl_downcast, DowncastSync};
 ///
 /// // Get a reference to the concrete error
 /// match failable_fn() {
-///     Err(trap) if trap.is_host() => {
+///     Err(trap) if trap.as_host().is_some() => {
 ///         let host_error = trap.as_host().unwrap();
 ///         let my_error: &MyError = host_error.downcast_ref::<MyError>().unwrap();
 ///         assert_eq!(my_error.code, 1312);

--- a/crates/core/src/host_error.rs
+++ b/crates/core/src/host_error.rs
@@ -30,17 +30,16 @@ use downcast_rs::{impl_downcast, DowncastSync};
 /// impl HostError for MyError { }
 ///
 /// fn failable_fn() -> Result<(), Trap> {
-///     let my_error = MyError { code: 1312 };
+///     let my_error = MyError { code: 42 };
 ///     // Note how you can just convert your errors to `wasmi::Error`
 ///     Err(my_error.into())
 /// }
 ///
 /// // Get a reference to the concrete error
 /// match failable_fn() {
-///     Err(trap) if trap.as_host().is_some() => {
-///         let host_error = trap.as_host().unwrap();
-///         let my_error: &MyError = host_error.downcast_ref::<MyError>().unwrap();
-///         assert_eq!(my_error.code, 1312);
+///     Err(trap) => {
+///         let my_error: &MyError = trap.downcast_ref().unwrap();
+///         assert_eq!(my_error.code, 42);
 ///     }
 ///     _ => panic!(),
 /// }
@@ -48,15 +47,14 @@ use downcast_rs::{impl_downcast, DowncastSync};
 /// // get the concrete error itself
 /// match failable_fn() {
 ///     Err(err) => {
-///         let my_error = match err.as_host() {
-///             Some(host_error) => host_error.downcast_ref::<MyError>().unwrap().clone(),
-///             None => panic!("expected host error but found: {}", err),
+///         let my_error = match err.downcast_ref::<MyError>() {
+///             Some(host_error) => host_error.clone(),
+///             None => panic!("expected host error `MyError` but found: {}", err),
 ///         };
-///         assert_eq!(my_error.code, 1312);
+///         assert_eq!(my_error.code, 42);
 ///     }
 ///     _ => panic!(),
 /// }
-///
 /// ```
 pub trait HostError: 'static + Display + Debug + DowncastSync {}
 impl_downcast!(HostError);

--- a/crates/core/src/host_error.rs
+++ b/crates/core/src/host_error.rs
@@ -16,7 +16,7 @@ use downcast_rs::{impl_downcast, DowncastSync};
 /// use std::fmt;
 /// use wasmi_core::{Trap, HostError};
 ///
-/// #[derive(Debug)]
+/// #[derive(Debug, Copy, Clone)]
 /// struct MyError {
 ///     code: u32,
 /// }
@@ -48,9 +48,9 @@ use downcast_rs::{impl_downcast, DowncastSync};
 /// // get the concrete error itself
 /// match failable_fn() {
 ///     Err(err) => {
-///         let my_error = match err {
-///             trap if trap.is_host() => trap.into_host().unwrap().downcast::<MyError>().unwrap(),
-///             unexpected => panic!("expected host error but found: {}", unexpected),
+///         let my_error = match err.as_host() {
+///             Some(host_error) => host_error.downcast_ref::<MyError>().unwrap().clone(),
+///             None => panic!("expected host error but found: {}", err),
 ///         };
 ///         assert_eq!(my_error.code, 1312);
 ///     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,7 +27,7 @@ extern crate std as alloc;
 pub use self::{
     host_error::HostError,
     nan_preserving_float::{F32, F64},
-    trap::{Trap, TrapCode, DisplayTrapReason},
+    trap::{Trap, TrapCode},
     units::Pages,
     untyped::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedError, UntypedValue},
     value::{

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,7 +27,7 @@ extern crate std as alloc;
 pub use self::{
     host_error::HostError,
     nan_preserving_float::{F32, F64},
-    trap::{Trap, TrapCode},
+    trap::{Trap, TrapCode, DisplayTrapReason},
     units::Pages,
     untyped::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedError, UntypedValue},
     value::{

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -85,13 +85,6 @@ impl Trap {
         Self::new(TrapInner::Host(Box::new(host_error)))
     }
 
-    /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
-    /// exit status value.
-    #[cold] // see Trap::host
-    pub fn i32_exit(status: i32) -> Self {
-        Self::new(TrapInner::I32Exit(status))
-    }
-
     /// Returns a shared reference to the [`HostError`] if any.
     ///
     /// Otherwise returns `None`.
@@ -100,6 +93,11 @@ impl Trap {
         self.inner.as_host()
     }
 
+    /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
+    /// exit status value.
+    #[cold] // see Trap::host
+    pub fn i32_exit(status: i32) -> Self {
+        Self::new(TrapInner::I32Exit(status))
     }
 
     /// Returns the classic `i32` exit program code of a `Trap` if any.
@@ -118,7 +116,7 @@ impl Trap {
 }
 
 impl From<TrapCode> for Trap {
-    #[cold]
+    #[cold] // see Trap::host
     fn from(error: TrapCode) -> Self {
         Self::new(TrapInner::Code(error))
     }

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -116,6 +116,7 @@ impl Trap {
 }
 
 impl From<TrapCode> for Trap {
+    #[inline]
     #[cold] // see Trap::host
     fn from(error: TrapCode) -> Self {
         Self::new(TrapInner::Code(error))

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -70,6 +70,16 @@ impl TrapReason {
     }
 }
 
+/// A [`Display`] wrapper for a trap reason.
+#[derive(Debug, Copy, Clone)]
+pub struct DisplayTrapReason<'a>(&'a TrapReason);
+
+impl Display for DisplayTrapReason<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <TrapReason as Display>::fmt(&self.0, f)
+    }
+}
+
 impl Trap {
     /// Create a new [`Trap`] from the [`TrapReason`].
     fn with_reason(reason: TrapReason) -> Self {
@@ -114,6 +124,17 @@ impl Trap {
     #[inline]
     pub fn trap_code(&self) -> Option<TrapCode> {
         self.reason.trap_code()
+    }
+
+    /// Returns a [`Display`] wrapper for the reason of this [`Trap`].
+    ///
+    /// # Note
+    ///
+    /// This is useful for when users are only interested in displaying the
+    /// underlying reason that caused a [`Trap`] without other information that
+    /// could later be added such as backtraces etc.
+    pub fn display_reason(&self) -> DisplayTrapReason {
+        DisplayTrapReason(&self.reason)
     }
 }
 

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -28,7 +28,7 @@ fn trap_size() {
 enum TrapInner {
     /// Traps during Wasm execution.
     Code(TrapCode),
-    /// An `i32` exit code.
+    /// An `i32` exit status code.
     ///
     /// # Note
     ///

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -99,7 +99,7 @@ impl Trap {
     {
         self.reason
             .as_host()
-            .and_then(|reason| reason.downcast_ref::<T>())
+            .and_then(<(dyn HostError + 'static)>::downcast_ref)
     }
 
     /// Creates a new `Trap` representing an explicit program exit with a classic `i32`

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -27,7 +27,7 @@ fn trap_size() {
 #[derive(Debug)]
 enum TrapInner {
     /// Traps during Wasm execution.
-    Code(TrapCode),
+    InstructionTrap(TrapCode),
     /// An `i32` exit status code.
     ///
     /// # Note
@@ -61,7 +61,7 @@ impl TrapInner {
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
     #[inline]
     pub fn trap_code(&self) -> Option<TrapCode> {
-        if let Self::Code(trap_code) = self {
+        if let Self::InstructionTrap(trap_code) = self {
             return Some(*trap_code);
         }
         None
@@ -119,7 +119,7 @@ impl From<TrapCode> for Trap {
     #[inline]
     #[cold] // see Trap::host
     fn from(error: TrapCode) -> Self {
-        Self::new(TrapInner::Code(error))
+        Self::from_inner(TrapInner::InstructionTrap(error))
     }
 }
 
@@ -136,7 +136,7 @@ where
 impl Display for TrapInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Code(trap_code) => Display::fmt(trap_code, f),
+            Self::InstructionTrap(trap_code) => Display::fmt(trap_code, f),
             Self::I32Exit(status) => write!(f, "Exited with i32 exit status {}", status),
             Self::Host(host_error) => Display::fmt(host_error, f),
         }

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -107,6 +107,17 @@ impl Trap {
         self.reason.as_host()
     }
 
+    /// Downcasts the [`Trap`] into the `T: HostError` if possible.
+    ///
+    /// Returns `None` otherwise.
+    #[inline]
+    pub fn downcast_ref<T>(&self) -> Option<&T>
+    where
+        T: HostError,
+    {
+        self.reason.as_host().and_then(|reason| reason.downcast_ref::<T>())
+    }
+
     /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
     /// exit status value.
     #[cold] // see Trap::new

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -97,7 +97,9 @@ impl Trap {
     where
         T: HostError,
     {
-        self.reason.as_host().and_then(|reason| reason.downcast_ref::<T>())
+        self.reason
+            .as_host()
+            .and_then(|reason| reason.downcast_ref::<T>())
     }
 
     /// Creates a new `Trap` representing an explicit program exit with a classic `i32`

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -99,14 +99,6 @@ impl Trap {
         Self::with_reason(TrapReason::Message(message.into().into_boxed_str()))
     }
 
-    /// Returns a shared reference to the [`HostError`] if any.
-    ///
-    /// Otherwise returns `None`.
-    #[inline]
-    pub fn as_host(&self) -> Option<&dyn HostError> {
-        self.reason.as_host()
-    }
-
     /// Downcasts the [`Trap`] into the `T: HostError` if possible.
     ///
     /// Returns `None` otherwise.

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -5,10 +5,12 @@ use core::fmt::{self, Display};
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
 
-/// Error type which can be thrown by wasm code or by host environment.
+/// Error type which can be returned by Wasm code or by the host environment.
 ///
-/// Under some conditions, wasm execution may produce a `Trap`, which immediately aborts execution.
-/// Traps can't be handled by WebAssembly code, but are reported to the embedder.
+/// Under some conditions, Wasm execution may produce a [`Trap`],
+/// which immediately aborts execution.
+/// Traps cannot be handled by WebAssembly code, but are reported to the
+/// host embedder.
 #[derive(Debug, Clone)]
 pub struct Trap {
     /// The cloneable reason of a [`Trap`].

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -1,5 +1,5 @@
 use crate::HostError;
-use alloc::{boxed::Box, sync::Arc};
+use alloc::{boxed::Box, string::String, sync::Arc};
 use core::fmt::{self, Display};
 
 #[cfg(feature = "std")]

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -90,7 +90,7 @@ impl TrapInner {
 
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
     #[inline]
-    pub fn as_code(&self) -> Option<TrapCode> {
+    pub fn trap_code(&self) -> Option<TrapCode> {
         if let Self::Code(trap_code) = self {
             return Some(*trap_code);
         }
@@ -166,8 +166,8 @@ impl Trap {
 
     /// Returns the [`TrapCode`] traps originating from Wasm execution.
     #[inline]
-    pub fn as_code(&self) -> Option<TrapCode> {
-        self.inner.as_code()
+    pub fn trap_code(&self) -> Option<TrapCode> {
+        self.inner.trap_code()
     }
 }
 
@@ -207,7 +207,7 @@ impl Display for Trap {
 #[cfg(feature = "std")]
 impl StdError for Trap {
     fn description(&self) -> &str {
-        self.as_code().map_or("", |code| code.trap_message())
+        self.trap_code().map_or("", |code| code.trap_message())
     }
 }
 

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -153,7 +153,7 @@ impl From<TrapCode> for Trap {
 
 impl<E> From<E> for Trap
 where
-    E: HostError + Sized,
+    E: HostError,
 {
     #[inline]
     #[cold] // see Trap::new

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -79,7 +79,7 @@ impl Trap {
     }
 
     /// Creates a new [`Trap`] described by a `message`.
-    #[cold]
+    #[cold] // traps are exceptional, this helps move handling off the main path
     pub fn new<T>(message: T) -> Self
     where
         T: Into<String>,
@@ -97,7 +97,7 @@ impl Trap {
 
     /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
     /// exit status value.
-    #[cold] // see Trap::host
+    #[cold] // see Trap::new
     pub fn i32_exit(status: i32) -> Self {
         Self::with_reason(TrapReason::I32Exit(status))
     }
@@ -119,7 +119,7 @@ impl Trap {
 
 impl From<TrapCode> for Trap {
     #[inline]
-    #[cold] // see Trap::host
+    #[cold] // see Trap::new
     fn from(error: TrapCode) -> Self {
         Self::with_reason(TrapReason::InstructionTrap(error))
     }
@@ -130,7 +130,7 @@ where
     E: HostError + Sized,
 {
     #[inline]
-    #[cold] // traps are exceptional, this helps move handling off the main path
+    #[cold] // see Trap::new
     fn from(host_error: E) -> Self {
         Self::with_reason(TrapReason::Host(Box::new(host_error)))
     }

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -72,16 +72,6 @@ impl TrapReason {
     }
 }
 
-/// A [`Display`] wrapper for a trap reason.
-#[derive(Debug, Copy, Clone)]
-pub struct DisplayTrapReason<'a>(&'a TrapReason);
-
-impl Display for DisplayTrapReason<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <TrapReason as Display>::fmt(&self.0, f)
-    }
-}
-
 impl Trap {
     /// Create a new [`Trap`] from the [`TrapReason`].
     fn with_reason(reason: TrapReason) -> Self {
@@ -129,17 +119,6 @@ impl Trap {
     #[inline]
     pub fn trap_code(&self) -> Option<TrapCode> {
         self.reason.trap_code()
-    }
-
-    /// Returns a [`Display`] wrapper for the reason of this [`Trap`].
-    ///
-    /// # Note
-    ///
-    /// This is useful for when users are only interested in displaying the
-    /// underlying reason that caused a [`Trap`] without other information that
-    /// could later be added such as backtraces etc.
-    pub fn display_reason(&self) -> DisplayTrapReason {
-        DisplayTrapReason(&self.reason)
     }
 }
 

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -39,18 +39,6 @@ enum TrapInner {
 }
 
 impl TrapInner {
-    /// Returns `true` if `self` trap originating from host code.
-    #[inline]
-    pub fn is_host(&self) -> bool {
-        matches!(self, TrapInner::Host(_))
-    }
-
-    /// Returns `true` if `self` trap originating from Wasm code.
-    #[inline]
-    pub fn is_code(&self) -> bool {
-        matches!(self, TrapInner::Code(_))
-    }
-
     /// Returns the classic `i32` exit program code of a `Trap` if any.
     ///
     /// Otherwise returns `None`.
@@ -102,18 +90,6 @@ impl Trap {
     #[cold] // see Trap::host
     pub fn i32_exit(status: i32) -> Self {
         Self::new(TrapInner::I32Exit(status))
-    }
-
-    /// Returns `true` if `self` trap originating from host code.
-    #[inline]
-    pub fn is_host(&self) -> bool {
-        self.inner.is_host()
-    }
-
-    /// Returns `true` if `self` trap originating from Wasm code.
-    #[inline]
-    pub fn is_code(&self) -> bool {
-        self.inner.is_code()
     }
 
     /// Returns a shared reference to the [`HostError`] if any.

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -125,7 +125,6 @@ impl Trap {
 }
 
 impl From<TrapCode> for Trap {
-    #[inline]
     #[cold] // see Trap::new
     fn from(error: TrapCode) -> Self {
         Self::with_reason(TrapReason::InstructionTrap(error))

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -819,15 +819,15 @@ macro_rules! impl_integer {
         impl Integer<Self> for $type {
             #[inline]
             fn leading_zeros(self) -> Self {
-                self.leading_zeros() as $type
+                self.leading_zeros() as _
             }
             #[inline]
             fn trailing_zeros(self) -> Self {
-                self.trailing_zeros() as $type
+                self.trailing_zeros() as _
             }
             #[inline]
             fn count_ones(self) -> Self {
-                self.count_ones() as $type
+                self.count_ones() as _
             }
             #[inline]
             fn rotl(self, other: Self) -> Self {
@@ -838,7 +838,7 @@ macro_rules! impl_integer {
                 self.rotate_right(other as u32)
             }
             #[inline]
-            fn div(self, other: $type) -> Result<$type, TrapCode> {
+            fn div(self, other: Self) -> Result<Self, TrapCode> {
                 if other == 0 {
                     return Err(TrapCode::IntegerDivisionByZero);
                 }

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -844,7 +844,7 @@ macro_rules! impl_integer {
                 }
                 match self.overflowing_div(other) {
                     (result, false) => Ok(result),
-                    (_, true) => Err(TrapCode::IntegerOverflow),
+                    _ => Err(TrapCode::IntegerOverflow),
                 }
             }
             #[inline]

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -511,7 +511,7 @@ macro_rules! impl_try_truncate_into {
             #[inline]
             fn try_truncate_into(self) -> Result<$into, TrapCode> {
                 if self.is_nan() {
-                    return Err(TrapCode::InvalidConversionToInt);
+                    return Err(TrapCode::BadConversionToInteger);
                 }
                 if self <= $rmin || self >= $rmax {
                     return Err(TrapCode::IntegerOverflow);
@@ -840,7 +840,7 @@ macro_rules! impl_integer {
             #[inline]
             fn div(self, other: $type) -> Result<$type, TrapCode> {
                 if other == 0 {
-                    return Err(TrapCode::DivisionByZero);
+                    return Err(TrapCode::IntegerDivisionByZero);
                 }
                 match self.overflowing_div(other) {
                     (result, false) => Ok(result),
@@ -850,7 +850,7 @@ macro_rules! impl_integer {
             #[inline]
             fn rem(self, other: Self) -> Result<Self, TrapCode> {
                 if other == 0 {
-                    return Err(TrapCode::DivisionByZero);
+                    return Err(TrapCode::IntegerDivisionByZero);
                 }
                 Ok(self.wrapping_rem(other))
             }

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -799,7 +799,7 @@ fn bench_execute_recursive_trap(c: &mut Criterion) {
             match error {
                 wasmi::Error::Trap(trap) => assert_matches::assert_matches!(
                     trap.trap_code(),
-                    Some(TrapCode::Unreachable),
+                    Some(TrapCode::UnreachableCodeReached),
                     "expected unreachable trap",
                 ),
                 _ => panic!("expected unreachable trap"),

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -798,7 +798,7 @@ fn bench_execute_recursive_trap(c: &mut Criterion) {
                 .unwrap_err();
             match error {
                 wasmi::Error::Trap(trap) => assert_matches::assert_matches!(
-                    trap.as_code(),
+                    trap.trap_code(),
                     Some(TrapCode::Unreachable),
                     "expected unreachable trap",
                 ),

--- a/crates/wasmi/src/engine/cache.rs
+++ b/crates/wasmi/src/engine/cache.rs
@@ -269,7 +269,7 @@ impl CachedMemoryBytes {
         let slice = self
             .data()
             .get(offset..(offset + len_buffer))
-            .ok_or(TrapCode::MemoryAccessOutOfBounds)?;
+            .ok_or(TrapCode::MemoryOutOfBounds)?;
         buffer.copy_from_slice(slice);
         Ok(())
     }
@@ -286,7 +286,7 @@ impl CachedMemoryBytes {
         let slice = self
             .data_mut()
             .get_mut(offset..(offset + len_buffer))
-            .ok_or(TrapCode::MemoryAccessOutOfBounds)?;
+            .ok_or(TrapCode::MemoryOutOfBounds)?;
         slice.copy_from_slice(buffer);
         Ok(())
     }

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -199,7 +199,7 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
 /// - If the trap message of the `error` is not as expected.
 fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message: &str) {
     match error {
-        TestError::Wasmi(WasmiError::Trap(trap)) if trap.is_code() => {
+        TestError::Wasmi(WasmiError::Trap(trap)) if trap.trap_code().is_some() => {
             let code = trap.trap_code().unwrap();
             assert_eq!(
                 code.trap_message(),

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -200,7 +200,7 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
 fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message: &str) {
     match error {
         TestError::Wasmi(WasmiError::Trap(trap)) if trap.is_code() => {
-            let code = trap.as_code().unwrap();
+            let code = trap.trap_code().unwrap();
             assert_eq!(
                 code.trap_message(),
                 message,


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/517.
Unblocks https://github.com/paritytech/wasmi/pull/557.

![2022-11-07-123148_1196x1097_scrot](https://user-images.githubusercontent.com/8193155/200300705-aa076f70-8b88-4fce-a53f-5516bd67e9bf.png)
