### PR TITLE
Fix issue #631

### DIFF
--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -592,8 +592,7 @@ impl<'engine> EngineExecutor<'engine> {
         self.initialize_args(params);
         match func.as_internal(ctx.as_context()) {
             FuncEntityInner::Wasm(wasm_func) => {
-                let res = self.res.read();
-                let mut frame = self.stack.call_wasm_root(wasm_func, &res.code_map)?;
+                let mut frame = self.stack.call_wasm_root(wasm_func, &self.res.read().code_map)?;
                 let mut cache = InstanceCache::from(frame.instance());
                 self.execute_wasm_func(ctx.as_context_mut(), &mut frame, &mut cache)?;
             }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -592,7 +592,9 @@ impl<'engine> EngineExecutor<'engine> {
         self.initialize_args(params);
         match func.as_internal(ctx.as_context()) {
             FuncEntityInner::Wasm(wasm_func) => {
-                let mut frame = self.stack.call_wasm_root(wasm_func, &self.res.read().code_map)?;
+                let mut frame = self
+                    .stack
+                    .call_wasm_root(wasm_func, &self.res.read().code_map)?;
                 let mut cache = InstanceCache::from(frame.instance());
                 self.execute_wasm_func(ctx.as_context_mut(), &mut frame, &mut cache)?;
             }

--- a/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
+++ b/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
@@ -1,0 +1,51 @@
+//! Test to assert that host functions that compile
+//! Wasm modules using the same `Engine` work properly.
+
+use wasmi::{Caller, Engine, Func, Linker, Module, Store};
+
+fn test_setup() -> (Store<()>, Linker<()>) {
+    let engine = Engine::default();
+    let store = Store::new(&engine, ());
+    let linker = <Linker<()>>::new(&engine);
+    (store, linker)
+}
+
+#[test]
+fn host_compiles_wasm() {
+    let wat = r#"
+        (module
+            (import "env" "host_fn" (func $host_fn (result i64)))
+            (func (export "wasm_fn") (result i64)
+                (call $host_fn)
+            )
+        )
+    "#;
+    let wasm = wat::parse_str(wat).unwrap();
+    // Required to resolve lifetime issues.
+    let wasm_hostfn = wat::parse_str(wat).unwrap();
+    let (mut store, mut linker) = test_setup();
+    let host_fn = Func::wrap(&mut store, move |caller: Caller<()>| -> u64 {
+        // The host function returns the amount of imports of the Wasm module
+        // by compiling it. This is not efficient and done for testing purposes.
+        let engine = caller.engine();
+        Module::new(engine, &mut &wasm_hostfn[..]).map(|module| {
+            println!("SUCCESS");
+            module.imports().len() as u64
+        }).unwrap_or_else(|error| {
+            println!("FAILURE: {error}");
+            0
+        })
+    });
+    linker.define("env", "host_fn", host_fn).unwrap();
+    let module = Module::new(store.engine(), &mut &wasm[..]).unwrap();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap()
+        .start(&mut store)
+        .unwrap();
+    let wasm_fn = instance
+        .get_typed_func::<(), i64>(&store, "wasm_fn")
+        .unwrap();
+    let result = wasm_fn.call(&mut store, ()).unwrap();
+    assert_eq!(result, 1);
+}

--- a/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
+++ b/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
@@ -28,13 +28,15 @@ fn host_compiles_wasm() {
         // The host function returns the amount of imports of the Wasm module
         // by compiling it. This is not efficient and done for testing purposes.
         let engine = caller.engine();
-        Module::new(engine, &mut &wasm_hostfn[..]).map(|module| {
-            println!("SUCCESS");
-            module.imports().len() as u64
-        }).unwrap_or_else(|error| {
-            println!("FAILURE: {error}");
-            0
-        })
+        Module::new(engine, &mut &wasm_hostfn[..])
+            .map(|module| {
+                println!("SUCCESS");
+                module.imports().len() as u64
+            })
+            .unwrap_or_else(|error| {
+                println!("FAILURE: {error}");
+                0
+            })
     });
     linker.define("env", "host_fn", host_fn).unwrap();
     let module = Module::new(store.engine(), &mut &wasm[..]).unwrap();

--- a/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
+++ b/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
@@ -30,13 +30,9 @@ fn host_compiles_wasm() {
         let engine = caller.engine();
         Module::new(engine, &mut &wasm_hostfn[..])
             .map(|module| {
-                println!("SUCCESS");
                 module.imports().len() as u64
             })
-            .unwrap_or_else(|error| {
-                println!("FAILURE: {error}");
-                0
-            })
+            .unwrap_or(0)
     });
     linker.define("env", "host_fn", host_fn).unwrap();
     let module = Module::new(store.engine(), &mut &wasm[..]).unwrap();

--- a/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
+++ b/crates/wasmi/tests/e2e/v1/host_compiles_wasm.rs
@@ -29,9 +29,7 @@ fn host_compiles_wasm() {
         // by compiling it. This is not efficient and done for testing purposes.
         let engine = caller.engine();
         Module::new(engine, &mut &wasm_hostfn[..])
-            .map(|module| {
-                module.imports().len() as u64
-            })
+            .map(|module| module.imports().len() as u64)
             .unwrap_or(0)
     });
     linker.define("env", "host_fn", host_fn).unwrap();

--- a/crates/wasmi/tests/e2e/v1/mod.rs
+++ b/crates/wasmi/tests/e2e/v1/mod.rs
@@ -1,4 +1,5 @@
 mod fuel_metering;
 mod func;
 mod host_calls_wasm;
+mod host_compiles_wasm;
 mod resumable_call;


### PR DESCRIPTION
This PR tries to fix issue #631 by simply locking `EngineResources` later. This might cause significant performance regression so we want to be sure that this is not the case by properly benchmarking this change before merging.

cc @lrubasze