### PR TITLE
feat: make Module::imports be `pub`

### DIFF
--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -137,6 +137,8 @@ pub use self::{
         Module,
         ModuleError,
         ModuleExportsIter,
+        ModuleImport,
+        ModuleImportType,
         ModuleImportsIter,
         Read,
     },

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -137,6 +137,7 @@ pub use self::{
         Module,
         ModuleError,
         ModuleExportsIter,
+        ModuleImportsIter,
         Read,
     },
     store::{AsContext, AsContextMut, Store, StoreContext, StoreContextMut},

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -178,7 +178,7 @@ impl Module {
     }
 
     /// Returns an iterator over the imports of the [`Module`].
-    pub(crate) fn imports(&self) -> ModuleImportsIter {
+    pub fn imports(&self) -> ModuleImportsIter {
         let len_imported_funcs = self.imports.len_funcs;
         let len_imported_globals = self.imports.len_globals;
         ModuleImportsIter {

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -340,6 +340,8 @@ pub enum ModuleImportType {
     /// [`Memory`]: [`crate::Memory`]
     Memory(MemoryType),
     /// An imported [`Global`].
+    ///
+    /// [`Global`]: [`crate::Global`]
     Global(GlobalType),
 }
 

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -293,7 +293,7 @@ pub struct ModuleImport<'a> {
 
 impl<'a> ModuleImport<'a> {
     /// Creates a new [`ModuleImport`].
-    pub fn new<T>(name: &'a ImportName, ty: T) -> Self
+    pub(crate) fn new<T>(name: &'a ImportName, ty: T) -> Self
     where
         T: Into<ModuleImportType>,
     {
@@ -304,7 +304,7 @@ impl<'a> ModuleImport<'a> {
     }
 
     /// Returns the import name.
-    pub fn name(&self) -> &ImportName {
+    pub(crate) fn name(&self) -> &ImportName {
         self.name
     }
 


### PR DESCRIPTION
If we want to create stub function, we must need to know the imports info.

I think substrate also need this method to do `prepare_import` like wasmtime.