### PR TITLE
Make `Engine`'s executor use `&mut StoreInner` (making it non-generic)

### DIFF
--- a/crates/arena/src/component_vec.rs
+++ b/crates/arena/src/component_vec.rs
@@ -1,4 +1,5 @@
 use crate::ArenaIndex;
+use alloc::vec::Vec;
 use core::{
     fmt::{self, Debug},
     marker::PhantomData,

--- a/crates/arena/src/component_vec.rs
+++ b/crates/arena/src/component_vec.rs
@@ -1,0 +1,151 @@
+use crate::ArenaIndex;
+use core::{
+    fmt::{self, Debug},
+    marker::PhantomData,
+    ops::{Index, IndexMut},
+};
+
+/// Stores components for entities backed by a [`Vec`].
+pub struct ComponentVec<Idx, T> {
+    components: Vec<Option<T>>,
+    marker: PhantomData<fn() -> Idx>,
+}
+
+/// [`ComponentVec`] does not store `Idx` therefore it is `Send` without its bound.
+unsafe impl<Idx, T> Send for ComponentVec<Idx, T> where T: Send {}
+
+/// [`ComponentVec`] does not store `Idx` therefore it is `Sync` without its bound.
+unsafe impl<Idx, T> Sync for ComponentVec<Idx, T> where T: Send {}
+
+impl<Idx, T> Debug for ComponentVec<Idx, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ComponentVec")
+            .field("components", &DebugComponents(&self.components))
+            .field("marker", &self.marker)
+            .finish()
+    }
+}
+
+struct DebugComponents<'a, T>(&'a [Option<T>]);
+
+impl<'a, T> Debug for DebugComponents<'a, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = f.debug_map();
+        let components = self
+            .0
+            .iter()
+            .enumerate()
+            .filter_map(|(n, component)| component.as_ref().map(|c| (n, c)));
+        for (idx, component) in components {
+            map.entry(&idx, component);
+        }
+        map.finish()
+    }
+}
+
+impl<Idx, T> Default for ComponentVec<Idx, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Idx, T> PartialEq for ComponentVec<Idx, T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.components.eq(&other.components)
+    }
+}
+
+impl<Idx, T> Eq for ComponentVec<Idx, T> where T: Eq {}
+
+impl<Idx, T> ComponentVec<Idx, T> {
+    /// Creates a new empty [`ComponentVec`].
+    pub fn new() -> Self {
+        Self {
+            components: Vec::new(),
+            marker: PhantomData,
+        }
+    }
+
+    /// Clears all components from the [`ComponentVec`].
+    pub fn clear(&mut self) {
+        self.components.clear();
+    }
+}
+
+impl<Idx, T> ComponentVec<Idx, T>
+where
+    Idx: ArenaIndex,
+{
+    /// Sets the `component` for the entity at `index`.
+    ///
+    /// Returns the old component of the same entity if any.
+    pub fn set(&mut self, index: Idx, component: T) -> Option<T> {
+        let index = index.into_usize();
+        if index >= self.components.len() {
+            // The underlying vector does not have enough capacity
+            // and is required to be enlarged.
+            self.components.resize_with(index + 1, || None);
+        }
+        self.components[index].replace(component)
+    }
+
+    /// Unsets the component for the entity at `index` and returns it if any.
+    pub fn unset(&mut self, index: Idx) -> Option<T> {
+        self.components
+            .get_mut(index.into_usize())
+            .and_then(Option::take)
+    }
+
+    /// Returns a shared reference to the component at the `index` if any.
+    ///
+    /// Returns `None` if no component is stored under the `index`.
+    #[inline]
+    pub fn get(&self, index: Idx) -> Option<&T> {
+        self.components
+            .get(index.into_usize())
+            .and_then(Option::as_ref)
+    }
+
+    /// Returns an exclusive reference to the component at the `index` if any.
+    ///
+    /// Returns `None` if no component is stored under the `index`.
+    #[inline]
+    pub fn get_mut(&mut self, index: Idx) -> Option<&mut T> {
+        self.components
+            .get_mut(index.into_usize())
+            .and_then(Option::as_mut)
+    }
+}
+
+impl<Idx, T> Index<Idx> for ComponentVec<Idx, T>
+where
+    Idx: ArenaIndex,
+{
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: Idx) -> &Self::Output {
+        self.get(index)
+            .unwrap_or_else(|| panic!("missing component at index: {}", index.into_usize()))
+    }
+}
+
+impl<Idx, T> IndexMut<Idx> for ComponentVec<Idx, T>
+where
+    Idx: ArenaIndex,
+{
+    #[inline]
+    fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
+        self.get_mut(index)
+            .unwrap_or_else(|| panic!("missing component at index: {}", index.into_usize()))
+    }
+}

