### PR TITLE
Re-export ambient_authority.

### DIFF
--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -4,6 +4,7 @@ pub mod snapshots;
 pub use self::guest_memory::WasmiGuestMemory;
 pub use snapshots::preview_1::define_wasi;
 pub use wasi_cap_std_sync::{
+    ambient_authority,
     clocks,
     file::{filetype_from, get_fd_flags, File},
     net,


### PR DESCRIPTION
According to [docs](https://docs.rs/ambient-authority/latest/ambient_authority/), this function should be exported.

It is used when preopening a folder with `Dir::open_ambient_dir`.