### PR TITLE
Defer charging fuel for bulk `table` and bulk `memory` operations

### DIFF
--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -512,7 +512,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
     /// - If the `exec` closure traps.
     fn consume_fuel_on_success<T, E>(
         &mut self,
-        delta: impl FnOnce(&Self) -> u64,
+        delta: impl FnOnce(&FuelCosts) -> u64,
         exec: impl FnOnce(&mut Self) -> Result<T, E>,
     ) -> Result<T, E>
     where
@@ -522,7 +522,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
             return exec(self);
         }
         // At this point we know that fuel metering is enabled.
-        let delta = delta(self);
+        let delta = delta(self.fuel_costs());
         self.ctx.fuel().sufficient_fuel(delta)?;
         let result = exec(self)?;
         self.ctx
@@ -720,9 +720,9 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
             }
         };
         let result = self.consume_fuel_on_success(
-            |this| {
+            |costs| {
                 let delta_in_bytes = delta.to_bytes().unwrap_or(0) as u64;
-                delta_in_bytes * this.fuel_costs().memory_per_byte
+                delta_in_bytes * costs.memory_per_byte
             },
             |this| {
                 this.ctx
@@ -748,7 +748,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let offset = i32::from(d) as usize;
         let byte = u8::from(val);
         self.consume_fuel_on_success(
-            |this| n as u64 * this.fuel_costs().memory_per_byte,
+            |costs| n as u64 * costs.memory_per_byte,
             |this| {
                 let bytes = this.cache.default_memory_bytes(this.ctx);
                 let memory = bytes
@@ -769,7 +769,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let src_offset = i32::from(s) as usize;
         let dst_offset = i32::from(d) as usize;
         self.consume_fuel_on_success(
-            |this| n as u64 * this.fuel_costs().memory_per_byte,
+            |costs| n as u64 * costs.memory_per_byte,
             |this| {
                 let data = this.cache.default_memory_bytes(this.ctx).data_mut();
                 // These accesses just perform the bounds checks required by the Wasm spec.
@@ -792,7 +792,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let src_offset = i32::from(s) as usize;
         let dst_offset = i32::from(d) as usize;
         self.consume_fuel_on_success(
-            |this| n as u64 * this.fuel_costs().memory_per_byte,
+            |costs| n as u64 * costs.memory_per_byte,
             |this| {
                 let (memory, data) = this
                     .cache
@@ -830,7 +830,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let (init, delta) = self.value_stack.pop2();
         let delta: u32 = delta.into();
         let result = self.consume_fuel_on_success(
-            |this| u64::from(delta) * this.fuel_costs().table_per_element,
+            |costs| u64::from(delta) * costs.table_per_element,
             |this| {
                 let table = this.cache.get_table(this.ctx, table_index);
                 this.ctx
@@ -854,7 +854,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let dst: u32 = i.into();
         let len: u32 = n.into();
         self.consume_fuel_on_success(
-            |this| u64::from(len) * this.fuel_costs().table_per_element,
+            |costs| u64::from(len) * costs.table_per_element,
             |this| {
                 let table = this.cache.get_table(this.ctx, table_index);
                 this.ctx
@@ -895,7 +895,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let src_index = u32::from(s);
         let dst_index = u32::from(d);
         self.consume_fuel_on_success(
-            |this| u64::from(len) * this.fuel_costs().table_per_element,
+            |costs| u64::from(len) * costs.table_per_element,
             |this| {
                 // Query both tables and check if they are the same:
                 let dst = this.cache.get_table(this.ctx, dst);
@@ -925,7 +925,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let src_index = u32::from(s);
         let dst_index = u32::from(d);
         self.consume_fuel_on_success(
-            |this| u64::from(len) * this.fuel_costs().table_per_element,
+            |costs| u64::from(len) * costs.table_per_element,
             |this| {
                 let (instance, table, element) = this
                     .cache

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -483,13 +483,18 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
     ///
     /// If the [`StoreInner`] ran out of fuel.
     fn consume_fuel_with(&mut self, delta: impl FnOnce(&Self) -> u64) -> Result<(), TrapCode> {
-        if self.ctx.engine().config().get_consume_fuel() {
+        if self.is_fuel_metering_enabled() {
             let delta = delta(self);
             self.ctx.fuel_mut().consume_fuel(delta)?;
         }
         Ok(())
     }
 
+
+    /// Returns `true` if fuel metering is enabled.
+    fn is_fuel_metering_enabled(&self) -> bool {
+        self.ctx.engine().config().get_consume_fuel()
+    }
     /// Returns a shared reference to the [`FuelCosts`] of the [`Engine`].
     fn fuel_costs(&self) -> &FuelCosts {
         self.ctx.engine().config().fuel_costs()

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -763,9 +763,10 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                     .and_then(|memory| memory.get_mut(..n))
                     .ok_or(TrapCode::MemoryOutOfBounds)?;
                 memory.fill(byte);
-                this.try_next_instr()
+                Ok(())
             },
-        )
+        )?;
+        self.try_next_instr()
     }
 
     fn visit_memory_copy(&mut self) -> Result<(), TrapCode> {
@@ -786,9 +787,10 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                     .and_then(|memory| memory.get(..n))
                     .ok_or(TrapCode::MemoryOutOfBounds)?;
                 data.copy_within(src_offset..src_offset.wrapping_add(n), dst_offset);
-                this.try_next_instr()
+                Ok(())
             },
-        )
+        )?;
+        self.try_next_instr()
     }
 
     fn visit_memory_init(&mut self, segment: DataSegmentIdx) -> Result<(), TrapCode> {
@@ -812,9 +814,10 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                     .and_then(|data| data.get(..n))
                     .ok_or(TrapCode::MemoryOutOfBounds)?;
                 memory.copy_from_slice(data);
-                this.try_next_instr()
+                Ok(())
             },
-        )
+        )?;
+        self.try_next_instr()
     }
 
     fn visit_data_drop(&mut self, segment_index: DataSegmentIdx) {
@@ -866,9 +869,10 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                 this.ctx
                     .resolve_table_mut(&table)
                     .fill_untyped(dst, val, len)?;
-                this.try_next_instr()
+                Ok(())
             },
-        )
+        )?;
+        self.try_next_instr()
     }
 
     fn visit_table_get(&mut self, table_index: TableIdx) -> Result<(), TrapCode> {
@@ -915,9 +919,10 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                     let (dst, src) = this.ctx.resolve_table_pair_mut(&dst, &src);
                     TableEntity::copy(dst, dst_index, src, src_index, len)?;
                 }
-                this.try_next_instr()
+                Ok(())
             },
-        )
+        )?;
+        self.try_next_instr()
     }
 
     fn visit_table_init(
@@ -941,9 +946,10 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                         .get_func(func_index)
                         .unwrap_or_else(|| panic!("missing function at index {func_index}"))
                 })?;
-                this.try_next_instr()
+                Ok(())
             },
