### PR TITLE
Remove Wasmtime dependency from `wasmi_wasi` crate

### DIFF
--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 
-wasi-common = "2.0.1"
-wasi-cap-std-sync = "2.0.1"
-wiggle = "2.0.0"
+wasi-common = "1.0.0"
+wasi-cap-std-sync = "1.0.0"
+wiggle = { version = "1.0.0", default-features = false, features = ["wiggle_metadata"] }
 wasmi = { version = "0.20.0", path = "../wasmi" }
 
 [dev-dependencies]

--- a/crates/wasi/src/guest_memory.rs
+++ b/crates/wasi/src/guest_memory.rs
@@ -1,0 +1,50 @@
+use wiggle::{borrow::BorrowChecker, BorrowHandle, GuestError, GuestMemory, Region};
+
+/// Lightweight `wasmi::Memory` wrapper so we can implement the
+/// `wiggle::GuestMemory` trait on it.
+pub struct WasmiGuestMemory<'a> {
+    mem: &'a mut [u8],
+    bc: BorrowChecker,
+}
+
+impl<'a> WasmiGuestMemory<'a> {
+    pub fn new(mem: &'a mut [u8]) -> Self {
+        Self {
+            mem,
+            // Wiggle does not expose any methods for functions to re-enter
+            // the WebAssembly instance, or expose the memory via non-wiggle
+            // mechanisms. However, the user-defined code may end up
+            // re-entering the instance, in which case this is an incorrect
+            // implementation - we require exactly one BorrowChecker exist per
+            // instance.
+            bc: BorrowChecker::new(),
+        }
+    }
+}
+
+unsafe impl GuestMemory for WasmiGuestMemory<'_> {
+    fn base(&self) -> (*mut u8, u32) {
+        (self.mem.as_ptr() as *mut u8, self.mem.len() as u32)
+    }
+    fn has_outstanding_borrows(&self) -> bool {
+        self.bc.has_outstanding_borrows()
+    }
+    fn is_shared_borrowed(&self, r: Region) -> bool {
+        self.bc.is_shared_borrowed(r)
+    }
+    fn is_mut_borrowed(&self, r: Region) -> bool {
+        self.bc.is_mut_borrowed(r)
+    }
+    fn shared_borrow(&self, r: Region) -> Result<BorrowHandle, GuestError> {
+        self.bc.shared_borrow(r)
+    }
+    fn mut_borrow(&self, r: Region) -> Result<BorrowHandle, GuestError> {
+        self.bc.mut_borrow(r)
+    }
+    fn shared_unborrow(&self, h: BorrowHandle) {
+        self.bc.shared_unborrow(h)
+    }
+    fn mut_unborrow(&self, h: BorrowHandle) {
+        self.bc.mut_unborrow(h)
+    }
+}

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,5 +1,7 @@
+mod guest_memory;
 pub mod snapshots;
 
+pub use self::guest_memory::WasmiGuestMemory;
 pub use snapshots::preview_1::define_wasi;
 pub use wasi_cap_std_sync::{
     clocks,

--- a/crates/wasi/src/snapshots/preview_1.rs
+++ b/crates/wasi/src/snapshots/preview_1.rs
@@ -1,3 +1,4 @@
+use crate::WasmiGuestMemory;
 use std::{
     pin::Pin,
     task::{Context, RawWaker, RawWakerVTable, Waker},
@@ -64,7 +65,7 @@ macro_rules! impl_add_to_linker_for_funcs {
                             };
                             let(mem, ctx) = mem.data_and_store_mut(&mut caller);
                             let ctx = wasi_ctx(ctx);
-                            let mem = wiggle::wasmtime::WasmtimeGuestMemory::new(mem);
+                            let mem = WasmiGuestMemory::new(mem);
 
                             match wasi_common::snapshots::preview_1::wasi_snapshot_preview1::$fname(ctx, &mem, $($arg,)*).await {
                                 Ok(r) => Ok(<$ret>::from(r)),


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/561.

Unfortunately `wiggle` version `1.0.2` is the most recent version that is Wasm runtime agnostic. All later major `wiggle` versions starting with `wiggle` version `2.0.0` and up and therefore also all later `wasi-common` version (since `wasi-common` builds on top of `wiggle`) are directly depending on Wasmtime.
Therefore a downgrade from version `2.0.0` to version `1.0.0` was necessary to fix this issue for `wasmi`.

In the long run we (`wasmi` team) might have to ship our own WASI implementation or find an alternative solution since we do not want us to depend on Wasmtime or any other Wasm runtime.