### PR TITLE
Experimental: Update `wasmparser` to experimental version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,16 +32,16 @@ jobs:
         with:
           command: build
           args: --workspace --all-features
-      - name: Build wasmi itself as no_std
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli --exclude wasmi_wasi
-      - name: Build (wasm32)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
+      # - name: Build wasmi itself as no_std
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: build
+      #     args: --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli --exclude wasmi_wasi
+      # - name: Build (wasm32)
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: build
+      #     args: --workspace --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
 
   test:
     name: Test

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -13,7 +13,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-wasmparser = { version = "0.99", package = "wasmparser-nostd", default-features = false }
+wasmparser = { git = "https://github.com/effect-handlers/wasm-tools", rev = "c1b5cc3a342c8d0b1e7b527b18438358755e1310" }
+# wasmparser = { version = "0.99", package = "wasmparser-nostd", default-features = false }
 wasmi_core = { version = "0.10", path = "../core", default-features = false }
 wasmi_arena = { version = "0.4", path = "../arena", default-features = false }
 spin = { version = "0.9", default-features = false, features = [
@@ -31,7 +32,7 @@ criterion = { version = "0.4", default-features = false }
 
 [features]
 default = ["std"]
-std = ["wasmi_core/std", "wasmi_arena/std", "wasmparser/std", "spin/std"]
+std = ["wasmi_core/std", "wasmi_arena/std", "spin/std"]
 
 [[bench]]
 name = "benches"

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -178,6 +178,7 @@ impl Config {
             memory64: false,
             extended_const: false,
             memory_control: false,
+            function_references: false,
         }
     }
 }

--- a/crates/wasmi/src/engine/func_builder/translator.rs
+++ b/crates/wasmi/src/engine/func_builder/translator.rs
@@ -1018,7 +1018,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         self.visit_select()
     }
 
-    fn visit_ref_null(&mut self, _ty: wasmparser::ValType) -> Result<(), TranslationError> {
+    fn visit_ref_null(&mut self, _ty: wasmparser::HeapType) -> Result<(), TranslationError> {
         // Since `wasmi` bytecode is untyped we have no special `null` instructions
         // but simply reuse the `constant` instruction with an immediate value of 0.
         // Note that `FuncRef` and `ExternRef` are encoded as 64-bit values in `wasmi`.

--- a/crates/wasmi/src/module/element.rs
+++ b/crates/wasmi/src/module/element.rs
@@ -110,11 +110,6 @@ impl From<wasmparser::ElementKind<'_>> for ElementSegmentKind {
 
 impl From<wasmparser::Element<'_>> for ElementSegment {
     fn from(element: wasmparser::Element<'_>) -> Self {
-        assert!(
-            element.ty.is_reference_type(),
-            "only reftypes are allowed as element types but found: {:?}",
-            element.ty
-        );
         let kind = ElementSegmentKind::from(element.kind);
         let ty = WasmiValueType::from(element.ty).into_inner();
         let items = ElementSegmentItems::new(&element.items);

--- a/crates/wasmi/src/module/init_expr.rs
+++ b/crates/wasmi/src/module/init_expr.rs
@@ -183,8 +183,8 @@ impl InitExprOperand {
             wasmparser::Operator::GlobalGet { global_index } => {
                 Self::GlobalGet(GlobalIdx::from(global_index))
             }
-            wasmparser::Operator::RefNull { ty } => Self::RefNull {
-                ty: WasmiValueType::from(ty).into_inner(),
+            wasmparser::Operator::RefNull { hty } => Self::RefNull {
+                ty: WasmiValueType::from(hty).into_inner(),
             },
             wasmparser::Operator::RefFunc { function_index } => Self::FuncRef(function_index),
             operator => {

--- a/crates/wasmi/src/module/parser.rs
+++ b/crates/wasmi/src/module/parser.rs
@@ -315,7 +315,7 @@ impl<'engine> ModuleParser<'engine> {
         self.validator.table_section(&section)?;
         let tables = section.into_iter().map(|table| {
             table
-                .map(TableType::from_wasmparser)
+                .map(TableType::from_wasmparser_table)
                 .map_err(ModuleError::from)
         });
         self.builder.push_tables(tables)?;


### PR DESCRIPTION
This PR commit updates wasmparser to a rev that implements the non-standard `function-references` Wasm proposal in order to check the performance implications on wasmi Wasm validation.

See comment: https://github.com/bytecodealliance/wasm-tools/pull/701#issuecomment-1421413395