-        )
+        )?;
+        self.try_next_instr()
     }
 
     fn visit_element_drop(&mut self, segment_index: ElementSegmentIdx) {

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -540,6 +540,8 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
     }
 
     /// Returns a shared reference to the [`FuelCosts`] of the [`Engine`].
+    /// 
+    /// [`Engine`]: crate::Engine
     fn fuel_costs(&self) -> &FuelCosts {
         self.ctx.engine().config().fuel_costs()
     }

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -725,7 +725,8 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
                 delta_in_bytes * costs.memory_per_byte
             },
             |this| {
-                let new_pages = this.ctx
+                let new_pages = this
+                    .ctx
                     .resolve_memory_mut(&memory)
                     .grow(delta)
                     .map(u32::from)

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -490,11 +490,51 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         Ok(())
     }
 
+    /// Consume an amount of fuel specified by `delta` if `exec` succeeds.
+    ///
+    /// # Note
+    ///
+    /// - `delta` is only evaluated if fuel metering is enabled.
+    /// - `exec` is only evaluated if the remaining fuel is sufficient
+    ///    for amount of required fuel determined by `delta` or if
+    ///    fuel metering is disabled.
+    ///
+    /// Only if `exec` runs successfully and fuel metering
+    /// is enabled the fuel determined by `delta` is charged.
+    ///
+    /// # Errors
+    ///
+    /// - If the [`StoreInner`] ran out of fuel.
+    /// - If the `exec` closure traps.
+    fn consume_fuel_on_success<T, E>(
+        &mut self,
+        delta: impl FnOnce(&Self) -> u64,
+        exec: impl FnOnce(&mut Self) -> Result<T, E>,
+    ) -> Result<T, E>
+    where
+        E: From<TrapCode>,
+    {
+        if !self.is_fuel_metering_enabled() {
+            return exec(self);
+        }
+        // At this point we know that fuel metering is enabled.
+        let delta = delta(self);
+        self.ctx.fuel().sufficient_fuel(delta)?;
+        let result = exec(self)?;
+        self.ctx
+            .fuel_mut()
+            .consume_fuel(delta)
+            .unwrap_or_else(|error| {
+                panic!("remaining fuel has already been approved prior but encountered: {error}")
+            });
+        Ok(result)
+    }
 
     /// Returns `true` if fuel metering is enabled.
     fn is_fuel_metering_enabled(&self) -> bool {
         self.ctx.engine().config().get_consume_fuel()
     }
