### PR TITLE
Make `wasmi` CLI print exported functions if `func_name` arg is missing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --no-default-features --target wasm32-unknown-unknown --exclude wasmi_wasi
+          args: --workspace --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
 
   test:
     name: Test


### PR DESCRIPTION
Before this change users had to provide a non-existing func name in order for the `wasmi` CLI to print out all exported function names such as `wasmi_cli fibonacci.wat foo`.
```
> wasmi_cli fibonacci.wat
Error: missing function name argument for fibonacci.wat

The Wasm module exports the following functions:

 - fn fib_recursive(i64) -> i64
 - fn fib_iterative(i64) -> i64
 ```