--- a/crates/arena/src/lib.rs
+++ b/crates/arena/src/lib.rs
@@ -22,13 +22,14 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 
+mod component_vec;
 mod dedup;
 mod guarded;
 
 #[cfg(test)]
 mod tests;
 
-pub use self::{dedup::DedupArena, guarded::GuardedEntity};
+pub use self::{component_vec::ComponentVec, dedup::DedupArena, guarded::GuardedEntity};
 use alloc::vec::Vec;
 use core::{
     iter::{DoubleEndedIterator, Enumerate, ExactSizeIterator},

--- a/crates/wasmi/src/engine/cache.rs
+++ b/crates/wasmi/src/engine/cache.rs
@@ -101,6 +101,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a default linear memory.
+    #[inline]
     pub fn default_memory(&mut self, ctx: &StoreInner) -> Memory {
         match self.default_memory {
             Some(default_memory) => default_memory,
@@ -113,6 +114,7 @@ impl InstanceCache {
     /// # Note
     ///
     /// This avoids one indirection compared to using the `default_memory`.
+    #[inline]
     pub fn default_memory_bytes(&mut self, ctx: &mut StoreInner) -> &mut CachedMemoryBytes {
         match self.default_memory_bytes {
             Some(ref mut cached) => cached,
@@ -140,6 +142,7 @@ impl InstanceCache {
     /// - Conservatively it is also recommended to reset default memory bytes
     ///   when calling a host function since that might invalidate linear memory
     ///   without the Wasm engine knowing.
+    #[inline]
     pub fn reset_default_memory_bytes(&mut self) {
         self.default_memory_bytes = None;
     }
@@ -149,6 +152,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a default table.
+    #[inline]
     pub fn default_table(&mut self, ctx: &StoreInner) -> Table {
         match self.default_table {
             Some(default_table) => default_table,
@@ -180,6 +184,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a [`Func`] at the index.
+    #[inline]
     pub fn get_func(&mut self, ctx: &StoreInner, func_idx: u32) -> Func {
         match self.last_func {
             Some((index, func)) if index == func_idx => func,
@@ -214,6 +219,7 @@ impl InstanceCache {
     /// # Panics
     ///
     /// If the currently used [`Instance`] does not have a [`Func`] at the index.
+    #[inline]
     pub fn get_global(&mut self, ctx: &mut StoreInner, global_idx: u32) -> &mut UntypedValue {
         let mut ptr = match self.last_global {
             Some((index, global)) if index == global_idx => global,

--- a/crates/wasmi/src/engine/cache.rs
+++ b/crates/wasmi/src/engine/cache.rs
@@ -1,9 +1,9 @@
 use crate::{
     module::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX},
-    store::StoreInner,
     Func,
     Instance,
     Memory,
+    StoreInner,
     Table,
 };
 use core::ptr::NonNull;

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -4,7 +4,6 @@ use super::{
     cache::InstanceCache,
     code_map::InstructionPtr,
     stack::ValueStackRef,
-    AsContextMut,
     CallOutcome,
     DropKeep,
     FuncFrame,
@@ -26,18 +25,12 @@ use wasmi_core::{Pages, UntypedValue};
 /// - If the execution of the function `frame` trapped.
 #[inline(always)]
 pub fn execute_frame<'engine>(
-    mut ctx: impl AsContextMut,
+    ctx: &mut StoreInner,
     value_stack: &'engine mut ValueStack,
     cache: &'engine mut InstanceCache,
     frame: &mut FuncFrame,
 ) -> Result<CallOutcome, TrapCode> {
-    Executor::new(
-        value_stack,
-        &mut ctx.as_context_mut().store.inner,
-        cache,
-        frame,
-    )
-    .execute()
+    Executor::new(value_stack, ctx, cache, frame).execute()
 }
 
 /// The function signature of Wasm load operations.

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -714,7 +714,7 @@ impl<'engine> EngineExecutor<'engine> {
     #[inline(always)]
     fn execute_frame(
         &mut self,
-        ctx: impl AsContextMut,
+        mut ctx: impl AsContextMut,
         frame: &mut FuncFrame,
         cache: &mut InstanceCache,
     ) -> Result<CallOutcome, Trap> {
@@ -729,6 +729,12 @@ impl<'engine> EngineExecutor<'engine> {
         }
 
         let value_stack = &mut self.stack.values;
-        execute_frame(ctx, value_stack, cache, frame).map_err(make_trap)
+        execute_frame(
+            &mut ctx.as_context_mut().store.inner,
+            value_stack,
+            cache,
+            frame,
+        )
+        .map_err(make_trap)
     }
 }

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -292,12 +292,4 @@ impl Global {
     pub fn get(&self, ctx: impl AsContext) -> Value {
         ctx.as_context().store.resolve_global(*self).get()
     }
-
-    /// Returns a pointer to the untyped value of the global variable.
-    pub(crate) fn get_untyped_ptr(&self, mut ctx: impl AsContextMut) -> NonNull<UntypedValue> {
-        ctx.as_context_mut()
-            .store
-            .resolve_global_mut(*self)
-            .get_untyped_ptr()
-    }
 }

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -366,19 +366,6 @@ impl Instance {
             .get_func(index)
     }
 
-    /// Returns the signature at the `index` if any.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `store` does not own this [`Instance`].
-    pub(crate) fn get_signature(&self, store: impl AsContext, index: u32) -> Option<DedupFuncType> {
-        store
-            .as_context()
-            .store
-            .resolve_instance(*self)
-            .get_signature(index)
-    }
-
     /// Returns the value exported to the given `name` if any.
     ///
     /// # Panics

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -353,45 +353,6 @@ impl Instance {
         self.0
     }
 
-    /// Returns the linear memory at the `index` if any.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `store` does not own this [`Instance`].
-    pub(crate) fn get_memory(&self, store: impl AsContext, index: u32) -> Option<Memory> {
-        store
-            .as_context()
-            .store
-            .resolve_instance(*self)
-            .get_memory(index)
-    }
-
-    /// Returns the table at the `index` if any.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `store` does not own this [`Instance`].
-    pub(crate) fn get_table(&self, store: impl AsContext, index: u32) -> Option<Table> {
-        store
-            .as_context()
-            .store
-            .resolve_instance(*self)
-            .get_table(index)
-    }
-
-    /// Returns the global variable at the `index` if any.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `store` does not own this [`Instance`].
-    pub(crate) fn get_global(&self, store: impl AsContext, index: u32) -> Option<Global> {
-        store
-            .as_context()
-            .store
-            .resolve_instance(*self)
-            .get_global(index)
-    }
-
     /// Returns the function at the `index` if any.
     ///
     /// # Panics

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -158,6 +158,6 @@ use self::{
     global::{GlobalEntity, GlobalIdx},
     instance::{InstanceEntity, InstanceEntityBuilder, InstanceIdx},
     memory::{MemoryEntity, MemoryIdx},
-    store::Stored,
+    store::{StoreInner, Stored},
     table::{TableEntity, TableIdx},
 };

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -35,8 +35,8 @@ fn instantiate_from_wat(wat: &str) -> (Store<()>, Instance) {
 }
 
 fn assert_no_duplicates(store: &Store<()>, instance: Instance) {
-    assert!(instance.get_memory(store, 1).is_none());
-    assert!(instance.get_table(store, 1).is_none());
+    assert!(store.resolve_instance(instance).get_memory(1).is_none());
+    assert!(store.resolve_instance(instance).get_table(1).is_none());
 }
 
 #[test]
@@ -47,8 +47,8 @@ fn test_import_memory_and_table() {
             (import "env" "table" (table 4 funcref))
         )"#;
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(instance.get_memory(&store, 0).is_some());
-    assert!(instance.get_table(&store, 0).is_some());
+    assert!(store.resolve_instance(instance).get_memory(0).is_some());
+    assert!(store.resolve_instance(instance).get_table(0).is_some());
     assert_no_duplicates(&store, instance);
 }
 
@@ -59,8 +59,8 @@ fn test_import_memory() {
             (import "env" "memory" (memory 4))
         )"#;
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(instance.get_memory(&store, 0).is_some());
-    assert!(instance.get_table(&store, 0).is_none());
+    assert!(store.resolve_instance(instance).get_memory(0).is_some());
+    assert!(store.resolve_instance(instance).get_table(0).is_none());
     assert_no_duplicates(&store, instance);
 }
 
@@ -71,8 +71,8 @@ fn test_import_table() {
             (import "env" "table" (table 4 funcref))
         )"#;
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(instance.get_memory(&store, 0).is_none());
-    assert!(instance.get_table(&store, 0).is_some());
+    assert!(store.resolve_instance(instance).get_memory(0).is_none());
+    assert!(store.resolve_instance(instance).get_table(0).is_some());
     assert_no_duplicates(&store, instance);
 }
 
@@ -80,8 +80,8 @@ fn test_import_table() {
 fn test_no_memory_no_table() {
     let wat = "(module)";
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(instance.get_memory(&store, 0).is_none());
-    assert!(instance.get_table(&store, 0).is_none());
+    assert!(store.resolve_instance(instance).get_memory(0).is_none());
+    assert!(store.resolve_instance(instance).get_table(0).is_none());
     assert_no_duplicates(&store, instance);
 }
 
@@ -89,8 +89,8 @@ fn test_no_memory_no_table() {
 fn test_internal_memory() {
     let wat = "(module (memory 1 10) )";
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(instance.get_memory(&store, 0).is_some());
-    assert!(instance.get_table(&store, 0).is_none());
+    assert!(store.resolve_instance(instance).get_memory(0).is_some());
+    assert!(store.resolve_instance(instance).get_table(0).is_none());
     assert_no_duplicates(&store, instance);
 }
 
@@ -98,7 +98,7 @@ fn test_internal_memory() {
 fn test_internal_table() {
     let wat = "(module (table 4 funcref) )";
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(instance.get_memory(&store, 0).is_none());
-    assert!(instance.get_table(&store, 0).is_some());
+    assert!(store.resolve_instance(instance).get_memory(0).is_none());
+    assert!(store.resolve_instance(instance).get_table(0).is_some());
     assert_no_duplicates(&store, instance);
 }

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -22,7 +22,7 @@ use core::{
     fmt::Debug,
     sync::atomic::{AtomicU32, Ordering},
 };
-use wasmi_arena::{Arena, ArenaIndex, GuardedEntity};
+use wasmi_arena::{Arena, ArenaIndex, ComponentVec, GuardedEntity};
 
 /// A unique store index.
 ///
@@ -81,6 +81,13 @@ pub struct StoreInner {
     ///
     /// Used to protect against invalid entity indices.
     store_idx: StoreIdx,
+    /// Stores the function type for each function.
+    ///
+    /// # Note
+    ///
+    /// This is required so that the [`Engine`] can work entirely
+    /// with a `&mut StoreInner` reference.
+    func_types: ComponentVec<FuncIdx, DedupFuncType>,
     /// Stored linear memories.
     memories: Arena<MemoryIdx, MemoryEntity>,
     /// Stored tables.
@@ -111,6 +118,7 @@ impl StoreInner {
         StoreInner {
             engine: engine.clone(),
             store_idx: StoreIdx::new(),
+            func_types: ComponentVec::new(),
             memories: Arena::new(),
             tables: Arena::new(),
             globals: Arena::new(),
@@ -157,6 +165,31 @@ impl StoreInner {
                 stored, self.store_idx,
             )
         })
+    }
+
+    /// Registers the `func_type` for the given `func`.
+    ///
+    /// # Note
+    ///
+    /// This is required so that the [`Engine`] can work entirely
+    /// with a `&mut StoreInner` reference.
+    pub fn register_func_type(&mut self, func: Func, func_type: DedupFuncType) {
+        let idx = self.unwrap_stored(func.into_inner());
+        let previous = self.func_types.set(idx, func_type);
+        debug_assert!(previous.is_none());
+    }
+
+    /// Returns the [`DedupFuncType`] for the given [`Func`].
+    ///
+    /// # Note
+    ///
+    /// Panics if no [`DedupFuncType`] for the given [`Func`] was registered.
+    pub fn get_func_type(&self, func: Func) -> DedupFuncType {
+        let idx = self.unwrap_stored(func.into_inner());
+        self.func_types
+            .get(idx)
+            .copied()
+            .unwrap_or_else(|| panic!("missing function type for func: {:?}", func))
     }
 
     /// Allocates a new [`GlobalEntity`] and returns a [`Global`] reference to it.
@@ -435,8 +468,11 @@ impl<T> Store<T> {
 
     /// Allocates a new Wasm or host [`FuncEntity`] and returns a [`Func`] reference to it.
     pub(super) fn alloc_func(&mut self, func: FuncEntity<T>) -> Func {
-        let func = self.funcs.alloc(func);
-        Func::from_inner(self.wrap_stored(func))
+        let func_type = func.signature();
+        let idx = self.funcs.alloc(func);
+        let func = Func::from_inner(self.wrap_stored(idx));
+        self.inner.register_func_type(func, func_type);
+        func
     }
 
     /// Allocates a new uninitialized [`InstanceEntity`] and returns an [`Instance`] reference to it.

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -62,9 +62,9 @@ pub type Stored<Idx> = GuardedEntity<StoreIdx, Idx>;
 #[derive(Debug)]
 pub struct Store<T> {
     /// All data that is not associated to `T`.
-    /// 
+    ///
     /// # Note
-    /// 
+    ///
     /// This is re-exported to the rest of the crate since
     /// it is used directly by the engine's executor.
     pub(crate) inner: StoreInner,

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -189,7 +189,7 @@ impl StoreInner {
         self.func_types
             .get(idx)
             .copied()
-            .unwrap_or_else(|| panic!("missing function type for func: {:?}", func))
+            .unwrap_or_else(|| panic!("missing function type for func: {func:?}"))
     }
 
     /// Allocates a new [`GlobalEntity`] and returns a [`Global`] reference to it.

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -62,7 +62,12 @@ pub type Stored<Idx> = GuardedEntity<StoreIdx, Idx>;
 #[derive(Debug)]
 pub struct Store<T> {
     /// All data that is not associated to `T`.
-    inner: StoreInner,
+    /// 
+    /// # Note
+    /// 
+    /// This is re-exported to the rest of the crate since
+    /// it is used directly by the engine's executor.
+    pub(crate) inner: StoreInner,
     /// Stored Wasm or host functions.
     funcs: Arena<FuncIdx, FuncEntity<T>>,
     /// User provided state.


### PR DESCRIPTION
This PR technically prepares `wasmi` for using the new `#[union_fn]` macro.
Before this PR the `Engine` executor was generic over a `ctx: impl AsContextMut` which is no longer required since the `Engine` executor now works given a non-generic `&mut StoreInner`. The `StoreInner` is a non-generic abstraction of the `Store<T>` type which holds all the data that is not associated to the `T` in `Store<T>`.