### PR TITLE
Remove `ModuleError` export from crate root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Changed
 
-- Removed `ModuleError` export from crate root.
+- Removed `ModuleError` export from crate root. (https://github.com/paritytech/wasmi/pull/618)
   - Now `ModuleError` is exported from `crate::errors` just like all the other error types.
 - Mirror Wasmtime API more closely. (https://github.com/paritytech/wasmi/pull/615, https://github.com/paritytech/wasmi/pull/616)
   - Renamed `Caller::host_data` method to `Caller::data`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ## [`x.y.z`] - UNRELEASED
 
-### Changed
+### Added
 
 - Add `Module::get_export` method. (https://github.com/paritytech/wasmi/pull/617)
+
+### Changed
+
+- Removed `ModuleError` export from crate root.
+  - Now `ModuleError` is exported from `crate::errors` just like all the other error types.
 - Mirror Wasmtime API more closely. (https://github.com/paritytech/wasmi/pull/615, https://github.com/paritytech/wasmi/pull/616)
   - Renamed `Caller::host_data` method to `Caller::data`.
   - Renamed `Caller::host_data_mut` method to `Caller::data_mut`.

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -139,7 +139,6 @@ pub use self::{
         ImportType,
         InstancePre,
         Module,
-        ModuleError,
         ModuleExportsIter,
         ModuleImportsIter,
         Read,

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -14,11 +14,11 @@ use super::{
 };
 use crate::{
     engine::{DedupFuncType, FuncBody},
+    errors::ModuleError,
     Engine,
     FuncType,
     GlobalType,
     MemoryType,
-    ModuleError,
     TableType,
 };
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};

--- a/crates/wasmi/src/module/compile/mod.rs
+++ b/crates/wasmi/src/module/compile/mod.rs
@@ -2,8 +2,8 @@ pub use self::block_type::BlockType;
 use super::{parser::ReusableAllocations, FuncIdx, ModuleResources};
 use crate::{
     engine::{FuncBody, FuncBuilder, FunctionBuilderAllocations},
+    errors::ModuleError,
     Engine,
-    ModuleError,
 };
 use wasmparser::{FuncValidator, FunctionBody, ValidatorResources};
 

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -1,4 +1,5 @@
-use super::{InitExpr, MemoryIdx, ModuleError};
+use super::{InitExpr, MemoryIdx};
+use crate::errors::ModuleError;
 use alloc::boxed::Box;
 
 /// A linear memory data segment within a [`Module`].

--- a/crates/wasmi/src/module/element.rs
+++ b/crates/wasmi/src/module/element.rs
@@ -1,7 +1,6 @@
-use crate::ModuleError;
-use alloc::{boxed::Box, vec::Vec};
-
 use super::{FuncIdx, InitExpr, TableIdx};
+use crate::errors::ModuleError;
+use alloc::{boxed::Box, vec::Vec};
 
 /// A table element segment within a [`Module`].
 ///

--- a/crates/wasmi/src/module/export.rs
+++ b/crates/wasmi/src/module/export.rs
@@ -1,5 +1,5 @@
 use super::GlobalIdx;
-use crate::{ExternType, Module, ModuleError};
+use crate::{errors::ModuleError, ExternType, Module};
 use alloc::{boxed::Box, collections::btree_map::Iter as BTreeIter};
 
 /// The index of a function declaration within a [`Module`].

--- a/crates/wasmi/src/module/global.rs
+++ b/crates/wasmi/src/module/global.rs
@@ -1,5 +1,5 @@
 use super::InitExpr;
-use crate::{GlobalType, ModuleError};
+use crate::{errors::ModuleError, GlobalType};
 
 /// The index of a global variable within a [`Module`].
 ///

--- a/crates/wasmi/src/module/import.rs
+++ b/crates/wasmi/src/module/import.rs
@@ -1,4 +1,4 @@
-use crate::{GlobalType, MemoryType, ModuleError, TableType};
+use crate::{errors::ModuleError, GlobalType, MemoryType, TableType};
 use alloc::boxed::Box;
 use core::fmt::{self, Display};
 use wasmparser::TypeRef;

--- a/crates/wasmi/src/module/init_expr.rs
+++ b/crates/wasmi/src/module/init_expr.rs
@@ -1,5 +1,5 @@
 use super::GlobalIdx;
-use crate::ModuleError;
+use crate::errors::ModuleError;
 use wasmi_core::{Value, F32, F64};
 
 /// An initializer expression.

--- a/crates/wasmi/src/module/utils.rs
+++ b/crates/wasmi/src/module/utils.rs
@@ -1,4 +1,4 @@
-use crate::{FuncType, GlobalType, MemoryType, ModuleError, Mutability, TableType};
+use crate::{errors::ModuleError, FuncType, GlobalType, MemoryType, Mutability, TableType};
 use wasmi_core::ValueType;
 
 impl TryFrom<wasmparser::TableType> for TableType {


### PR DESCRIPTION
Now `ModuleError` lives under `crate::errors` just like all other error types.