+
     /// Returns a shared reference to the [`FuelCosts`] of the [`Engine`].
     fn fuel_costs(&self) -> &FuelCosts {
         self.ctx.engine().config().fuel_costs()
@@ -709,15 +749,19 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let n = i32::from(n) as usize;
         let offset = i32::from(d) as usize;
         let byte = u8::from(val);
-        self.consume_fuel_with(|this| n as u64 * this.fuel_costs().memory_per_byte)?;
-        let bytes = self.cache.default_memory_bytes(self.ctx);
-        let memory = bytes
-            .data_mut()
-            .get_mut(offset..)
-            .and_then(|memory| memory.get_mut(..n))
-            .ok_or(TrapCode::MemoryOutOfBounds)?;
-        memory.fill(byte);
-        self.try_next_instr()
+        self.consume_fuel_on_success(
+            |this| n as u64 * this.fuel_costs().memory_per_byte,
+            |this| {
+                let bytes = this.cache.default_memory_bytes(this.ctx);
+                let memory = bytes
+                    .data_mut()
+                    .get_mut(offset..)
+                    .and_then(|memory| memory.get_mut(..n))
+                    .ok_or(TrapCode::MemoryOutOfBounds)?;
+                memory.fill(byte);
+                this.try_next_instr()
+            },
+        )
     }
 
     fn visit_memory_copy(&mut self) -> Result<(), TrapCode> {
@@ -726,17 +770,21 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let n = i32::from(n) as usize;
         let src_offset = i32::from(s) as usize;
         let dst_offset = i32::from(d) as usize;
-        self.consume_fuel_with(|this| n as u64 * this.fuel_costs().memory_per_byte)?;
-        let data = self.cache.default_memory_bytes(self.ctx).data_mut();
-        // These accesses just perform the bounds checks required by the Wasm spec.
-        data.get(src_offset..)
-            .and_then(|memory| memory.get(..n))
-            .ok_or(TrapCode::MemoryOutOfBounds)?;
-        data.get(dst_offset..)
-            .and_then(|memory| memory.get(..n))
-            .ok_or(TrapCode::MemoryOutOfBounds)?;
-        data.copy_within(src_offset..src_offset.wrapping_add(n), dst_offset);
-        self.try_next_instr()
+        self.consume_fuel_on_success(
+            |this| n as u64 * this.fuel_costs().memory_per_byte,
+            |this| {
+                let data = this.cache.default_memory_bytes(this.ctx).data_mut();
+                // These accesses just perform the bounds checks required by the Wasm spec.
+                data.get(src_offset..)
+                    .and_then(|memory| memory.get(..n))
+                    .ok_or(TrapCode::MemoryOutOfBounds)?;
+                data.get(dst_offset..)
+                    .and_then(|memory| memory.get(..n))
+                    .ok_or(TrapCode::MemoryOutOfBounds)?;
+                data.copy_within(src_offset..src_offset.wrapping_add(n), dst_offset);
+                this.try_next_instr()
+            },
+        )
     }
 
     fn visit_memory_init(&mut self, segment: DataSegmentIdx) -> Result<(), TrapCode> {
@@ -745,20 +793,24 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let n = i32::from(n) as usize;
         let src_offset = i32::from(s) as usize;
         let dst_offset = i32::from(d) as usize;
-        self.consume_fuel_with(|this| n as u64 * this.fuel_costs().memory_per_byte)?;
-        let (memory, data) = self
-            .cache
-            .get_default_memory_and_data_segment(self.ctx, segment);
-        let memory = memory
-            .get_mut(dst_offset..)
-            .and_then(|memory| memory.get_mut(..n))
-            .ok_or(TrapCode::MemoryOutOfBounds)?;
-        let data = data
-            .get(src_offset..)
-            .and_then(|data| data.get(..n))
-            .ok_or(TrapCode::MemoryOutOfBounds)?;
-        memory.copy_from_slice(data);
-        self.try_next_instr()
+        self.consume_fuel_on_success(
+            |this| n as u64 * this.fuel_costs().memory_per_byte,
+            |this| {
+                let (memory, data) = this
+                    .cache
+                    .get_default_memory_and_data_segment(this.ctx, segment);
+                let memory = memory
+                    .get_mut(dst_offset..)
+                    .and_then(|memory| memory.get_mut(..n))
+                    .ok_or(TrapCode::MemoryOutOfBounds)?;
+                let data = data
+                    .get(src_offset..)
+                    .and_then(|data| data.get(..n))
+                    .ok_or(TrapCode::MemoryOutOfBounds)?;
+                memory.copy_from_slice(data);
+                this.try_next_instr()
+            },
+        )
     }
 
     fn visit_data_drop(&mut self, segment_index: DataSegmentIdx) {
@@ -777,18 +829,42 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
     }
 
     fn visit_table_grow(&mut self, table_index: TableIdx) -> Result<(), TrapCode> {
-        // As demanded by the Wasm specification this value is returned
-        // by `table.grow` if the growth operation was unsuccessful.
-        const ERROR_CODE: u32 = u32::MAX;
+        /// An error that can occur upon `table.grow`.
+        #[derive(Copy, Clone)]
+        pub enum TableGrowError {
+            /// Usually a [`TrapCode::OutOfFuel`] trap.
+            TrapCode(TrapCode),
+            /// Encountered when growing the `table` fails.
+            InvalidGrow,
+        }
+
+        impl From<TrapCode> for TableGrowError {
+            fn from(trap_code: TrapCode) -> Self {
+                Self::TrapCode(trap_code)
+            }
+        }
+
         let (init, delta) = self.value_stack.pop2();
         let delta: u32 = delta.into();
-        self.consume_fuel_with(|this| u64::from(delta) * this.fuel_costs().table_per_element)?;
-        let table = self.cache.get_table(self.ctx, table_index);
-        let result = self
-            .ctx
-            .resolve_table_mut(&table)
-            .grow_untyped(delta, init)
-            .unwrap_or(ERROR_CODE);
+        let result = self.consume_fuel_on_success(
+            |this| u64::from(delta) * this.fuel_costs().table_per_element,
+            |this| {
+                let table = this.cache.get_table(this.ctx, table_index);
+                this.ctx
+                    .resolve_table_mut(&table)
+                    .grow_untyped(delta, init)
+                    .map_err(|_| TableGrowError::InvalidGrow)
+            },
+        );
+        let result = match result {
+            Ok(result) => result,
+            Err(TableGrowError::InvalidGrow) => {
+                // The Wasm specification demands that this value is returned
+                // by `table.grow` if the growth operation was unsuccessful.
+                u32::MAX
+            }
+            Err(TableGrowError::TrapCode(trap_code)) => return Err(trap_code),
+        };
         self.value_stack.push(result);
         self.try_next_instr()
     }
