### PR TITLE
Prepare `wasmi` release version `0.26.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Fixed
 
-- Fixed a bug where resuming a resumable function with more outputs than
+- Fixed a bug where resuming a resumable function from a host function with more outputs than
   inputs could lead to incorrect behavior or runtime panics. (https://github.com/paritytech/wasmi/pull/671)
     - Thanks to [Pierre Krieger (tomaka)](https://github.com/tomaka) for reporting and crafting an initial minimal test case.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Additionally we have an `Internal` section for changes that are of interest to d
 
 Dates in this file are formattes as `YYYY-MM-DD`.
 
+## [`0.26.1`] - 2023-02-13
+
+### Fixed
+
+- Fixed a bug where a resumable function with more outputs than
+  inputs could lead to incorrect behavior or runtime panics. (https://github.com/paritytech/wasmi/pull/671)
+    - Thanks to [Pierre Krieger (tomaka)](https://github.com/tomaka) for reporting and crafting an initial minimal test case.
+
 ## [`0.26.0`] - 2023-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Fixed
 
-- Fixed a bug where a resumable function with more outputs than
+- Fixed a bug where resuming a resumable function with more outputs than
   inputs could lead to incorrect behavior or runtime panics. (https://github.com/paritytech/wasmi/pull/671)
     - Thanks to [Pierre Krieger (tomaka)](https://github.com/tomaka) for reporting and crafting an initial minimal test case.
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-wasmi = { version = "0.26.0", path = "../wasmi" }
+wasmi = { version = "0.26.1", path = "../wasmi" }
 wasmi_wasi = { version = "0.1.0", path = "../wasi" }
 wat = "1"
 

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 wasi-common = "2.0"
 wasi-cap-std-sync = "2.0"
 wiggle = { version = "2.0", default-features = false, features = ["wiggle_metadata"] }
-wasmi = { version = "0.26.0", path = "../wasmi" }
+wasmi = { version = "0.26.1", path = "../wasmi" }
 
 [dev-dependencies]
 wat = "1.0.50"

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.26.0"
+version = "0.26.1"
 documentation = "https://docs.rs/wasmi/"
 description = "WebAssembly interpreter"
 exclude = ["tests/*", "benches/*"]

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -205,8 +205,7 @@ impl Config {
     ///
     /// # Note
     ///
-    /// This can be used to disallow floating-point operators.
-    /// Note that disabling this does not disable the `f32` and `f64` Wasm types, only the operators that work on them.
+    /// This can be used to disallow floating-point operators and types.
     ///
     /// Enabled by default.
     pub fn floats(&mut self, enable: bool) -> &mut Self {


### PR DESCRIPTION
Unblocking https://github.com/smol-dot/smoldot/pull/18.