### PR TITLE
Make `Module::imports` iterator return `FuncType` instead of `DedupFuncType`

### DIFF
--- a/crates/wasmi/src/engine/func_types.rs
+++ b/crates/wasmi/src/engine/func_types.rs
@@ -1,7 +1,6 @@
 use super::{EngineIdx, Guarded};
-use crate::{FuncType, Store};
+use crate::FuncType;
 use wasmi_arena::{DedupArena, GuardedEntity, Index};
-use wasmi_core::ValueType;
 
 /// A raw index to a function signature entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -48,15 +47,6 @@ impl DedupFuncType {
     /// Returns the underlying stored representation.
     pub(super) fn into_inner(self) -> GuardedEntity<EngineIdx, DedupFuncTypeIdx> {
         self.0
-    }
-
-    /// Creates a new function signature to the store.
-    pub fn new<T, I, O>(ctx: &mut Store<T>, inputs: I, outputs: O) -> Self
-    where
-        I: IntoIterator<Item = ValueType>,
-        O: IntoIterator<Item = ValueType>,
-    {
-        ctx.alloc_func_type(FuncType::new(inputs, outputs))
     }
 }
 

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -376,11 +376,12 @@ impl<T> Linker<T> {
             ModuleImportType::Func(expected_func_type) => {
                 let func = resolved.and_then(Extern::into_func).ok_or_else(make_err)?;
                 let actual_func_type = func.signature(&context);
+                let actual_func_type = context.store.resolve_func_type(actual_func_type);
                 if &actual_func_type != expected_func_type {
                     return Err(LinkerError::FuncTypeMismatch {
                         name: import.name().clone(),
-                        expected: context.store.resolve_func_type(*expected_func_type),
-                        actual: context.store.resolve_func_type(actual_func_type),
+                        expected: expected_func_type.clone(),
+                        actual: actual_func_type,
                     })
                     .map_err(Into::into);
                 }

--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -1,9 +1,9 @@
 use super::ModuleImportType;
 use crate::{
-    engine::DedupFuncType,
     errors::{MemoryError, TableError},
     global::GlobalError,
     Extern,
+    FuncType,
     Table,
 };
 use core::{fmt, fmt::Display};
@@ -25,9 +25,9 @@ pub enum InstantiationError {
     /// Caused when a function has a mismatching signature.
     SignatureMismatch {
         /// The expected function signature for the function import.
-        expected: DedupFuncType,
+        expected: FuncType,
         /// The actual function signature for the function import.
-        actual: DedupFuncType,
+        actual: FuncType,
     },
     /// Occurs when an imported table does not satisfy the required table type.
     Table(TableError),

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     Error,
     Extern,
     FuncEntity,
+    FuncType,
     Global,
     Instance,
     InstanceEntity,
@@ -121,6 +122,9 @@ impl Module {
             match (import.item_type(), external) {
                 (ModuleImportType::Func(expected_signature), Extern::Func(func)) => {
                     let actual_signature = func.signature(context.as_context());
+                    let actual_signature = self
+                        .engine
+                        .resolve_func_type(actual_signature, FuncType::clone);
                     // Note: We can compare function signatures without resolving them because
                     //       we deduplicate them before registering. Therefore two equal instances of
                     //       [`SignatureEntity`] will be associated to the same [`Signature`].
@@ -128,7 +132,7 @@ impl Module {
                         // Note: In case of error we could resolve the signatures for better error readability.
                         return Err(InstantiationError::SignatureMismatch {
                             actual: actual_signature,
-                            expected: *expected_signature,
+                            expected: expected_signature.clone(),
                         });
                     }
                     builder.push_func(func);


### PR DESCRIPTION
From what I understand about the sparse description of the issue this PR closes https://github.com/paritytech/wasmi/issues/581.