@@ -798,12 +874,16 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let (i, val, n) = self.value_stack.pop3();
         let dst: u32 = i.into();
         let len: u32 = n.into();
-        self.consume_fuel_with(|this| u64::from(len) * this.fuel_costs().table_per_element)?;
-        let table = self.cache.get_table(self.ctx, table_index);
-        self.ctx
-            .resolve_table_mut(&table)
-            .fill_untyped(dst, val, len)?;
-        self.try_next_instr()
+        self.consume_fuel_on_success(
+            |this| u64::from(len) * this.fuel_costs().table_per_element,
+            |this| {
+                let table = this.cache.get_table(this.ctx, table_index);
+                this.ctx
+                    .resolve_table_mut(&table)
+                    .fill_untyped(dst, val, len)?;
+                this.try_next_instr()
+            },
+        )
     }
 
     fn visit_table_get(&mut self, table_index: TableIdx) -> Result<(), TrapCode> {
@@ -835,20 +915,24 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let len = u32::from(n);
         let src_index = u32::from(s);
         let dst_index = u32::from(d);
-        self.consume_fuel_with(|this| u64::from(len) * this.fuel_costs().table_per_element)?;
-        // Query both tables and check if they are the same:
-        let dst = self.cache.get_table(self.ctx, dst);
-        let src = self.cache.get_table(self.ctx, src);
-        if Table::eq(&dst, &src) {
-            // Copy within the same table:
-            let table = self.ctx.resolve_table_mut(&dst);
-            table.copy_within(dst_index, src_index, len)?;
-        } else {
-            // Copy from one table to another table:
-            let (dst, src) = self.ctx.resolve_table_pair_mut(&dst, &src);
-            TableEntity::copy(dst, dst_index, src, src_index, len)?;
-        }
-        self.try_next_instr()
+        self.consume_fuel_on_success(
+            |this| u64::from(len) * this.fuel_costs().table_per_element,
+            |this| {
+                // Query both tables and check if they are the same:
+                let dst = this.cache.get_table(this.ctx, dst);
+                let src = this.cache.get_table(this.ctx, src);
+                if Table::eq(&dst, &src) {
+                    // Copy within the same table:
+                    let table = this.ctx.resolve_table_mut(&dst);
+                    table.copy_within(dst_index, src_index, len)?;
+                } else {
+                    // Copy from one table to another table:
+                    let (dst, src) = this.ctx.resolve_table_pair_mut(&dst, &src);
+                    TableEntity::copy(dst, dst_index, src, src_index, len)?;
+                }
+                this.try_next_instr()
+            },
+        )
     }
 
     fn visit_table_init(
@@ -861,16 +945,20 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
         let len = u32::from(n);
         let src_index = u32::from(s);
         let dst_index = u32::from(d);
-        self.consume_fuel_with(|this| u64::from(len) * this.fuel_costs().table_per_element)?;
-        let (instance, table, element) = self
-            .cache
-            .get_table_and_element_segment(self.ctx, table, elem);
-        table.init(dst_index, element, src_index, len, |func_index| {
-            instance
-                .get_func(func_index)
-                .unwrap_or_else(|| panic!("missing function at index {func_index}"))
-        })?;
-        self.try_next_instr()
+        self.consume_fuel_on_success(
+            |this| u64::from(len) * this.fuel_costs().table_per_element,
+            |this| {
+                let (instance, table, element) = this
+                    .cache
+                    .get_table_and_element_segment(this.ctx, table, elem);
+                table.init(dst_index, element, src_index, len, |func_index| {
+                    instance
+                        .get_func(func_index)
+                        .unwrap_or_else(|| panic!("missing function at index {func_index}"))
+                })?;
+                this.try_next_instr()
+            },
+        )
     }
 
     fn visit_element_drop(&mut self, segment_index: ElementSegmentIdx) {

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -540,7 +540,7 @@ impl<'ctx, 'engine, 'func> Executor<'ctx, 'engine, 'func> {
     }
 
     /// Returns a shared reference to the [`FuelCosts`] of the [`Engine`].
-    /// 
+    ///
     /// [`Engine`]: crate::Engine
     fn fuel_costs(&self) -> &FuelCosts {
         self.ctx.engine().config().fuel_costs()

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -1,11 +1,11 @@
 use super::errors::{
+    FuelError,
     FuncError,
     GlobalError,
     InstantiationError,
     LinkerError,
     MemoryError,
     ModuleError,
-    FuelError,
     TableError,
 };
 use crate::core::Trap;

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -5,7 +5,7 @@ use super::errors::{
     LinkerError,
     MemoryError,
     ModuleError,
-    StoreError,
+    FuelError,
     TableError,
 };
 use crate::core::Trap;
@@ -28,7 +28,7 @@ pub enum Error {
     /// A module compilation, validation and translation error.
     Module(ModuleError),
     /// A store error.
-    Store(StoreError),
+    Store(FuelError),
     /// A function error.
     Func(FuncError),
     /// A trap as defined by the WebAssembly specification.
@@ -96,8 +96,8 @@ impl From<ModuleError> for Error {
     }
 }
 
-impl From<StoreError> for Error {
-    fn from(error: StoreError) -> Self {
+impl From<FuelError> for Error {
+    fn from(error: FuelError) -> Self {
         Self::Store(error)
     }
 }

--- a/crates/wasmi/src/func/caller.rs
+++ b/crates/wasmi/src/func/caller.rs
@@ -1,5 +1,5 @@
 use super::super::{AsContext, AsContextMut, StoreContext, StoreContextMut};
-use crate::{store::StoreError, Engine, Extern, Instance};
+use crate::{store::FuelError, Engine, Extern, Instance};
 
 /// Represents the caller’s context when creating a host function via [`Func::wrap`].
 ///
@@ -58,7 +58,7 @@ impl<'a, T> Caller<'a, T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn add_fuel(&mut self, delta: u64) -> Result<(), StoreError> {
+    pub fn add_fuel(&mut self, delta: u64) -> Result<(), FuelError> {
         self.ctx.store.add_fuel(delta)
     }
 
@@ -81,7 +81,7 @@ impl<'a, T> Caller<'a, T> {
     ///
     /// - If fuel metering is disabled.
     /// - If more fuel is consumed than available.
-    pub fn consume_fuel(&mut self, delta: u64) -> Result<u64, StoreError> {
+    pub fn consume_fuel(&mut self, delta: u64) -> Result<u64, FuelError> {
         self.ctx.store.consume_fuel(delta)
     }
 }

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -112,7 +112,7 @@ pub mod errors {
         linker::LinkerError,
         memory::MemoryError,
         module::{InstantiationError, ModuleError},
-        store::StoreError,
+        store::FuelError,
         table::TableError,
     };
 }

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -742,7 +742,7 @@ impl<T> Store<T> {
 
     /// Returns `Ok` if fuel metering has been enabled.
     ///
-    /// Otherwise returns the respective [`StoreError`].
+    /// Otherwise returns the respective [`FuelError`].
     fn check_fuel_metering_enabled(&self) -> Result<(), FuelError> {
         if !self.is_fuel_metering_enabled() {
             return Err(FuelError::fuel_metering_disabled());

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -205,6 +205,16 @@ impl Fuel {
         self.total.wrapping_sub(self.remaining)
     }
 
+    /// Returns `Ok` if enough fuel is remaining to satisfy `delta` fuel consumption.
+    ///
+    /// Returns a [`TrapCode::OutOfFuel`] error otherwise.
+    pub fn sufficient_fuel(&self, delta: u64) -> Result<(), TrapCode> {
+        self.remaining
+            .checked_sub(delta)
+            .map(|_| ())
+            .ok_or(TrapCode::OutOfFuel)
+    }
+
     /// Synthetically consumes an amount of [`Fuel`] for the [`Store`].
     ///
     /// Returns the remaining amount of [`Fuel`] after this operation.
@@ -238,6 +248,11 @@ impl StoreInner {
     /// Returns the [`Engine`] that this store is associated with.
     pub fn engine(&self) -> &Engine {
         &self.engine
+    }
+
+    /// Returns a shared reference to the [`Fuel`] counters.
+    pub fn fuel(&self) -> &Fuel {
+        &self.fuel
     }
 
     /// Returns an exclusive reference to the [`Fuel`] counters.

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -136,14 +136,14 @@ fn test_store_is_send_sync() {
 
 /// An error that may be encountered when operating on the [`Store`].
 #[derive(Debug, Clone)]
-pub enum StoreError {
+pub enum FuelError {
     /// Raised when trying to use any of the `fuel` methods while fuel metering is disabled.
     FuelMeteringDisabled,
     /// Raised when trying to consume more fuel than is available in the [`Store`].
     OutOfFuel,
 }
 
-impl fmt::Display for StoreError {
+impl fmt::Display for FuelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::FuelMeteringDisabled => write!(f, "fuel metering is disabled"),
@@ -152,7 +152,7 @@ impl fmt::Display for StoreError {
     }
 }
 
-impl StoreError {
+impl FuelError {
     /// Returns an error indicating that fuel metering has been disabled.
     ///
     /// # Note
@@ -728,9 +728,9 @@ impl<T> Store<T> {
     /// Returns `Ok` if fuel metering has been enabled.
     ///
     /// Otherwise returns the respective [`StoreError`].
-    fn check_fuel_metering_enabled(&self) -> Result<(), StoreError> {
+    fn check_fuel_metering_enabled(&self) -> Result<(), FuelError> {
         if !self.is_fuel_metering_enabled() {
-            return Err(StoreError::fuel_metering_disabled());
+            return Err(FuelError::fuel_metering_disabled());
         }
         Ok(())
     }
@@ -744,7 +744,7 @@ impl<T> Store<T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn add_fuel(&mut self, delta: u64) -> Result<(), StoreError> {
+    pub fn add_fuel(&mut self, delta: u64) -> Result<(), FuelError> {
         self.check_fuel_metering_enabled()?;
         self.inner.fuel.add_fuel(delta);
         Ok(())
@@ -770,12 +770,12 @@ impl<T> Store<T> {
     ///
     /// - If fuel metering is disabled.
     /// - If more fuel is consumed than available.
-    pub fn consume_fuel(&mut self, delta: u64) -> Result<u64, StoreError> {
+    pub fn consume_fuel(&mut self, delta: u64) -> Result<u64, FuelError> {
         self.check_fuel_metering_enabled()?;
         self.inner
             .fuel
             .consume_fuel(delta)
-            .map_err(|_error| StoreError::out_of_fuel())
+            .map_err(|_error| FuelError::out_of_fuel())
     }
 
     /// Allocates a new Wasm or host [`FuncEntity`] and returns a [`Func`] reference to it.


### PR DESCRIPTION
Fuel checks are still happening before the bulk operation execution but fuel charging only happens if those operations succeeded.
This make sense given that all of these bulk operations fail fast. So only if they succeeded they actually performed a lot of potential computation.

This affects the following Wasm bulk operations:

- `memory.grow`: Already implemented deferred fuel charging but this implementation improves upon it.
- `memory.fill`
- `memory.copy`
- `data.init`
- `table.grow`
- `table.fill`
- `table.copy`
- `elem.init`