### PR TITLE
Import `wasi_cap_std_sync::Dir` instead of `wasi_cap_std_sync::dir::Dir`.

### DIFF
--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -5,11 +5,11 @@ pub use self::guest_memory::WasmiGuestMemory;
 pub use snapshots::preview_1::define_wasi;
 pub use wasi_cap_std_sync::{
     clocks,
-    dir::Dir,
     file::{filetype_from, get_fd_flags, File},
     net,
     sched,
     stdio,
+    Dir,
     WasiCtxBuilder,
 };
 pub use wasi_common::{Error, WasiCtx, WasiDir, WasiFile};


### PR DESCRIPTION
The former is re-exported from `cap-std`, which is the type used in `preopen_dir`, while the latter is the internal type of `wasi_cap_std_sync`. This change follows the behavior of `wasmtime-wasi`, and will reduce users' works on managing imports.

https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi/src/lib.rs#L15-L24