### PR TITLE
`wasmi_cli`: Properly forward WASI arguments

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -64,7 +64,11 @@ pub struct Args {
     invoke: Option<String>,
 
     /// Possibly zero list of positional arguments
-    #[clap(value_name = "ARGS", trailing_var_arg = true, allow_hyphen_values = true)]
+    #[clap(
+        value_name = "ARGS",
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
     func_args: Vec<String>,
 }
 

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -64,7 +64,7 @@ pub struct Args {
     invoke: Option<String>,
 
     /// Possibly zero list of positional arguments
-    #[clap(value_name = "ARGS")]
+    #[clap(value_name = "ARGS", trailing_var_arg = true, allow_hyphen_values = true)]
     func_args: Vec<String>,
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
     typecheck_args(&func_name, &ty, &func_args)?;
 
     print_execution_start(args.wasm_file(), &func_name, &func_args);
-    if ty.params().len() != args.func_args().len() {
+    if args.invoked().is_some() && ty.params().len() != args.func_args().len() {
         bail!(
             "invalid amount of arguments given to function {}. expected {} but received {}",
             DisplayFuncType::new(&func_name, &ty),


### PR DESCRIPTION
Closes #661.