### PR TITLE
make `ConstRef` based on `u32` instead of `intx::U24`

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -22,7 +22,6 @@ spin = { version = "0.9", default-features = false, features = [
     "rwlock",
 ] }
 smallvec = { version = "1.10.0", features = ["union"] }
-intx = "0.1.0"
 
 [dev-dependencies]
 wat = "1"

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -6,7 +6,6 @@ use alloc::{
 use wasmi_core::UntypedValue;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(transparent)]
 pub struct ConstRef(u32);
 
 impl TryFrom<usize> for ConstRef {

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -23,7 +23,6 @@ impl TryFrom<usize> for ConstRef {
 
 impl ConstRef {
     /// Returns the index of the [`ConstRef`] as `usize` value.
-    #[inline]
     pub fn to_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -12,10 +12,12 @@ impl TryFrom<usize> for ConstRef {
     type Error = TranslationError;
 
     fn try_from(index: usize) -> Result<Self, Self::Error> {
-        u32::try_from(index)
-            .map_err(|_| TranslationErrorInner::ConstRefOutOfBounds)
-            .map_err(TranslationError::new)
-            .map(Self)
+        match u32::try_from(index) {
+            Ok(index) => Ok(Self(index)),
+            Err(_) => Err(TranslationError::new(
+                TranslationErrorInner::ConstRefOutOfBounds,
+            )),
+        }
     }
 }
 

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -6,6 +6,7 @@ use alloc::{
 use wasmi_core::UntypedValue;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct ConstRef(u32);
 
 impl TryFrom<usize> for ConstRef {

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -21,6 +21,7 @@ impl TryFrom<usize> for ConstRef {
 
 impl ConstRef {
     /// Returns the index of the [`ConstRef`] as `usize` value.
+    #[inline]
     pub fn to_usize(self) -> usize {
         self.0 as usize
     }
@@ -81,6 +82,7 @@ impl ConstPool {
     }
 
     /// Returns the read-only [`ConstPoolView`] of this [`ConstPool`].
+    #[inline]
     pub fn view(&self) -> ConstPoolView {
         ConstPoolView {
             idx2const: &self.idx2const,
@@ -102,6 +104,7 @@ impl ConstPoolView<'_> {
     /// Returns the [`UntypedValue`] for the given [`ConstRef`] if existing.
     ///
     /// Returns `None` is the [`ConstPool`] does not store a value for the [`ConstRef`].
+    #[inline]
     pub fn get(&self, cref: ConstRef) -> Option<UntypedValue> {
         self.idx2const.get(cref.to_usize()).copied()
     }

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -105,6 +105,7 @@ impl ConstPoolView<'_> {
     /// Returns the [`UntypedValue`] for the given [`ConstRef`] if existing.
     ///
     /// Returns `None` is the [`ConstPool`] does not store a value for the [`ConstRef`].
+    #[inline]
     pub fn get(&self, cref: ConstRef) -> Option<UntypedValue> {
         self.idx2const.get(cref.to_usize()).copied()
     }

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -104,7 +104,6 @@ impl ConstPoolView<'_> {
     /// Returns the [`UntypedValue`] for the given [`ConstRef`] if existing.
     ///
     /// Returns `None` is the [`ConstPool`] does not store a value for the [`ConstRef`].
-    #[inline]
     pub fn get(&self, cref: ConstRef) -> Option<UntypedValue> {
         self.idx2const.get(cref.to_usize()).copied()
     }

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -105,7 +105,6 @@ impl ConstPoolView<'_> {
     /// Returns the [`UntypedValue`] for the given [`ConstRef`] if existing.
     ///
     /// Returns `None` is the [`ConstPool`] does not store a value for the [`ConstRef`].
-    #[inline]
     pub fn get(&self, cref: ConstRef) -> Option<UntypedValue> {
         self.idx2const.get(cref.to_usize()).copied()
     }

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -84,7 +84,6 @@ impl ConstPool {
     }
 
     /// Returns the read-only [`ConstPoolView`] of this [`ConstPool`].
-    #[inline]
     pub fn view(&self) -> ConstPoolView {
         ConstPoolView {
             idx2const: &self.idx2const,

--- a/crates/wasmi/src/engine/const_pool.rs
+++ b/crates/wasmi/src/engine/const_pool.rs
@@ -3,29 +3,26 @@ use alloc::{
     collections::{btree_map, BTreeMap},
     vec::Vec,
 };
-use intx::U24;
 use wasmi_core::UntypedValue;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ConstRef(U24);
+pub struct ConstRef(u32);
 
 impl TryFrom<usize> for ConstRef {
     type Error = TranslationError;
 
     fn try_from(index: usize) -> Result<Self, Self::Error> {
-        match U24::try_from(index as u64) {
-            Ok(index) => Ok(Self(index)),
-            Err(_) => Err(TranslationError::new(
-                TranslationErrorInner::ConstRefOutOfBounds,
-            )),
-        }
+        u32::try_from(index)
+            .map_err(|_| TranslationErrorInner::ConstRefOutOfBounds)
+            .map_err(TranslationError::new)
+            .map(Self)
     }
 }
 
 impl ConstRef {
     /// Returns the index of the [`ConstRef`] as `usize` value.
     pub fn to_usize(self) -> usize {
-        u32::from(self.0) as usize
+        self.0 as usize
     }
 }
 

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -848,7 +848,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`DropKeep`] value in
     ///   another instruction word.
-    #[inline(always)]
+    #[inline]
     fn fetch_drop_keep(&self, offset: usize) -> DropKeep {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);
@@ -868,7 +868,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`TableIdx`] value in
     ///   another instruction word.
-    #[inline(always)]
+    #[inline]
     fn fetch_table_idx(&self, offset: usize) -> TableIdx {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -848,7 +848,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`DropKeep`] value in
     ///   another instruction word.
-    #[inline]
     fn fetch_drop_keep(&self, offset: usize) -> DropKeep {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);
@@ -868,7 +867,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`TableIdx`] value in
     ///   another instruction word.
-    #[inline]
     fn fetch_table_idx(&self, offset: usize) -> TableIdx {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -848,6 +848,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`DropKeep`] value in
     ///   another instruction word.
+    #[inline(always)]
     fn fetch_drop_keep(&self, offset: usize) -> DropKeep {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);
@@ -867,6 +868,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`TableIdx`] value in
     ///   another instruction word.
+    #[inline(always)]
     fn fetch_table_idx(&self, offset: usize) -> TableIdx {
         let mut addr: InstructionPtr = self.ip;
         addr.add(offset);


### PR DESCRIPTION
This allows us to remove `intx` dependency. This was an oversight in a previous PR.