### PR TITLE
Support for `ResourceLimiter` API

### DIFF
--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -286,10 +286,10 @@ pub enum TrapCode {
     OutOfFuel,
 
     /// This trap is raised when a growth operation was attempted and an
-    /// installed [`ResourceLimiter`](crate::ResourceLimiter) returned
-    /// `Err(...)` from the associated `table_growing` or `memory_growing`
-    /// method, indicating a desire on the part of the embedder to trap the
-    /// interpreter rather than merely fail the growth operation.
+    /// installed `wasmi::ResourceLimiter` returned `Err(...)` from the
+    /// associated `table_growing` or `memory_growing` method, indicating a
+    /// desire on the part of the embedder to trap the interpreter rather than
+    /// merely fail the growth operation.
     GrowthOperationLimited,
 }
 

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -286,10 +286,10 @@ pub enum TrapCode {
     OutOfFuel,
 
     /// This trap is raised when a growth operation was attempted and an
-    /// installed `ResourceLimiter` returned `Err(...)` from the associated
-    /// `table_growing` or `memory_growing` method, indicating a desire on the
-    /// part of the embedder to trap the interpreter rather than merely fail the
-    /// growth operation.
+    /// installed [`ResourceLimiter`](crate::ResourceLimiter) returned
+    /// `Err(...)` from the associated `table_growing` or `memory_growing`
+    /// method, indicating a desire on the part of the embedder to trap the
+    /// interpreter rather than merely fail the growth operation.
     GrowthOperationLimited,
 }
 

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -284,6 +284,13 @@ pub enum TrapCode {
     /// internal bytecode so that fuel is consumed for each executed instruction.
     /// This is useful to deterministically halt or yield a WebAssembly execution.
     OutOfFuel,
+
+    /// This trap is raised when a growth operation was attempted and an
+    /// installed `ResourceLimiter` returned `Err(...)` from the associated
+    /// `table_growing` or `memory_growing` method, indicating a desire on the
+    /// part of the embedder to trap the interpreter rather than merely fail the
+    /// growth operation.
+    GrowthOperationLimited,
 }
 
 impl TrapCode {
@@ -305,6 +312,7 @@ impl TrapCode {
             Self::StackOverflow => "call stack exhausted",
             Self::BadSignature => "indirect call type mismatch",
             Self::OutOfFuel => "all fuel consumed by WebAssembly",
+            Self::GrowthOperationLimited => "growth operation limited",
         }
     }
 }

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -100,7 +100,7 @@ pub fn execute_wasm<'ctx, 'engine>(
     call_stack: &'engine mut CallStack,
     code_map: &'engine CodeMap,
     const_pool: ConstPoolView<'engine>,
-    resource_limiter: ResourceLimiterRef<'ctx>,
+    resource_limiter: &'ctx mut ResourceLimiterRef<'ctx>,
 ) -> Result<WasmOutcome, TrapCode> {
     Executor::new(
         ctx,
@@ -179,7 +179,7 @@ struct Executor<'ctx, 'engine> {
     code_map: &'engine CodeMap,
     /// A read-only view to a pool of constant values.
     const_pool: ConstPoolView<'engine>,
-    resource_limiter: ResourceLimiterRef<'ctx>,
+    resource_limiter: &'ctx mut ResourceLimiterRef<'ctx>,
 }
 
 macro_rules! forward_call {
@@ -207,7 +207,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         call_stack: &'engine mut CallStack,
         code_map: &'engine CodeMap,
         const_pool: ConstPoolView<'engine>,
-        resource_limiter: ResourceLimiterRef<'ctx>,
+        resource_limiter: &'ctx mut ResourceLimiterRef<'ctx>,
     ) -> Self {
         let frame = call_stack.pop().expect("must have frame on the call stack");
         let sp = value_stack.stack_ptr();

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -1112,8 +1112,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                     .ctx
                     .resolve_memory_mut(memory)
                     .grow(delta, &mut this.resource_limiter)
-                    .map(u32::from)
-                    .map_err(|_| EntityGrowError::InvalidGrow)?;
+                    .map(u32::from)?;
                 // The `memory.grow` operation might have invalidated the cached
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
@@ -1231,10 +1230,11 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             |costs| costs.fuel_for_elements(u64::from(delta)),
             |this| {
                 let table = this.cache.get_table(this.ctx, table_index);
-                this.ctx
-                    .resolve_table_mut(&table)
-                    .grow_untyped(delta, init, &mut this.resource_limiter)
-                    .map_err(|_| EntityGrowError::InvalidGrow)
+                this.ctx.resolve_table_mut(&table).grow_untyped(
+                    delta,
+                    init,
+                    &mut this.resource_limiter,
+                )
             },
         );
         let result = match result {

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -793,7 +793,7 @@ impl<'engine> EngineExecutor<'engine> {
             code.into()
         }
 
-        let (store_inner, resource_limiter) = ctx.store.store_inner_and_resource_limiter_ref();
+        let (store_inner, mut resource_limiter) = ctx.store.store_inner_and_resource_limiter_ref();
         let value_stack = &mut self.stack.values;
         let call_stack = &mut self.stack.frames;
         let code_map = &self.res.code_map;
@@ -806,7 +806,7 @@ impl<'engine> EngineExecutor<'engine> {
             call_stack,
             code_map,
             const_pool,
-            resource_limiter,
+            &mut resource_limiter,
         )
         .map_err(make_trap)
     }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -48,6 +48,7 @@ pub(crate) use self::{
 use crate::{
     core::{Trap, TrapCode},
     func::FuncEntity,
+    store::ResourceLimiterRef,
     AsContext,
     AsContextMut,
     Func,
@@ -798,6 +799,11 @@ impl<'engine> EngineExecutor<'engine> {
         let call_stack = &mut self.stack.frames;
         let code_map = &self.res.code_map;
         let const_pool = self.res.const_pool.view();
+        let resource_limiter = ResourceLimiterRef(match &mut ctx.store.limiter {
+            Some(q) => Some(q.0(&mut ctx.store.data)),
+            None => None,
+        });
+
         execute_wasm(
             store_inner,
             cache,
@@ -805,6 +811,7 @@ impl<'engine> EngineExecutor<'engine> {
             call_stack,
             code_map,
             const_pool,
+            resource_limiter,
         )
         .map_err(make_trap)
     }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -48,7 +48,6 @@ pub(crate) use self::{
 use crate::{
     core::{Trap, TrapCode},
     func::FuncEntity,
-    store::ResourceLimiterRef,
     AsContext,
     AsContextMut,
     Func,
@@ -794,15 +793,11 @@ impl<'engine> EngineExecutor<'engine> {
             code.into()
         }
 
-        let store_inner = &mut ctx.store.inner;
+        let (store_inner, resource_limiter) = ctx.store.store_inner_and_resource_limiter_ref();
         let value_stack = &mut self.stack.values;
         let call_stack = &mut self.stack.frames;
         let code_map = &self.res.code_map;
         let const_pool = self.res.const_pool.view();
-        let resource_limiter = ResourceLimiterRef(match &mut ctx.store.limiter {
-            Some(q) => Some(q.0(&mut ctx.store.data)),
-            None => None,
-        });
 
         execute_wasm(
             store_inner,

--- a/crates/wasmi/src/func/typed_func.rs
+++ b/crates/wasmi/src/func/typed_func.rs
@@ -173,9 +173,7 @@ impl<Results> Default for CallResultsTuple<Results> {
 impl<Results> Copy for CallResultsTuple<Results> {}
 impl<Results> Clone for CallResultsTuple<Results> {
     fn clone(&self) -> Self {
-        Self {
-            _marker: PhantomData,
-        }
+        *self
     }
 }
 

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -146,7 +146,7 @@ pub use self::{
     },
     global::{Global, GlobalType, Mutability},
     instance::{Export, ExportsIter, Extern, ExternType, Instance},
-    limits::ResourceLimiter,
+    limits::{ResourceLimiter, StoreLimits, StoreLimitsBuilder},
     linker::Linker,
     memory::{Memory, MemoryType},
     module::{

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -93,6 +93,7 @@ mod externref;
 mod func;
 mod global;
 mod instance;
+mod limits;
 mod linker;
 mod memory;
 mod module;
@@ -145,6 +146,7 @@ pub use self::{
     },
     global::{Global, GlobalType, Mutability},
     instance::{Export, ExportsIter, Extern, ExternType, Instance},
+    limits::ResourceLimiter,
     linker::Linker,
     memory::{Memory, MemoryType},
     module::{

--- a/crates/wasmi/src/limits.rs
+++ b/crates/wasmi/src/limits.rs
@@ -257,7 +257,7 @@ impl ResourceLimiter for StoreLimits {
 
     fn table_growing(
         &mut self,
-        _current: u32,
+        current: u32,
         desired: u32,
         maximum: Option<u32>,
     ) -> Result<bool, TableError> {
@@ -269,7 +269,11 @@ impl ResourceLimiter for StoreLimits {
             },
         };
         if !allow && self.trap_on_grow_failure {
-            Err(TableError::GrowOutOfBounds)
+            Err(TableError::GrowOutOfBounds {
+                maximum: maximum.unwrap_or(u32::MAX),
+                current: current,
+                delta: desired - current,
+            })
         } else {
             Ok(allow)
         }

--- a/crates/wasmi/src/limits.rs
+++ b/crates/wasmi/src/limits.rs
@@ -257,7 +257,7 @@ impl ResourceLimiter for StoreLimits {
 
     fn table_growing(
         &mut self,
-        current: u32,
+        _current: u32,
         desired: u32,
         maximum: Option<u32>,
     ) -> Result<bool, TableError> {

--- a/crates/wasmi/src/limits.rs
+++ b/crates/wasmi/src/limits.rs
@@ -1,0 +1,39 @@
+use crate::{memory::MemoryError, table::TableError};
+
+/// Value returned by [`ResourceLimiter::instances`] default method
+pub const DEFAULT_INSTANCE_LIMIT: usize = 10000;
+
+/// Value returned by [`ResourceLimiter::tables`] default method
+pub const DEFAULT_TABLE_LIMIT: usize = 10000;
+
+/// Value returned by [`ResourceLimiter::memories`] default method
+pub const DEFAULT_MEMORY_LIMIT: usize = 10000;
+
+pub trait ResourceLimiter {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> Result<bool, MemoryError>;
+
+    fn table_growing(
+        &mut self,
+        current: u32,
+        desired: u32,
+        maximum: Option<u32>,
+    ) -> Result<bool, TableError>;
+
+    // Provided methods
+    fn memory_grow_failed(&mut self, _error: &MemoryError) {}
+    fn table_grow_failed(&mut self, _error: &TableError) {}
+    fn instances(&self) -> usize {
+        DEFAULT_INSTANCE_LIMIT
+    }
+    fn tables(&self) -> usize {
+        DEFAULT_TABLE_LIMIT
+    }
+    fn memories(&self) -> usize {
+        DEFAULT_MEMORY_LIMIT
+    }
+}

--- a/crates/wasmi/src/limits.rs
+++ b/crates/wasmi/src/limits.rs
@@ -9,7 +9,53 @@ pub const DEFAULT_TABLE_LIMIT: usize = 10000;
 /// Value returned by [`ResourceLimiter::memories`] default method
 pub const DEFAULT_MEMORY_LIMIT: usize = 10000;
 
+/// Used by hosts to limit resource consumption of instances.
+///
+/// This trait is used in conjunction with the
+/// [`Store::limiter`](crate::Store::limiter) to limit the
+/// allocation of resources within a store. As a store-level limit this means
+/// that all creation of instances, memories, and tables are limited within the
+/// store. Resources limited via this trait are primarily related to memory and
+/// limiting CPU resources needs to be done with something such as
+/// [`Config::consume_fuel`](crate::Config::consume_fuel).
+///
+/// Note that this trait does not limit 100% of memory allocated via a
+/// [`Store`](crate::Store). Wasmi will still allocate memory to track data
+/// structures and additionally embedder-specific memory allocations are not
+/// tracked via this trait. This trait only limits resources allocated by a
+/// WebAssembly instance itself.
 pub trait ResourceLimiter {
+    /// Notifies the resource limiter that an instance's linear memory has been
+    /// requested to grow.
+    ///
+    /// * `current` is the current size of the linear memory in bytes.
+    /// * `desired` is the desired size of the linear memory in bytes.
+    /// * `maximum` is either the linear memory's maximum or a maximum from an
+    ///   instance allocator, also in bytes. A value of `None`
+    ///   indicates that the linear memory is unbounded.
+    ///
+    /// The `current` and `desired` amounts are guaranteed to always be
+    /// multiples of the WebAssembly page size, 64KiB.
+    ///
+    /// ## Return Value
+    ///
+    /// If `Ok(true)` is returned from this function then the growth operation
+    /// is allowed. This means that the wasm `memory.grow` instruction will
+    /// return with the `desired` size, in wasm pages. Note that even if
+    /// `Ok(true)` is returned, though, if `desired` exceeds `maximum` then the
+    /// growth operation will still fail.
+    ///
+    /// If `Ok(false)` is returned then this will cause the `memory.grow`
+    /// instruction in a module to return -1 (failure), or in the case of an
+    /// embedder API calling [`Memory::new`](crate::Memory::new) or
+    /// [`Memory::grow`](crate::Memory::grow) an error will be returned from
+    /// those methods.
+    ///
+    /// If `Err(e)` is returned then the `memory.grow` function will behave
+    /// as if a trap has been raised. Note that this is not necessarily
+    /// compliant with the WebAssembly specification but it can be a handy and
+    /// useful tool to get a precise backtrace at "what requested so much memory
+    /// to cause a growth failure?".
     fn memory_growing(
         &mut self,
         current: usize,
@@ -17,6 +63,16 @@ pub trait ResourceLimiter {
         maximum: Option<usize>,
     ) -> Result<bool, MemoryError>;
 
+    /// Notifies the resource limiter that an instance's table has been
+    /// requested to grow.
+    ///
+    /// * `current` is the current number of elements in the table.
+    /// * `desired` is the desired number of elements in the table.
+    /// * `maximum` is either the table's maximum or a maximum from an instance
+    ///   allocator.  A value of `None` indicates that the table is unbounded.
+    ///
+    /// See the details on the return values for `memory_growing` for what the
+    /// return value of this function indicates.
     fn table_growing(
         &mut self,
         current: u32,
@@ -24,16 +80,210 @@ pub trait ResourceLimiter {
         maximum: Option<u32>,
     ) -> Result<bool, TableError>;
 
-    // Provided methods
+    /// Notifies the resource limiter that growing a linear memory, permitted by
+    /// the `memory_growing` method, has failed.
     fn memory_grow_failed(&mut self, _error: &MemoryError) {}
+
+    /// Notifies the resource limiter that growing a linear memory, permitted by
+    /// the `table_growing` method, has failed.
     fn table_grow_failed(&mut self, _error: &TableError) {}
+
+    /// The maximum number of instances that can be created for a `Store`.
+    ///
+    /// Module instantiation will fail if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
     fn instances(&self) -> usize {
         DEFAULT_INSTANCE_LIMIT
     }
+
+    /// The maximum number of tables that can be created for a `Store`.
+    ///
+    /// Creation of tables will fail if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
     fn tables(&self) -> usize {
         DEFAULT_TABLE_LIMIT
     }
+
+    /// The maximum number of linear memories that can be created for a `Store`
+    ///
+    /// Creation of memories will fail with an error if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
     fn memories(&self) -> usize {
         DEFAULT_MEMORY_LIMIT
+    }
+}
+
+/// Used to build [`StoreLimits`].
+pub struct StoreLimitsBuilder(StoreLimits);
+
+impl StoreLimitsBuilder {
+    /// Creates a new [`StoreLimitsBuilder`].
+    ///
+    /// See the documentation on each builder method for the default for each
+    /// value.
+    pub fn new() -> Self {
+        Self(StoreLimits::default())
+    }
+
+    /// The maximum number of bytes a linear memory can grow to.
+    ///
+    /// Growing a linear memory beyond this limit will fail. This limit is
+    /// applied to each linear memory individually, so if a wasm module has
+    /// multiple linear memories then they're all allowed to reach up to the
+    /// `limit` specified.
+    ///
+    /// By default, linear memory will not be limited.
+    pub fn memory_size(mut self, limit: usize) -> Self {
+        self.0.memory_size = Some(limit);
+        self
+    }
+
+    /// The maximum number of elements in a table.
+    ///
+    /// Growing a table beyond this limit will fail. This limit is applied to
+    /// each table individually, so if a wasm module has multiple tables then
+    /// they're all allowed to reach up to the `limit` specified.
+    ///
+    /// By default, table elements will not be limited.
+    pub fn table_elements(mut self, limit: u32) -> Self {
+        self.0.table_elements = Some(limit);
+        self
+    }
+
+    /// The maximum number of instances that can be created for a [`Store`](crate::Store).
+    ///
+    /// Module instantiation will fail if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
+    pub fn instances(mut self, limit: usize) -> Self {
+        self.0.instances = limit;
+        self
+    }
+
+    /// The maximum number of tables that can be created for a [`Store`](crate::Store).
+    ///
+    /// Module instantiation will fail if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
+    pub fn tables(mut self, tables: usize) -> Self {
+        self.0.tables = tables;
+        self
+    }
+
+    /// The maximum number of linear memories that can be created for a [`Store`](crate::Store).
+    ///
+    /// Instantiation will fail with an error if this limit is exceeded.
+    ///
+    /// This value defaults to 10,000.
+    pub fn memories(mut self, memories: usize) -> Self {
+        self.0.memories = memories;
+        self
+    }
+
+    /// Indicates that a trap should be raised whenever a growth operation
+    /// would fail.
+    ///
+    /// This operation will force `memory.grow` and `table.grow` instructions
+    /// to raise a trap on failure instead of returning -1. This is not
+    /// necessarily spec-compliant, but it can be quite handy when debugging a
+    /// module that fails to allocate memory and might behave oddly as a result.
+    ///
+    /// This value defaults to `false`.
+    pub fn trap_on_grow_failure(mut self, trap: bool) -> Self {
+        self.0.trap_on_grow_failure = trap;
+        self
+    }
+
+    /// Consumes this builder and returns the [`StoreLimits`].
+    pub fn build(self) -> StoreLimits {
+        self.0
+    }
+}
+
+/// Provides limits for a [`Store`](crate::Store).
+///
+/// This type is created with a [`StoreLimitsBuilder`] and is typically used in
+/// conjunction with [`Store::limiter`](crate::Store::limiter).
+///
+/// This is a convenience type included to avoid needing to implement the
+/// [`ResourceLimiter`] trait if your use case fits in the static configuration
+/// that this [`StoreLimits`] provides.
+#[derive(Clone, Debug)]
+pub struct StoreLimits {
+    memory_size: Option<usize>,
+    table_elements: Option<u32>,
+    instances: usize,
+    tables: usize,
+    memories: usize,
+    trap_on_grow_failure: bool,
+}
+
+impl Default for StoreLimits {
+    fn default() -> Self {
+        Self {
+            memory_size: None,
+            table_elements: None,
+            instances: DEFAULT_INSTANCE_LIMIT,
+            tables: DEFAULT_TABLE_LIMIT,
+            memories: DEFAULT_MEMORY_LIMIT,
+            trap_on_grow_failure: false,
+        }
+    }
+}
+
+impl ResourceLimiter for StoreLimits {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> Result<bool, MemoryError> {
+        let allow = match self.memory_size {
+            Some(limit) if desired > limit => false,
+            _ => match maximum {
+                Some(max) if desired > max => false,
+                _ => true,
+            },
+        };
+        if !allow && self.trap_on_grow_failure {
+            Err(MemoryError::OutOfBoundsGrowth)
+        } else {
+            Ok(allow)
+        }
+    }
+
+    fn table_growing(
+        &mut self,
+        current: u32,
+        desired: u32,
+        maximum: Option<u32>,
+    ) -> Result<bool, TableError> {
+        let allow = match self.table_elements {
+            Some(limit) if desired > limit => false,
+            _ => match maximum {
+                Some(max) if desired > max => false,
+                _ => true,
+            },
+        };
+        if !allow && self.trap_on_grow_failure {
+            Err(TableError::GrowOutOfBounds)
+        } else {
+            Ok(allow)
+        }
+    }
+
+    fn instances(&self) -> usize {
+        self.instances
+    }
+
+    fn tables(&self) -> usize {
+        self.tables
+    }
+
+    fn memories(&self) -> usize {
+        self.memories
     }
 }

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -649,6 +649,8 @@ impl<T> Linker<T> {
         module: &Module,
     ) -> Result<InstancePre, Error> {
         assert!(Engine::same(self.engine(), context.as_context().engine()));
+        // TODO: possibly add further resource limtation here on number of externals.
+        // Not clear that user can't import the same external lots of times to inflate this.
         let externals = module
             .imports()
             .map(|import| self.process_import(&mut context, import))

--- a/crates/wasmi/src/memory/error.rs
+++ b/crates/wasmi/src/memory/error.rs
@@ -31,7 +31,7 @@ impl Display for MemoryError {
                 write!(f, "out of bounds memory allocation")
             }
             Self::OutOfBoundsGrowth => {
-                write!(f, "out fo bounds memory growth")
+                write!(f, "out of bounds memory growth")
             }
             Self::OutOfBoundsAccess => {
                 write!(f, "out of bounds memory access")

--- a/crates/wasmi/src/memory/error.rs
+++ b/crates/wasmi/src/memory/error.rs
@@ -20,6 +20,8 @@ pub enum MemoryError {
         /// The [`MemoryType`] which is supposed to be a supertype of `ty`.
         other: MemoryType,
     },
+    /// Tried to create too many memories
+    TooManyMemories,
 }
 
 impl Display for MemoryError {
@@ -39,6 +41,9 @@ impl Display for MemoryError {
             }
             Self::InvalidSubtype { ty, other } => {
                 write!(f, "memory type {ty:?} is not a subtype of {other:?}",)
+            }
+            Self::TooManyMemories => {
+                write!(f, "too many memories")
             }
         }
     }

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -238,7 +238,7 @@ impl MemoryEntity {
         }
 
         // If there was an error, ResourceLimiter gets to see.
-        if let Err(e) = &ret {
+        if ret.is_err() {
             if let Some(limiter) = limiter.as_resource_limiter() {
                 limiter.memory_grow_failed(&MemoryError::OutOfBoundsGrowth)
             }

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -316,6 +316,7 @@ impl Memory {
             .as_context_mut()
             .store
             .store_inner_and_resource_limiter_ref();
+
         let entity = MemoryEntity::new(ty, &mut resource_limiter)?;
         let memory = inner.alloc_memory(entity);
         Ok(memory)

--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -49,6 +49,7 @@ pub enum InstantiationError {
         /// The index of the found `start` function.
         index: u32,
     },
+    TooManyInstances,
 }
 
 #[cfg(feature = "std")]
@@ -85,6 +86,7 @@ impl Display for InstantiationError {
             Self::Table(error) => Display::fmt(error, f),
             Self::Memory(error) => Display::fmt(error, f),
             Self::Global(error) => Display::fmt(error, f),
+            Self::TooManyInstances => write!(f, "too many instances")
         }
     }
 }

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -57,7 +57,10 @@ impl Module {
         let handle = context.as_context_mut().store.inner.alloc_instance();
         let mut builder = InstanceEntity::build(self);
 
-        context.as_context_mut().store.bump_resource_counts(self)?;
+        #[cfg(feature = "std")]
+        {
+            context.as_context_mut().store.bump_resource_counts(self)?;
+        }
 
         self.extract_imports(&mut context, &mut builder, externals)?;
         self.extract_functions(&mut context, &mut builder, handle);

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -8,7 +8,7 @@ pub use self::{error::InstantiationError, pre::InstancePre};
 use super::{element::ElementSegmentKind, export, ConstExpr, DataSegmentKind, Module};
 use crate::{
     func::WasmFuncEntity,
-    memory::DataSegment,
+    memory::{DataSegment, MemoryError},
     value::WithType,
     AsContext,
     AsContextMut,
@@ -65,7 +65,7 @@ impl Module {
         self.extract_imports(&mut context, &mut builder, externals)?;
         self.extract_functions(&mut context, &mut builder, handle);
         self.extract_tables(&mut context, &mut builder)?;
-        self.extract_memories(&mut context, &mut builder);
+        self.extract_memories(&mut context, &mut builder)?;
         self.extract_globals(&mut context, &mut builder);
         self.extract_exports(&mut builder);
         self.extract_start_fn(&mut builder);
@@ -209,17 +209,12 @@ impl Module {
         &self,
         context: &mut impl AsContextMut,
         builder: &mut InstanceEntityBuilder,
-    ) {
+    ) -> Result<(), MemoryError> {
         for memory_type in self.internal_memories().copied() {
-            let memory =
-                Memory::new(context.as_context_mut(), memory_type).unwrap_or_else(|error| {
-                    panic!(
-                        "encountered unexpected invalid memory type \
-                        {memory_type:?} after Wasm validation: {error}",
-                    )
-                });
+            let memory = Memory::new(context.as_context_mut(), memory_type)?;
             builder.push_memory(memory);
         }
+        Ok(())
     }
 
     /// Extracts the Wasm global variables from the module and stores them into the [`Store`].

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -57,6 +57,8 @@ impl Module {
         let handle = context.as_context_mut().store.inner.alloc_instance();
         let mut builder = InstanceEntity::build(self);
 
+        context.as_context_mut().store.bump_resource_counts(self)?;
+
         self.extract_imports(&mut context, &mut builder, externals)?;
         self.extract_functions(&mut context, &mut builder, handle);
         self.extract_tables(&mut context, &mut builder)?;

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -756,7 +756,7 @@ impl<T> Store<T> {
         let (inner, mut limiter) = self.store_inner_and_resource_limiter_ref();
         if let Some(limiter) = limiter.as_resource_limiter() {
             if inner.instances.len().saturating_add(num_new_instances) > limiter.instances() {
-                return Err(InstantiationError::TooManyInstances.into());
+                return Err(InstantiationError::TooManyInstances);
             }
         }
         Ok(())

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -71,7 +71,7 @@ impl StoreIdx {
 /// A stored entity.
 pub type Stored<Idx> = GuardedEntity<StoreIdx, Idx>;
 
-pub struct ResourceLimiterRef<'a>(pub(crate) Option<&'a mut (dyn crate::ResourceLimiter)>);
+pub struct ResourceLimiterRef<'a>(Option<&'a mut (dyn crate::ResourceLimiter)>);
 impl<'a> core::fmt::Debug for ResourceLimiterRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ResourceLimiterRef(...)")

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -106,7 +106,7 @@ pub struct Store<T> {
     trampolines: Arena<TrampolineIdx, TrampolineEntity<T>>,
     /// User provided host data owned by the [`Store`].
     data: T,
-    /// User provided hook to retrieve a [`ResourceLimiter`].
+    /// User provided hook to retrieve a [`crate::ResourceLimiter`].
     limiter: Option<ResourceLimiterQuery<T>>,
 }
 

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -28,7 +28,6 @@ use crate::{
     TableEntity,
     TableIdx,
 };
-#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 use core::{
     fmt::{self, Debug},

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -752,6 +752,9 @@ impl<T> Store<T> {
         self.data
     }
 
+    /// Installs a function into the [`Store`] that will be called with the user
+    /// data type `T` to retrieve a [`ResourceLimiter`] any time a limited,
+    /// growable resource such as a linear memory or table is grown.
     pub fn limiter(
         &mut self,
         limiter: impl FnMut(&mut T) -> &mut (dyn ResourceLimiter) + Send + Sync + 'static,

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -89,7 +89,7 @@ impl<'a> ResourceLimiterRef<'a> {
 
 /// A wrapper around a boxed `dyn FnMut(&mut T)` returning a `&mut dyn`
 /// [`ResourceLimiter`]; in other words a function that one can call to retrieve
-/// a [`ResourceLimiter`] from the [`State`] object's user data type `T`.
+/// a [`ResourceLimiter`] from the [`Store`] object's user data type `T`.
 ///
 /// This wrapper exists both to make types a little easier to read and to
 /// provide a `Debug` impl so that `#[derive(Debug)]` works on structs that

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -28,7 +28,7 @@ use crate::{
     TableEntity,
     TableIdx,
 };
-#[cfg(feature = "std")]
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 use core::{
     fmt::{self, Debug},

--- a/crates/wasmi/src/table/error.rs
+++ b/crates/wasmi/src/table/error.rs
@@ -7,7 +7,14 @@ use core::{fmt, fmt::Display};
 #[non_exhaustive]
 pub enum TableError {
     /// Occurs when growing a table out of its set bounds.
-    GrowOutOfBounds,
+    GrowOutOfBounds {
+        /// The maximum allowed table size.
+        maximum: u32,
+        /// The current table size before the growth operation.
+        current: u32,
+        /// The amount of requested invalid growth.
+        delta: u32,
+    },
     /// Occurs when operating with a [`Table`](crate::Table) and mismatching element types.
     ElementTypeMismatch {
         /// Expected element type for the [`Table`](crate::Table).
@@ -37,8 +44,16 @@ pub enum TableError {
 impl Display for TableError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::GrowOutOfBounds => {
-                write!(f, "out of bounds table growth")
+            Self::GrowOutOfBounds {
+                maximum,
+                current,
+                delta,
+            } => {
+                write!(
+                    f,
+                    "tried to grow table with size of {current} and maximum of \
+                                    {maximum} by {delta} out of bounds",
+                )
             }
             Self::ElementTypeMismatch { expected, actual } => {
                 write!(f, "encountered mismatching table element type, expected {expected:?} but found {actual:?}")

--- a/crates/wasmi/src/table/error.rs
+++ b/crates/wasmi/src/table/error.rs
@@ -7,14 +7,7 @@ use core::{fmt, fmt::Display};
 #[non_exhaustive]
 pub enum TableError {
     /// Occurs when growing a table out of its set bounds.
-    GrowOutOfBounds {
-        /// The maximum allowed table size.
-        maximum: u32,
-        /// The current table size before the growth operation.
-        current: u32,
-        /// The amount of requested invalid growth.
-        delta: u32,
-    },
+    GrowOutOfBounds,
     /// Occurs when operating with a [`Table`](crate::Table) and mismatching element types.
     ElementTypeMismatch {
         /// Expected element type for the [`Table`](crate::Table).
@@ -44,16 +37,8 @@ pub enum TableError {
 impl Display for TableError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::GrowOutOfBounds {
-                maximum,
-                current,
-                delta,
-            } => {
-                write!(
-                    f,
-                    "tried to grow table with size of {current} and maximum of \
-                    {maximum} by {delta} out of bounds",
-                )
+            Self::GrowOutOfBounds => {
+                write!(f, "out of bounds table growth")
             }
             Self::ElementTypeMismatch { expected, actual } => {
                 write!(f, "encountered mismatching table element type, expected {expected:?} but found {actual:?}")

--- a/crates/wasmi/src/table/error.rs
+++ b/crates/wasmi/src/table/error.rs
@@ -38,6 +38,7 @@ pub enum TableError {
         /// The [`TableType`] which is supposed to be a supertype of `ty`.
         other: TableType,
     },
+    TooManyTables,
 }
 
 impl Display for TableError {
@@ -69,6 +70,9 @@ impl Display for TableError {
             }
             Self::InvalidSubtype { ty, other } => {
                 write!(f, "table type {ty:?} is not a subtype of {other:?}",)
+            }
+            Self::TooManyTables => {
+                write!(f, "too many tables")
             }
         }
     }

--- a/crates/wasmi/src/table/mod.rs
+++ b/crates/wasmi/src/table/mod.rs
@@ -586,7 +586,6 @@ impl Table {
         mut ctx: impl AsContextMut,
         delta: u32,
         init: Value,
-        limiter: &mut ResourceLimiterRef<'_>,
     ) -> Result<u32, TableError> {
         let (inner, mut limiter) = ctx
             .as_context_mut()

--- a/crates/wasmi/src/table/mod.rs
+++ b/crates/wasmi/src/table/mod.rs
@@ -161,7 +161,7 @@ impl TableEntity {
         ty.matches_element_type(init.ty())?;
 
         if let Some(limiter) = limiter.as_resource_limiter() {
-            if limiter.table_growing(0, ty.minimum(), ty.maximum())? {
+            if !limiter.table_growing(0, ty.minimum(), ty.maximum())? {
                 // Here there's no meaningful way to map Ok(false) to
                 // INVALID_GROWTH_ERRCODE, so we just translate it to an
                 // appropriate Err(...)

--- a/crates/wasmi/tests/e2e/v1/mod.rs
+++ b/crates/wasmi/tests/e2e/v1/mod.rs
@@ -2,4 +2,5 @@ mod fuel_consumption_mode;
 mod fuel_metering;
 mod func;
 mod host_calls_wasm;
+mod resource_limiter;
 mod resumable_call;

--- a/crates/wasmi/tests/e2e/v1/resource_limiter.rs
+++ b/crates/wasmi/tests/e2e/v1/resource_limiter.rs
@@ -1,0 +1,209 @@
+//! Tests to check if wasmi's ResourceLimiter works as intended.
+use wasmi::{
+    Config,
+    Engine,
+    Error,
+    Linker,
+    Module,
+    Store,
+    StoreLimits,
+    StoreLimitsBuilder,
+    TypedFunc,
+};
+use wasmi_core::TrapCode;
+
+/// Setup [`Engine`] and [`Store`] for resource limiting.
+fn test_setup(limits: StoreLimits) -> (Store<StoreLimits>, Linker<StoreLimits>) {
+    let config = Config::default();
+    let engine = Engine::new(&config);
+    let mut store = Store::new(&engine, limits);
+    store.limiter(|limits| limits);
+    let linker = Linker::new(&engine);
+    (store, linker)
+}
+
+/// Converts the `wat` string source into `wasm` encoded byte.
+fn wat2wasm(wat: &str) -> Vec<u8> {
+    wat::parse_str(wat).unwrap()
+}
+
+/// Compiles the `wasm` encoded bytes into a [`Module`].
+///
+/// # Panics
+///
+/// If an error occurred upon module compilation, validation or translation.
+fn create_module(store: &Store<StoreLimits>, bytes: &[u8]) -> Result<Module, Error> {
+    Module::new(store.engine(), bytes)
+}
+
+struct Test {
+    store: Store<StoreLimits>,
+    memory_grow: TypedFunc<(i32,), i32>,
+    memory_size: TypedFunc<(), i32>,
+    table_grow: TypedFunc<(i32,), i32>,
+    table_size: TypedFunc<(), i32>,
+}
+
+impl Test {
+    fn new(mem_pages: i32, table_elts: i32, limits: StoreLimits) -> Result<Self, Error> {
+        let wasm = wat2wasm(&format!(
+            r#"
+        (module
+            (memory {})
+            (table {} funcref)
+            (func (export "memory_grow") (param $pages i32) (result i32) (memory.grow (local.get $pages)))
+            (func (export "memory_size") (result i32) (memory.size))
+            (func (export "table_grow") (param $elts i32) (result i32) (table.grow (ref.func 0) (local.get $elts)))
+            (func (export "table_size") (result i32) (table.size))
+        )
+        "#,
+            mem_pages, table_elts
+        ));
+        let (mut store, linker) = test_setup(limits);
+        let module = create_module(&store, &wasm)?;
+        let instance = linker.instantiate(&mut store, &module)?.start(&mut store)?;
+        let memory_grow = instance.get_func(&store, "memory_grow").unwrap();
+        let memory_size = instance.get_func(&store, "memory_size").unwrap();
+        let table_grow = instance.get_func(&store, "table_grow").unwrap();
+        let table_size = instance.get_func(&store, "table_size").unwrap();
+        let memory_grow = memory_grow.typed::<(i32,), i32>(&store)?;
+        let memory_size = memory_size.typed::<(), i32>(&store)?;
+        let table_grow = table_grow.typed::<(i32,), i32>(&store)?;
+        let table_size = table_size.typed::<(), i32>(&store)?;
+        Ok(Self {
+            store,
+            memory_grow,
+            memory_size,
+            table_grow,
+            table_size,
+        })
+    }
+}
+
+#[test]
+fn test_big_memory_fails_to_instantiate() {
+    let loose_limits = StoreLimitsBuilder::new().memory_size(0x30_0000).build();
+    let tight_limits = StoreLimitsBuilder::new().memory_size(0x20_0000).build();
+    assert!(Test::new(0x30, 0, loose_limits).is_ok());
+    assert!(Test::new(0x30, 0, tight_limits).is_err());
+}
+
+#[test]
+fn test_big_table_fails_to_instantiate() {
+    let loose_limits = StoreLimitsBuilder::new().table_elements(100).build();
+    let tight_limits = StoreLimitsBuilder::new().table_elements(99).build();
+    assert!(Test::new(0x30, 100, loose_limits).is_ok());
+    assert!(Test::new(0x30, 100, tight_limits).is_err());
+}
+
+#[test]
+fn test_memory_count_limit() {
+    let limits = StoreLimitsBuilder::new().memories(0).build();
+    assert!(Test::new(0x30, 100, limits).is_err());
+}
+
+#[test]
+fn test_instance_count_limit() {
+    let limits = StoreLimitsBuilder::new().instances(0).build();
+    assert!(Test::new(0x30, 100, limits).is_err());
+}
+
+#[test]
+fn test_tables_count_limit() {
+    let limits = StoreLimitsBuilder::new().tables(0).build();
+    assert!(Test::new(0x30, 100, limits).is_err());
+}
+
+#[test]
+fn test_memory_does_not_grow_on_limited_growth() -> Result<(), Error> {
+    let limits = StoreLimitsBuilder::new().memory_size(0x30_0000).build();
+    let mut test = Test::new(0x20, 100, limits)?;
+    // By default the policy of a memory.grow failure is just for the instruction
+    // to return -1 and not-grow the underlying memory. We also have the option to
+    // trap on failure, which is exercised by the next test below.
+
+    // Check memory size is what we expect.
+    assert_eq!(test.memory_size.call(&mut test.store, ())?, 0x20);
+    // First memory.grow doesn't hit the limit, so succeeds, returns previous size.
+    assert_eq!(test.memory_grow.call(&mut test.store, (0x10,))?, 0x20);
+    // Check memory size is what we expect.
+    assert_eq!(test.memory_size.call(&mut test.store, ())?, 0x30);
+    // Second call goes past the limit, so fails to grow the memory, but returns Ok(-1)
+    assert_eq!(test.memory_grow.call(&mut test.store, (0x10,))?, -1);
+    // Check memory size is what we expect.
+    assert_eq!(test.memory_size.call(&mut test.store, ())?, 0x30);
+    Ok(())
+}
+
+#[test]
+fn test_memory_traps_on_limited_growth() -> Result<(), Error> {
+    let limits = StoreLimitsBuilder::new()
+        .memory_size(0x30_0000)
+        .trap_on_grow_failure(true)
+        .build();
+    let mut test = Test::new(0x20, 100, limits)?;
+    // Check memory size is what we expect.
+    assert_eq!(test.memory_size.call(&mut test.store, ())?, 0x20);
+    // First memory.grow doesn't hit the limit, so succeeds, returns previous size.
+    assert_eq!(test.memory_grow.call(&mut test.store, (0x10,))?, 0x20);
+    // Check memory size is what we expect.
+    assert_eq!(test.memory_size.call(&mut test.store, ())?, 0x30);
+    // Second call goes past the limit, so fails to grow the memory, and we've configured it to trap.
+    assert!(matches!(
+        test.memory_grow
+            .call(&mut test.store, (0x10,))
+            .unwrap_err()
+            .trap_code(),
+        Some(TrapCode::GrowthOperationLimited)
+    ));
+    // Check memory size is what we expect.
+    assert_eq!(test.memory_size.call(&mut test.store, ())?, 0x30);
+    Ok(())
+}
+
+#[test]
+fn test_table_does_not_grow_on_limited_growth() -> Result<(), Error> {
+    let limits = StoreLimitsBuilder::new().table_elements(100).build();
+    let mut test = Test::new(0x20, 99, limits)?;
+    // By default the policy of a table.grow failure is just for the instruction
+    // to return -1 and not-grow the underlying table. We also have the option to
+    // trap on failure, which is exercised by the next test below.
+
+    // Check table size is what we expect.
+    assert_eq!(test.table_size.call(&mut test.store, ())?, 99);
+    // First table.grow doesn't hit the limit, so succeeds, returns previous size.
+    assert_eq!(test.table_grow.call(&mut test.store, (1,))?, 99);
+    // Check table size is what we expect.
+    assert_eq!(test.table_size.call(&mut test.store, ())?, 100);
+    // Second call goes past the limit, so fails to grow the table, but returns Ok(-1)
+    assert_eq!(test.table_grow.call(&mut test.store, (1,))?, -1);
+    // Check table size is what we expect.
+    assert_eq!(test.table_size.call(&mut test.store, ())?, 100);
+    Ok(())
+}
+
+#[test]
+fn test_table_traps_on_limited_growth() -> Result<(), Error> {
+    let limits = StoreLimitsBuilder::new()
+        .table_elements(100)
+        .trap_on_grow_failure(true)
+        .build();
+    let mut test = Test::new(0x20, 99, limits)?;
+    // Check table size is what we expect.
+    assert_eq!(test.table_size.call(&mut test.store, ())?, 99);
+    // First table.grow doesn't hit the limit, so succeeds, returns previous size.
+    assert_eq!(test.table_grow.call(&mut test.store, (1,))?, 99);
+    // Check table size is what we expect.
+    assert_eq!(test.table_size.call(&mut test.store, ())?, 100);
+    // Second call goes past the limit, so fails to grow the table, and we've configured it to trap.
+    assert!(matches!(
+        test.table_grow
+            .call(&mut test.store, (1,))
+            .unwrap_err()
+            .trap_code(),
+        Some(TrapCode::GrowthOperationLimited)
+    ));
+    // Check table size is what we expect.
+    assert_eq!(test.table_size.call(&mut test.store, ())?, 100);
+    Ok(())
+}


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/728.

This implements the `wasmtime` `ResourceLimiter` API, as discussed in bug https://github.com/paritytech/wasmi/issues/728 .

Current limitations, caveats and points to discuss/review:

- ~Missing tests~
- ~Missing docs~
- ~Missing convenience types `StoreLimits` and `StoreLimitsBuilder`~
- To keep `#[derive(Debug)]` working I had to add a couple wrapper types.
- ~As much as possible, I tried to track `wasmtime`'s implementation: the `{instance,memory,table}_{count,limit}` fields, the `Store::bump_resource_counts` method, the `limits.rs` file, the global defaults returned from the default methods, etc. etc. This all feels like a fairly weird design to me (information cached or returned from multiple places) but I figured you'd prefer to follow along their lead rather than make something gratuitously incompatible. Any deviations (see following points) were forced by differences between `wasmtime` and `wasmi`.~
- Awkwardly, because `wasmi` does not thread the full typed `Store<T>` into its executor context, only `StoreInner`, it's not possible to call the typed `FnMut(&mut T) -> &mut dyn ResourceLimiter` query API on `StoreInner` (it has no `data: T` element to pass as an argument) so I had to hoist the query up the call stack to caller sites that still have a `Store<T>` and then pass through a new `ResourceLimiterRef` type carrying the resulting ref. This seems to work but it's a bit ugly. The other options (refactoring `Store` and/or `Executor`) seemed worse.
- Unfortunately `wasmtime` just uses `anyhow::Error` everywhere, so `wasmi`'s specific error types all deviate. I did not do a lot of careful design work on the errors, I just reused those that already seemed to cover the cases and added new ones where necessary. They could theoretically be reorganized or refactored -- I don't care how they're represented at all, happy to do whatever you prefer.
- The `wasmtime` `ResourceLimiter` API actually seems .. fairly bad? I mean, it operates in terms of bytes (weird) and has the option of both returning an `Err(...)`-which-means-trap (which I didn't even try to support) _and_ returning `Ok(false)`-which-means-return-your-own-error. I am not sure how best to map its seemingly-bad-API-choices onto `wasmi`, I did my best.
- It also doesn't cap the number of globals, imports or exports, or any other sources of "too much stuff" in a wasm module. No explanation why. I think it probably should?
- Because `ResourceLimiter` wants to be called both before any inherent checks _and_ after any error occurs (including those resulting from inherent checks) I had to refactor the arithmetic in the memory and table growth functions, and repeat some code between initialization and growth. I believe I kept the logic the same. I might be able to factor some of this more, but it seems like diminishing returns.

Anyway, all that aside I _think_ this holds together. Feedback welcome!