### PR TITLE
Clean-up and improve Wasm spec test

### DIFF
--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -48,13 +48,13 @@ impl Display for MemoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::OutOfBoundsAllocation => {
-                write!(f, "tried to allocate too much virtual memory")
+                write!(f, "out of bounds linear memory allocation")
             }
             Self::OutOfBoundsGrowth => {
-                write!(f, "tried to grow virtual memory out of bounds")
+                write!(f, "out fo bounds linear memory growth")
             }
             Self::OutOfBoundsAccess => {
-                write!(f, "tried to access virtual memory out of bounds")
+                write!(f, "out of bounds linear memory access")
             }
             Self::InvalidMemoryType => {
                 write!(f, "tried to create an invalid virtual memory type")

--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -77,7 +77,7 @@ impl Display for InstantiationError {
                 amount,
             } => write!(
                 f,
-                "table {table:?} does not fit {offset} elements starting from offset {amount}",
+                "out of bounds: table {table:?} does not fit {amount} elements starting from offset {offset}",
             ),
             Self::FoundStartFn { index } => {
                 write!(f, "found an unexpected start function with index {index}")

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -161,7 +161,11 @@ mod bulk_memory {
     }
 
     define_spec_tests! {
-        // TODO: comment
+        // Even though `wasmi` does not implement the `bulk-memory` Wasm proposal
+        // at the time of this writing we run this specific test from its test suite
+        // because `wasmi` already uses the changed semantics for segment instantiation
+        // coming from the `bulk-memory` Wasm proposal.
+        // This is why the other `linking` tests are expected to fail.
         fn wasm_linking("proposals/bulk-memory-operations/linking");
     }
 }

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -140,13 +140,29 @@ mod mutable_global {
 
     define_spec_tests! {
         fn wasm_globals("proposals/mutable-global/globals");
-        // We ignore this test case temporarily because `wasmi` already implements
+        // We expect failure for this test case temporarily because `wasmi` already implements
         // the intended behavior using the semantics introduced in the `bulk-memory`
         // Wasm proposal withot having `bulk-memory` Wasm proposal support:
         // https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md#segment-initialization
         //
         // Unignore the test case and remove this comment once `bulk-memory` has been implemented.
-        #[ignore] fn wasm_linking("proposals/mutable-global/linking");
+        #[should_panic] fn wasm_linking("proposals/mutable-global/linking");
+    }
+}
+
+mod bulk_memory {
+    use super::mvp_config;
+
+    /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
+    fn run_wasm_spec_test(file_name: &str) {
+        let mut config = mvp_config();
+        config.wasm_mutable_global(true);
+        super::run::run_wasm_spec_test(file_name, config)
+    }
+
+    define_spec_tests! {
+        // TODO: comment
+        fn wasm_linking("proposals/bulk-memory-operations/linking");
     }
 }
 
@@ -195,13 +211,13 @@ define_spec_tests! {
     fn wasm_int_literals("int_literals");
     fn wasm_labels("labels");
     fn wasm_left_to_right("left-to-right");
-    // We ignore this test case temporarily because `wasmi` already implements
+    // We expect failure for this test case temporarily because `wasmi` already implements
     // the intended behavior using the semantics introduced in the `bulk-memory`
     // Wasm proposal withot having `bulk-memory` Wasm proposal support:
     // https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md#segment-initialization
     //
     // Unignore the test case and remove this comment once `bulk-memory` has been implemented.
-    #[ignore] fn wasm_linking("linking");
+    #[should_panic] fn wasm_linking("linking");
     fn wasm_loop("loop");
     fn wasm_load("load");
     fn wasm_local_get("local_get");
@@ -227,6 +243,9 @@ define_spec_tests! {
     fn wasm_type("type");
     fn wasm_typecheck("typecheck");
     fn wasm_unreachable("unreachable");
+    // I do not remember why we ignored this test but it might either be
+    // due to some updated semantics in Wasm proposals that we already
+    // implement or due to actual bugs in `wasmi`. Need to
     #[ignore] fn wasm_unreached_invalid("unreached-invalid");
     fn wasm_unwind("unwind");
     fn wasm_utf8_custom_section_id("utf8-custom-section-id");

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -249,7 +249,7 @@ define_spec_tests! {
     fn wasm_unreachable("unreachable");
     // I do not remember why we ignored this test but it might either be
     // due to some updated semantics in Wasm proposals that we already
-    // implement or due to actual bugs in `wasmi`. Need to
+    // implement or due to actual bugs in `wasmi`. Need to investigate.
     #[ignore] fn wasm_unreached_invalid("unreached-invalid");
     fn wasm_unwind("unwind");
     fn wasm_utf8_custom_section_id("utf8-custom-section-id");

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -128,6 +128,28 @@ mod multi_value {
     }
 }
 
+mod mutable_global {
+    use super::mvp_config;
+
+    /// Run Wasm spec test suite using `multi-value` Wasm proposal enabled.
+    fn run_wasm_spec_test(file_name: &str) {
+        let mut config = mvp_config();
+        config.wasm_mutable_global(true);
+        super::run::run_wasm_spec_test(file_name, config)
+    }
+
+    define_spec_tests! {
+        fn wasm_globals("proposals/mutable-global/globals");
+        // We ignore this test case temporarily because `wasmi` already implements
+        // the intended behavior using the semantics introduced in the `bulk-memory`
+        // Wasm proposal withot having `bulk-memory` Wasm proposal support:
+        // https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md#segment-initialization
+        //
+        // Unignore the test case and remove this comment once `bulk-memory` has been implemented.
+        #[ignore] fn wasm_linking("proposals/mutable-global/linking");
+    }
+}
+
 define_spec_tests! {
     fn wasm_address("address");
     fn wasm_align("align");
@@ -173,6 +195,12 @@ define_spec_tests! {
     fn wasm_int_literals("int_literals");
     fn wasm_labels("labels");
     fn wasm_left_to_right("left-to-right");
+    // We ignore this test case temporarily because `wasmi` already implements
+    // the intended behavior using the semantics introduced in the `bulk-memory`
+    // Wasm proposal withot having `bulk-memory` Wasm proposal support:
+    // https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md#segment-initialization
+    //
+    // Unignore the test case and remove this comment once `bulk-memory` has been implemented.
     #[ignore] fn wasm_linking("linking");
     fn wasm_loop("loop");
     fn wasm_load("load");

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -201,6 +201,21 @@ fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message
     match error {
         TestError::Wasmi(WasmiError::Trap(trap)) if trap.trap_code().is_some() => {
             let code = trap.trap_code().unwrap();
+            if code.trap_message() == "uninitialized element" && message == "uninitialized"
+            {
+                // Fixes inconsistencies in the official Wasm spec test suite.
+                return;
+            }
+            if code.trap_message() == "undefined element" && message == "undefined"
+            {
+                // Fixes inconsistencies in the official Wasm spec test suite.
+                return;
+            }
+            if code.trap_message() == "indirect call type mismatch" && message == "indirect call"
+            {
+                // Fixes inconsistencies in the official Wasm spec test suite.
+                return;
+            }
             assert_eq!(
                 code.trap_message(),
                 message,

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -207,7 +207,7 @@ fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message
                     encountered: {}",
                 test_context.spanned(span),
                 message,
-                error.to_string(),
+                error,
             );
         }
         unexpected => panic!(

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -1,6 +1,6 @@
 use super::{error::TestError, TestContext, TestDescriptor};
 use anyhow::Result;
-use wasmi::{Config, Error as WasmiError};
+use wasmi::Config;
 use wasmi_core::{Value, F32, F64};
 use wast::{
     lexer::Lexer,
@@ -199,28 +199,15 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
 /// - If the trap message of the `error` is not as expected.
 fn assert_trap(test_context: &TestContext, span: Span, error: TestError, message: &str) {
     match error {
-        TestError::Wasmi(WasmiError::Trap(trap)) if trap.trap_code().is_some() => {
-            let code = trap.trap_code().unwrap();
-            if code.trap_message() == "uninitialized element" && message == "uninitialized"
-            {
-                // Fixes inconsistencies in the official Wasm spec test suite.
-                return;
-            }
-            if code.trap_message() == "undefined element" && message == "undefined"
-            {
-                // Fixes inconsistencies in the official Wasm spec test suite.
-                return;
-            }
-            if code.trap_message() == "indirect call type mismatch" && message == "indirect call"
-            {
-                // Fixes inconsistencies in the official Wasm spec test suite.
-                return;
-            }
-            assert_eq!(
-                code.trap_message(),
-                message,
-                "{}: the directive trapped as expected but with an unexpected message",
+        TestError::Wasmi(error) => {
+            assert!(
+                error.to_string().starts_with(message),
+                "{}: the directive trapped as expected but with an unexpected message\n\
+                    expected: {},\n\
+                    encountered: {}",
                 test_context.spanned(span),
+                message,
+                error.to_string(),
             );
         }
         unexpected => panic!(


### PR DESCRIPTION
If the Wasm spec test suite expects a trap, then the trap message no longer has to fully match the expected trap message. Instead it now only has to start with the exact same characters. This allows for `wasmi` to provide more information to users and still kind of abide to the general expected trap messages.

Also this PR adds tests from the `mutable-global` Wasm proposal and introduces a temporary fix for the long standing `linking` test failure. This temporary fix will be gone when `wasmi` implements the `bulk-memory` Wasm proposal.