### PR TITLE
Return `()` from `CallResults` for slices

### DIFF
--- a/crates/wasmi/src/engine/traits.rs
+++ b/crates/wasmi/src/engine/traits.rs
@@ -75,13 +75,12 @@ pub trait CallResults {
 }
 
 impl<'a> CallResults for &'a mut [Value] {
-    type Results = Self;
+    type Results = ();
 
     fn call_results(self, results: &[UntypedValue]) -> Self::Results {
         assert_eq!(self.len(), results.len());
         self.iter_mut().zip(results).for_each(|(dst, src)| {
             *dst = src.with_type(dst.value_type());
-        });
-        self
+        })
     }
 }


### PR DESCRIPTION
The return value was never used and thus can be removed. This may improve performance.

Maybe this micro optimizes certain use cases. (experiment)