### PR TITLE
Use references where possible in `Store` and `StoreInner`

### DIFF
--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -528,7 +528,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let table = self.default_table();
         let func = self
             .ctx
-            .resolve_table(table)
+            .resolve_table(&table)
             .get(func_index)
             .map_err(|_| TrapCode::TableOutOfBounds)?
             .ok_or(TrapCode::IndirectCallToNull)?;
@@ -570,7 +570,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
 
     fn visit_current_memory(&mut self) {
         let memory = self.default_memory();
-        let result: u32 = self.ctx.resolve_memory(memory).current_pages().into();
+        let result: u32 = self.ctx.resolve_memory(&memory).current_pages().into();
         self.value_stack.push(result);
         self.next_instr()
     }
@@ -582,7 +582,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let memory = self.default_memory();
         let result = Pages::new(self.value_stack.pop_as()).map_or(ERR_VALUE, |additional| {
             self.ctx
-                .resolve_memory_mut(memory)
+                .resolve_memory_mut(&memory)
                 .grow(additional)
                 .map(u32::from)
                 .unwrap_or(ERR_VALUE)

--- a/crates/wasmi/src/engine/func_types.rs
+++ b/crates/wasmi/src/engine/func_types.rs
@@ -117,7 +117,7 @@ impl FuncTypeRegistry {
     ///
     /// - If the deduplicated function type is not owned by the engine.
     /// - If the deduplicated function type cannot be resolved to its entity.
-    pub(crate) fn resolve_func_type(&self, func_type: DedupFuncType) -> &FuncType {
+    pub(crate) fn resolve_func_type(&self, func_type: &DedupFuncType) -> &FuncType {
         let entity_index = self.unwrap_index(func_type.into_inner());
         self.func_types
             .get(entity_index)

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -142,7 +142,7 @@ impl Engine {
     ///
     /// - If the deduplicated function type is not owned by the engine.
     /// - If the deduplicated function type cannot be resolved to its entity.
-    pub(super) fn resolve_func_type<F, R>(&self, func_type: DedupFuncType, f: F) -> R
+    pub(super) fn resolve_func_type<F, R>(&self, func_type: &DedupFuncType, f: F) -> R
     where
         F: FnOnce(&FuncType) -> R,
     {
@@ -371,7 +371,7 @@ impl EngineInner {
             .alloc(len_locals, max_stack_height, insts)
     }
 
-    fn resolve_func_type<F, R>(&self, func_type: DedupFuncType, f: F) -> R
+    fn resolve_func_type<F, R>(&self, func_type: &DedupFuncType, f: F) -> R
     where
         F: FnOnce(&FuncType) -> R,
     {

--- a/crates/wasmi/src/engine/stack/frames.rs
+++ b/crates/wasmi/src/engine/stack/frames.rs
@@ -36,8 +36,8 @@ impl FuncFrame {
     }
 
     /// Returns the instance of the [`FuncFrame`].
-    pub fn instance(&self) -> Instance {
-        self.instance
+    pub fn instance(&self) -> &Instance {
+        &self.instance
     }
 }
 

--- a/crates/wasmi/src/engine/stack/mod.rs
+++ b/crates/wasmi/src/engine/stack/mod.rs
@@ -260,7 +260,7 @@ impl Stack {
         &mut self,
         mut ctx: C,
         host_func: HostFuncEntity<<C as AsContext>::UserState>,
-        instance: Option<Instance>,
+        instance: Option<&Instance>,
         func_types: &FuncTypeRegistry,
     ) -> Result<(), Trap>
     where

--- a/crates/wasmi/src/engine/tests.rs
+++ b/crates/wasmi/src/engine/tests.rs
@@ -58,7 +58,7 @@ fn assert_func_body<E>(
             actual,
             expected,
             "encountered instruction mismatch for {} at position {index}",
-            engine.resolve_func_type(func_type, Clone::clone),
+            engine.resolve_func_type(&func_type, Clone::clone),
         );
     }
     if let Some(unexpected) = engine.resolve_inst(func_body, len_expected) {

--- a/crates/wasmi/src/func/caller.rs
+++ b/crates/wasmi/src/func/caller.rs
@@ -15,13 +15,13 @@ pub struct Caller<'a, T> {
 
 impl<'a, T> Caller<'a, T> {
     /// Creates a new [`Caller`] from the given store context and [`Instance`] handle.
-    pub(crate) fn new<C>(ctx: &'a mut C, instance: Option<Instance>) -> Self
+    pub(crate) fn new<C>(ctx: &'a mut C, instance: Option<&Instance>) -> Self
     where
         C: AsContextMut<UserState = T>,
     {
         Self {
             store: ctx.as_context_mut(),
-            instance,
+            instance: instance.copied(),
         }
     }
 

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -246,7 +246,7 @@ impl Func {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn to_inner(&self) -> &Stored<FuncIdx> {
+    pub(super) fn as_inner(&self) -> &Stored<FuncIdx> {
         &self.0
     }
 

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -226,7 +226,7 @@ impl Global {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn to_inner(&self) -> &Stored<GlobalIdx> {
+    pub(super) fn as_inner(&self) -> &Stored<GlobalIdx> {
         &self.0
     }
 

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -226,8 +226,8 @@ impl Global {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn into_inner(self) -> Stored<GlobalIdx> {
-        self.0
+    pub(super) fn to_inner(&self) -> &Stored<GlobalIdx> {
+        &self.0
     }
 
     /// Creates a new global variable to the store.
@@ -240,7 +240,7 @@ impl Global {
 
     /// Returns the [`GlobalType`] of the global variable.
     pub fn ty(&self, ctx: impl AsContext) -> GlobalType {
-        ctx.as_context().store.inner.resolve_global(*self).ty()
+        ctx.as_context().store.inner.resolve_global(self).ty()
     }
 
     /// Sets a new value to the global variable.
@@ -257,7 +257,7 @@ impl Global {
         ctx.as_context_mut()
             .store
             .inner
-            .resolve_global_mut(*self)
+            .resolve_global_mut(self)
             .set(new_value)
     }
 
@@ -267,6 +267,6 @@ impl Global {
     ///
     /// Panics if `ctx` does not own this [`Global`].
     pub fn get(&self, ctx: impl AsContext) -> Value {
-        ctx.as_context().store.inner.resolve_global(*self).get()
+        ctx.as_context().store.inner.resolve_global(self).get()
     }
 }

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -425,8 +425,8 @@ impl Instance {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn into_inner(self) -> Stored<InstanceIdx> {
-        self.0
+    pub(super) fn to_inner(&self) -> &Stored<InstanceIdx> {
+        &self.0
     }
 
     /// Returns the function at the `index` if any.
@@ -439,7 +439,7 @@ impl Instance {
             .as_context()
             .store
             .inner
-            .resolve_instance(*self)
+            .resolve_instance(self)
             .get_func(index)
     }
 
@@ -453,7 +453,7 @@ impl Instance {
             .as_context()
             .store
             .inner
-            .resolve_instance(*self)
+            .resolve_instance(self)
             .get_export(name)
     }
 
@@ -545,6 +545,6 @@ impl Instance {
         &self,
         store: impl Into<StoreContext<'ctx, T>>,
     ) -> ExportsIter<'ctx> {
-        store.into().store.inner.resolve_instance(*self).exports()
+        store.into().store.inner.resolve_instance(self).exports()
     }
 }

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -425,7 +425,7 @@ impl Instance {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn to_inner(&self) -> &Stored<InstanceIdx> {
+    pub(super) fn as_inner(&self) -> &Stored<InstanceIdx> {
         &self.0
     }
 

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -260,7 +260,7 @@ impl Memory {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn to_inner(&self) -> &Stored<MemoryIdx> {
+    pub(super) fn as_inner(&self) -> &Stored<MemoryIdx> {
         &self.0
     }
 

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -260,8 +260,8 @@ impl Memory {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn into_inner(self) -> Stored<MemoryIdx> {
-        self.0
+    pub(super) fn to_inner(&self) -> &Stored<MemoryIdx> {
+        &self.0
     }
 
     /// Creates a new linear memory to the store.
@@ -281,7 +281,7 @@ impl Memory {
     ///
     /// Panics if `ctx` does not own this [`Memory`].
     pub fn ty(&self, ctx: impl AsContext) -> MemoryType {
-        ctx.as_context().store.inner.resolve_memory(*self).ty()
+        ctx.as_context().store.inner.resolve_memory(self).ty()
     }
 
     /// Returns the amount of pages in use by the linear memory.
@@ -293,7 +293,7 @@ impl Memory {
         ctx.as_context()
             .store
             .inner
-            .resolve_memory(*self)
+            .resolve_memory(self)
             .current_pages()
     }
 
@@ -317,7 +317,7 @@ impl Memory {
         ctx.as_context_mut()
             .store
             .inner
-            .resolve_memory_mut(*self)
+            .resolve_memory_mut(self)
             .grow(additional)
     }
 
@@ -327,7 +327,7 @@ impl Memory {
     ///
     /// Panics if `ctx` does not own this [`Memory`].
     pub fn data<'a, T: 'a>(&self, ctx: impl Into<StoreContext<'a, T>>) -> &'a [u8] {
-        ctx.into().store.inner.resolve_memory(*self).data()
+        ctx.into().store.inner.resolve_memory(self).data()
     }
 
     /// Returns an exclusive slice to the bytes underlying the [`Memory`].
@@ -336,7 +336,7 @@ impl Memory {
     ///
     /// Panics if `ctx` does not own this [`Memory`].
     pub fn data_mut<'a, T: 'a>(&self, ctx: impl Into<StoreContextMut<'a, T>>) -> &'a mut [u8] {
-        ctx.into().store.inner.resolve_memory_mut(*self).data_mut()
+        ctx.into().store.inner.resolve_memory_mut(self).data_mut()
     }
 
     /// Returns an exclusive slice to the bytes underlying the [`Memory`], and an exclusive
@@ -349,7 +349,7 @@ impl Memory {
         &self,
         ctx: impl Into<StoreContextMut<'a, T>>,
     ) -> (&'a mut [u8], &'a mut T) {
-        let (memory, store) = ctx.into().store.resolve_memory_and_state_mut(*self);
+        let (memory, store) = ctx.into().store.resolve_memory_and_state_mut(self);
         (memory.data_mut(), store)
     }
 
@@ -372,7 +372,7 @@ impl Memory {
         ctx.as_context()
             .store
             .inner
-            .resolve_memory(*self)
+            .resolve_memory(self)
             .read(offset, buffer)
     }
 
@@ -395,7 +395,7 @@ impl Memory {
         ctx.as_context_mut()
             .store
             .inner
-            .resolve_memory_mut(*self)
+            .resolve_memory_mut(self)
             .write(offset, buffer)
     }
 }

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -75,13 +75,13 @@ impl<'a> ModuleResources<'a> {
     }
 
     /// Returns the [`FuncType`] at the given index.
-    pub fn get_func_type(&self, func_type_idx: FuncTypeIdx) -> DedupFuncType {
-        self.res.func_types[func_type_idx.into_usize()]
+    pub fn get_func_type(&self, func_type_idx: FuncTypeIdx) -> &DedupFuncType {
+        &self.res.func_types[func_type_idx.into_usize()]
     }
 
     /// Returns the [`FuncType`] of the indexed function.
-    pub fn get_type_of_func(&self, func_idx: FuncIdx) -> DedupFuncType {
-        self.res.funcs[func_idx.into_usize()]
+    pub fn get_type_of_func(&self, func_idx: FuncIdx) -> &DedupFuncType {
+        &self.res.funcs[func_idx.into_usize()]
     }
 
     /// Returns the [`GlobalType`] the the indexed global variable.

--- a/crates/wasmi/src/module/compile/block_type.rs
+++ b/crates/wasmi/src/module/compile/block_type.rs
@@ -62,8 +62,8 @@ impl BlockType {
     }
 
     /// Creates a [`BlockType`] with parameters and results.
-    pub(crate) fn func_type(func_type: DedupFuncType) -> Self {
-        Self::from_inner(BlockTypeInner::FuncType(func_type))
+    pub(crate) fn func_type(func_type: &DedupFuncType) -> Self {
+        Self::from_inner(BlockTypeInner::FuncType(*func_type))
     }
 
     /// Returns the number of parameters of the [`BlockType`].
@@ -71,7 +71,7 @@ impl BlockType {
         match &self.inner {
             BlockTypeInner::Empty | BlockTypeInner::Returns(_) => 0,
             BlockTypeInner::FuncType(func_type) => {
-                engine.resolve_func_type(*func_type, |func_type| func_type.params().len() as u32)
+                engine.resolve_func_type(func_type, |func_type| func_type.params().len() as u32)
             }
         }
     }
@@ -82,7 +82,7 @@ impl BlockType {
             BlockTypeInner::Empty => 0,
             BlockTypeInner::Returns(_) => 1,
             BlockTypeInner::FuncType(func_type) => {
-                engine.resolve_func_type(*func_type, |func_type| func_type.results().len() as u32)
+                engine.resolve_func_type(func_type, |func_type| func_type.results().len() as u32)
             }
         }
     }
@@ -95,7 +95,7 @@ impl BlockType {
         match &self.inner {
             BlockTypeInner::Empty | BlockTypeInner::Returns(_) => (),
             BlockTypeInner::FuncType(func_type) => {
-                engine.resolve_func_type(*func_type, |func_type| {
+                engine.resolve_func_type(func_type, |func_type| {
                     for param in func_type.params() {
                         f(*param);
                     }
@@ -115,7 +115,7 @@ impl BlockType {
                 f(*result);
             }
             BlockTypeInner::FuncType(func_type) => {
-                engine.resolve_func_type(*func_type, |func_type| {
+                engine.resolve_func_type(func_type, |func_type| {
                     for result in func_type.results() {
                         f(*result);
                     }

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -46,13 +46,13 @@ fn instantiate_from_wat(wat: &str) -> (Store<()>, Instance) {
     try_instantiate_from_wat(wat).unwrap()
 }
 
-fn resolve_instance(store: &Store<()>, instance: Instance) -> &InstanceEntity {
+fn resolve_instance<'a>(store: &'a Store<()>, instance: &Instance) -> &'a InstanceEntity {
     store.inner.resolve_instance(instance)
 }
 
 fn assert_no_duplicates(store: &Store<()>, instance: Instance) {
-    assert!(resolve_instance(store, instance).get_memory(1).is_none());
-    assert!(resolve_instance(store, instance).get_table(1).is_none());
+    assert!(resolve_instance(store, &instance).get_memory(1).is_none());
+    assert!(resolve_instance(store, &instance).get_table(1).is_none());
 }
 
 #[test]
@@ -63,8 +63,8 @@ fn test_import_memory_and_table() {
             (import "env" "table" (table 4 funcref))
         )"#;
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(resolve_instance(&store, instance).get_memory(0).is_some());
-    assert!(resolve_instance(&store, instance).get_table(0).is_some());
+    assert!(resolve_instance(&store, &instance).get_memory(0).is_some());
+    assert!(resolve_instance(&store, &instance).get_table(0).is_some());
     assert_no_duplicates(&store, instance);
 }
 
@@ -75,8 +75,8 @@ fn test_import_memory() {
             (import "env" "memory" (memory 4))
         )"#;
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(resolve_instance(&store, instance).get_memory(0).is_some());
-    assert!(resolve_instance(&store, instance).get_table(0).is_none());
+    assert!(resolve_instance(&store, &instance).get_memory(0).is_some());
+    assert!(resolve_instance(&store, &instance).get_table(0).is_none());
     assert_no_duplicates(&store, instance);
 }
 
@@ -87,8 +87,8 @@ fn test_import_table() {
             (import "env" "table" (table 4 funcref))
         )"#;
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(resolve_instance(&store, instance).get_memory(0).is_none());
-    assert!(resolve_instance(&store, instance).get_table(0).is_some());
+    assert!(resolve_instance(&store, &instance).get_memory(0).is_none());
+    assert!(resolve_instance(&store, &instance).get_table(0).is_some());
     assert_no_duplicates(&store, instance);
 }
 
@@ -96,8 +96,8 @@ fn test_import_table() {
 fn test_no_memory_no_table() {
     let wat = "(module)";
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(resolve_instance(&store, instance).get_memory(0).is_none());
-    assert!(resolve_instance(&store, instance).get_table(0).is_none());
+    assert!(resolve_instance(&store, &instance).get_memory(0).is_none());
+    assert!(resolve_instance(&store, &instance).get_table(0).is_none());
     assert_no_duplicates(&store, instance);
 }
 
@@ -105,8 +105,8 @@ fn test_no_memory_no_table() {
 fn test_internal_memory() {
     let wat = "(module (memory 1 10) )";
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(resolve_instance(&store, instance).get_memory(0).is_some());
-    assert!(resolve_instance(&store, instance).get_table(0).is_none());
+    assert!(resolve_instance(&store, &instance).get_memory(0).is_some());
+    assert!(resolve_instance(&store, &instance).get_table(0).is_none());
     assert_no_duplicates(&store, instance);
 }
 
@@ -114,7 +114,7 @@ fn test_internal_memory() {
 fn test_internal_table() {
     let wat = "(module (table 4 funcref) )";
     let (store, instance) = instantiate_from_wat(wat);
-    assert!(resolve_instance(&store, instance).get_memory(0).is_none());
-    assert!(resolve_instance(&store, instance).get_table(0).is_some());
+    assert!(resolve_instance(&store, &instance).get_memory(0).is_none());
+    assert!(resolve_instance(&store, &instance).get_table(0).is_some());
     assert_no_duplicates(&store, instance);
 }

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -279,7 +279,7 @@ impl Module {
     fn get_extern_type(&self, idx: ExternIdx) -> ExternType {
         match idx {
             ExternIdx::Func(index) => {
-                let dedup = self.funcs[index.into_usize()];
+                let dedup = &self.funcs[index.into_usize()];
                 let func_type = self.engine.resolve_func_type(dedup, Clone::clone);
                 ExternType::Func(func_type)
             }
@@ -321,7 +321,7 @@ impl<'a> Iterator for ModuleImportsIter<'a> {
                     let func_type = self.funcs.next().unwrap_or_else(|| {
                         panic!("unexpected missing imported function for {name:?}")
                     });
-                    let func_type = self.engine.resolve_func_type(*func_type, FuncType::clone);
+                    let func_type = self.engine.resolve_func_type(func_type, FuncType::clone);
                     ImportType::new(name, func_type)
                 }
                 Imported::Table(name) => {

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -174,7 +174,7 @@ impl StoreInner {
     /// This is required so that the [`Engine`] can work entirely
     /// with a `&mut StoreInner` reference.
     pub fn register_func_type(&mut self, func: Func, func_type: &DedupFuncType) {
-        let idx = self.unwrap_stored(func.to_inner());
+        let idx = self.unwrap_stored(func.as_inner());
         let previous = self.func_types.set(idx, *func_type);
         debug_assert!(previous.is_none());
     }
@@ -185,7 +185,7 @@ impl StoreInner {
     ///
     /// Panics if no [`DedupFuncType`] for the given [`Func`] was registered.
     pub fn get_func_type(&self, func: Func) -> DedupFuncType {
-        let idx = self.unwrap_stored(func.to_inner());
+        let idx = self.unwrap_stored(func.as_inner());
         self.func_types
             .get(idx)
             .copied()
@@ -241,7 +241,7 @@ impl StoreInner {
             init.is_initialized(),
             "encountered an uninitialized new instance entity: {init:?}",
         );
-        let idx = self.unwrap_stored(instance.to_inner());
+        let idx = self.unwrap_stored(instance.as_inner());
         let uninit = self
             .instances
             .get_mut(idx)
@@ -323,7 +323,7 @@ impl StoreInner {
     /// - If the [`Global`] does not originate from this [`Store`].
     /// - If the [`Global`] cannot be resolved to its entity.
     pub fn resolve_global(&self, global: &Global) -> &GlobalEntity {
-        self.resolve(global.to_inner(), &self.globals)
+        self.resolve(global.as_inner(), &self.globals)
     }
 
     /// Returns an exclusive reference to the [`GlobalEntity`] associated to the given [`Global`].
@@ -333,7 +333,7 @@ impl StoreInner {
     /// - If the [`Global`] does not originate from this [`Store`].
     /// - If the [`Global`] cannot be resolved to its entity.
     pub fn resolve_global_mut(&mut self, global: &Global) -> &mut GlobalEntity {
-        let idx = self.unwrap_stored(global.to_inner());
+        let idx = self.unwrap_stored(global.as_inner());
         Self::resolve_mut(idx, &mut self.globals)
     }
 
@@ -344,7 +344,7 @@ impl StoreInner {
     /// - If the [`Table`] does not originate from this [`Store`].
     /// - If the [`Table`] cannot be resolved to its entity.
     pub fn resolve_table(&self, table: &Table) -> &TableEntity {
-        self.resolve(table.to_inner(), &self.tables)
+        self.resolve(table.as_inner(), &self.tables)
     }
 
     /// Returns an exclusive reference to the [`TableEntity`] associated to the given [`Table`].
@@ -354,7 +354,7 @@ impl StoreInner {
     /// - If the [`Table`] does not originate from this [`Store`].
     /// - If the [`Table`] cannot be resolved to its entity.
     pub fn resolve_table_mut(&mut self, table: &Table) -> &mut TableEntity {
-        let idx = self.unwrap_stored(table.to_inner());
+        let idx = self.unwrap_stored(table.as_inner());
         Self::resolve_mut(idx, &mut self.tables)
     }
 
@@ -365,7 +365,7 @@ impl StoreInner {
     /// - If the [`Memory`] does not originate from this [`Store`].
     /// - If the [`Memory`] cannot be resolved to its entity.
     pub fn resolve_memory(&self, memory: &Memory) -> &MemoryEntity {
-        self.resolve(memory.to_inner(), &self.memories)
+        self.resolve(memory.as_inner(), &self.memories)
     }
 
     /// Returns an exclusive reference to the [`MemoryEntity`] associated to the given [`Memory`].
@@ -375,7 +375,7 @@ impl StoreInner {
     /// - If the [`Memory`] does not originate from this [`Store`].
     /// - If the [`Memory`] cannot be resolved to its entity.
     pub fn resolve_memory_mut(&mut self, memory: &Memory) -> &mut MemoryEntity {
-        let idx = self.unwrap_stored(memory.to_inner());
+        let idx = self.unwrap_stored(memory.as_inner());
         Self::resolve_mut(idx, &mut self.memories)
     }
 
@@ -386,7 +386,7 @@ impl StoreInner {
     /// - If the [`Instance`] does not originate from this [`Store`].
     /// - If the [`Instance`] cannot be resolved to its entity.
     pub fn resolve_instance(&self, instance: &Instance) -> &InstanceEntity {
-        self.resolve(instance.to_inner(), &self.instances)
+        self.resolve(instance.as_inner(), &self.instances)
     }
 }
 
@@ -450,7 +450,7 @@ impl<T> Store<T> {
     /// - If the [`Func`] does not originate from this [`Store`].
     /// - If the [`Func`] cannot be resolved to its entity.
     pub(super) fn resolve_func(&self, func: &Func) -> &FuncEntity<T> {
-        let entity_index = self.inner.unwrap_stored(func.to_inner());
+        let entity_index = self.inner.unwrap_stored(func.as_inner());
         self.funcs.get(entity_index).unwrap_or_else(|| {
             panic!("failed to resolve stored Wasm or host function: {entity_index:?}")
         })

--- a/crates/wasmi/src/table.rs
+++ b/crates/wasmi/src/table.rs
@@ -245,8 +245,8 @@ impl Table {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn into_inner(self) -> Stored<TableIdx> {
-        self.0
+    pub(super) fn to_inner(&self) -> &Stored<TableIdx> {
+        &self.0
     }
 
     /// Creates a new table to the store.
@@ -263,7 +263,7 @@ impl Table {
     ///
     /// Panics if `ctx` does not own this [`Table`].
     pub fn ty(&self, ctx: impl AsContext) -> TableType {
-        ctx.as_context().store.inner.resolve_table(*self).ty()
+        ctx.as_context().store.inner.resolve_table(self).ty()
     }
 
     /// Returns the current size of the [`Table`].
@@ -272,7 +272,7 @@ impl Table {
     ///
     /// If `ctx` does not own this [`Table`].
     pub fn size(&self, ctx: impl AsContext) -> u32 {
-        ctx.as_context().store.inner.resolve_table(*self).size()
+        ctx.as_context().store.inner.resolve_table(self).size()
     }
 
     /// Grows the table by the given amount of elements.
@@ -292,7 +292,7 @@ impl Table {
         ctx.as_context_mut()
             .store
             .inner
-            .resolve_table_mut(*self)
+            .resolve_table_mut(self)
             .grow(delta)
     }
 
@@ -306,7 +306,7 @@ impl Table {
     ///
     /// Panics if `ctx` does not own this [`Table`].
     pub fn get(&self, ctx: impl AsContext, index: u32) -> Result<Option<Func>, TableError> {
-        ctx.as_context().store.inner.resolve_table(*self).get(index)
+        ctx.as_context().store.inner.resolve_table(self).get(index)
     }
 
     /// Writes the `value` provided into `index` within this [`Table`].
@@ -327,7 +327,7 @@ impl Table {
         ctx.as_context_mut()
             .store
             .inner
-            .resolve_table_mut(*self)
+            .resolve_table_mut(self)
             .set(index, value)
     }
 }

--- a/crates/wasmi/src/table.rs
+++ b/crates/wasmi/src/table.rs
@@ -245,7 +245,7 @@ impl Table {
     }
 
     /// Returns the underlying stored representation.
-    pub(super) fn to_inner(&self) -> &Stored<TableIdx> {
+    pub(super) fn as_inner(&self) -> &Stored<TableIdx> {
         &self.0
     }
 


### PR DESCRIPTION
The idea behind this change is that the Rust compiler (and LLVM) have a greater chance to apply optimizations if parameters are at most pointer sized. Unfortunately `wasmi` reference types such as `Func`, `Global` etc. do eventually not fit into a pointer and therefore might regress performance.

Furthermore this is more aligned with what the Wasmtime API does in such cases.
As an additional bonus this allows us to more room for experimentation with the internals of those `wasmi` reference types such as `Func`, `Global` etc. since `wasmi` methods are less dependent on the actual structure of those types with these changes.