### PR TITLE
CI: Use Cargo cache for GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,6 +148,26 @@ jobs:
           command: audit
           args: ''
 
+  udeps:
+    name: uDeps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: Install cargo-udeps
+        run: |
+          # Note: We use `|| true` because cargo install returns an error
+          #       if cargo-udeps was already installed on the CI runner.
+          cargo install --locked cargo-udeps || true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: udeps
+          args: --all-targets
+
   miri:
     name: Miri
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           command: build
           args: --workspace --all-features
-      - name: Build wasmi itself as no_std
+      - name: Build (no_std)
         uses: actions-rs/cargo@v1
         with:
           command: build
@@ -53,7 +53,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
+          args: --workspace --lib --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
 
   test:
     name: Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,18 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Add extra targets
         # Workaround for https://github.com/actions-rs/toolchain/issues/165
         run: |
@@ -58,6 +70,18 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Test (default features)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,18 @@ jobs:
           toolchain: stable
           override: true
           components: rust-docs, rust-src
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - uses: actions-rs/cargo@v1
         env:
           RUSTDOCFLAGS: '-D warnings'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -261,6 +261,18 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-coverage-
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Run cargo-tarpaulin (default features)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,6 +158,20 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-udeps-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-udeps-
+      - name: Checkout Submodules
+        run: git submodule update --init --recursive
       - name: Install cargo-udeps
         run: |
           # Note: We use `|| true` because cargo install returns an error

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,6 +239,18 @@ jobs:
           toolchain: nightly
           override: true
           components: clippy
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Clippy (default features)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -193,6 +193,18 @@ jobs:
           toolchain: nightly
           override: true
           components: miri
+      - name: Set up Cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-miri-
       - name: Clippy (--lib)
         uses: actions-rs/cargo@v1
         with:

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,3 +24,7 @@ rand = "0.8.2"
 default = ["std"]
 # Use `no-default-features` for a `no_std` build.
 std = ["num-traits/std", "downcast-rs/std"]
+
+[package.metadata.cargo-udeps.ignore]
+# cargo-udeps cannot detect that libm is used for no_std targets only.
+normal = ["libm"]


### PR DESCRIPTION
According to [this blog post](https://ectobit.com/blog/speed-up-github-actions-rust-pipelines/) this should speed up the CI a bit.

This reduced the time for the `test` runs from 8-10 minutes down to 2-3 minutes on both Windows and MacOS targets.
Also it reduced build time for the `build` run from 1 minute to 40 seconds.