### PR TITLE
Add `F64Const32` instruction

### DIFF
--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -14,6 +14,7 @@ pub use self::utils::{
     DropKeep,
     DropKeepError,
     ElementSegmentIdx,
+    F64Const32,
     FuncIdx,
     GlobalIdx,
     LocalDepth,
@@ -212,8 +213,17 @@ pub enum Instruction {
     /// # Note
     ///
     /// This is a space-optimized variant of [`Instruction::ConstRef`] but can
-    /// only used for small integer values that fit into a 24-bit integer value.
+    /// only used for small integer values that fit into a 32-bit integer value.
     I64Const32(i32),
+    /// A 64-bit float value losslessly encoded as 32-bit float.
+    ///
+    /// Upon execution the 32-bit float is promoted to the 64-bit float.
+    ///
+    /// # Note
+    ///
+    /// This is a space-optimized variant of [`Instruction::ConstRef`] but can
+    /// only used for certain float values that fit into a 32-bit float value.
+    F64Const32(F64Const32),
     /// Pushes a constant value onto the stack.
     ///
     /// The constant value is referred to indirectly by the [`ConstRef`].

--- a/crates/wasmi/src/engine/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/bytecode/utils.rs
@@ -7,7 +7,7 @@ pub struct F64Const32(u32);
 
 impl F64Const32 {
     /// Creates an [`Instruction::F64Const32`] from the given `f64` value if possible.
-    /// 
+    ///
     /// [`Instruction::F64Const32`]: [`super::Instruction::F64Const32`]
     pub fn new(value: f64) -> Option<Self> {
         let demoted = value as f32;

--- a/crates/wasmi/src/engine/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/bytecode/utils.rs
@@ -1,6 +1,28 @@
 use crate::engine::{func_builder::TranslationErrorInner, Instr, TranslationError};
 use core::fmt::{self, Display};
 
+/// A 32-bit encoded `f64` value.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct F64Const32(u32);
+
+impl F64Const32 {
+    /// Creates an [`Instruction::F64Const32`] from the given `f64` value if possible.
+    /// 
+    /// [`Instruction::F64Const32`]: [`super::Instruction::F64Const32`]
+    pub fn new(value: f64) -> Option<Self> {
+        let demoted = value as f32;
+        if f64::from(demoted).to_bits() != value.to_bits() {
+            return None;
+        }
+        Some(Self(demoted.to_bits()))
+    }
+
+    /// Returns the 32-bit encoded `f64` value.
+    pub fn to_f64(self) -> f64 {
+        f64::from(f32::from_bits(self.0))
+    }
+}
+
 /// A function index.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]

--- a/crates/wasmi/src/engine/executor.rs
+++ b/crates/wasmi/src/engine/executor.rs
@@ -1,4 +1,9 @@
-use super::{bytecode::BranchOffset, const_pool::ConstRef, CompiledFunc, ConstPoolView};
+use super::{
+    bytecode::{BranchOffset, F64Const32},
+    const_pool::ConstRef,
+    CompiledFunc,
+    ConstPoolView,
+};
 use crate::{
     core::TrapCode,
     engine::{
@@ -302,6 +307,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 Instr::RefFunc(func_index) => self.visit_ref_func(func_index),
                 Instr::Const32(bytes) => self.visit_const_32(bytes),
                 Instr::I64Const32(value) => self.visit_i64_const_32(value),
+                Instr::F64Const32(value) => self.visit_f64_const_32(value),
                 Instr::ConstRef(cref) => self.visit_const(cref),
                 Instr::I32Eqz => self.visit_i32_eqz(),
                 Instr::I32Eq => self.visit_i32_eq(),
@@ -1042,6 +1048,13 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     fn visit_i64_const_32(&mut self, value: i32) {
         let sign_extended = i64::from(value);
         self.sp.push(UntypedValue::from(sign_extended));
+        self.next_instr()
+    }
+
+    #[inline(always)]
+    fn visit_f64_const_32(&mut self, value: F64Const32) {
+        let promoted = value.to_f64();
+        self.sp.push(UntypedValue::from(promoted));
         self.next_instr()
     }
 


### PR DESCRIPTION
This is an optimization for certain constant `f64` values that can losslessly be encoded as 32-bit `f32` values. This way we can avoid allocating `ConstRef` for many common cases.