### PR TITLE
Refactor `reftype` `Transposer` conversion utility

### DIFF
--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -97,6 +97,7 @@ mod limits;
 mod linker;
 mod memory;
 mod module;
+mod reftype;
 mod store;
 mod table;
 mod value;

--- a/crates/wasmi/src/reftype.rs
+++ b/crates/wasmi/src/reftype.rs
@@ -4,7 +4,7 @@ use crate::core::UntypedValue;
 ///
 /// # Note
 ///
-/// This is primarily used for conversions of [`FuncRef`] and [`ExternRef`].
+/// This is used for conversions of [`FuncRef`] and [`ExternRef`].
 ///
 /// [`FuncRef`]: [`crate::FuncRef`]
 /// [`ExternRef`]: [`crate::ExternRef`]

--- a/crates/wasmi/src/reftype.rs
+++ b/crates/wasmi/src/reftype.rs
@@ -1,0 +1,35 @@
+use crate::core::UntypedValue;
+
+/// Utility type used to convert between `reftype` and [`UntypedValue`].
+///
+/// # Note
+///
+/// This is primarily used for conversions of [`FuncRef`] and [`ExternRef`].
+pub union Transposer<T: Copy> {
+    /// The `reftype` based representation.
+    pub reftype: T,
+    /// The integer based representation to model pointer types.
+    pub value: u64,
+}
+
+impl<T: Copy> Transposer<T> {
+    /// Creates a `null` [`Transposer`].
+    pub fn null() -> Self {
+        Self { value: 0 }
+    }
+}
+
+impl<T: Copy> Transposer<T> {
+    /// Creates a new [`Transposer`] from the given `reftype`.
+    pub fn new(reftype: T) -> Self {
+        Transposer { reftype }
+    }
+}
+
+impl<T: Copy> From<UntypedValue> for Transposer<T> {
+    fn from(untyped: UntypedValue) -> Self {
+        Transposer {
+            value: u64::from(untyped),
+        }
+    }
+}

--- a/crates/wasmi/src/reftype.rs
+++ b/crates/wasmi/src/reftype.rs
@@ -5,7 +5,7 @@ use crate::core::UntypedValue;
 /// # Note
 ///
 /// This is primarily used for conversions of [`FuncRef`] and [`ExternRef`].
-/// 
+///
 /// [`FuncRef`]: [`crate::FuncRef`]
 /// [`ExternRef`]: [`crate::ExternRef`]
 pub union Transposer<T: Copy> {

--- a/crates/wasmi/src/reftype.rs
+++ b/crates/wasmi/src/reftype.rs
@@ -5,6 +5,9 @@ use crate::core::UntypedValue;
 /// # Note
 ///
 /// This is primarily used for conversions of [`FuncRef`] and [`ExternRef`].
+/// 
+/// [`FuncRef`]: [`crate::FuncRef`]
+/// [`ExternRef`]: [`crate::ExternRef`]
 pub union Transposer<T: Copy> {
     /// The `reftype` based representation.
     pub reftype: T,


### PR DESCRIPTION
It is now based on `u64` instead of `UntypedValue` directly which makes more sense since `u64` is a more stable type and `UntypedValue` will likely change in the future, for example with the addition of the Wasm 128-bit SIMD proposal.

Also now both `FuncRef` and `ExternRef` share the same `Transposer` type.