### PR TITLE
Use wiggle 2.0.

### DIFF
--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 
-wasi-common = "1.0.0"
-wasi-cap-std-sync = "1.0.0"
-wiggle = { version = "1.0.0", default-features = false, features = ["wiggle_metadata"] }
+wasi-common = "2.0"
+wasi-cap-std-sync = "2.0"
+wiggle = { version = "2.0", default-features = false, features = ["wiggle_metadata"] }
 wasmi = { version = "0.20.0", path = "../wasmi" }
 
 [dev-dependencies]


### PR DESCRIPTION
Wiggle 2.0 still allows removing wasmtime dependencies.

The one in the main branch of wasmtime repo doesn't allow removing it, but it is v4.0. I'll open an issue about that.

Bonus: fixes #564 