### PR TITLE
Fix `[return_]call_indirect` miscompilation

### DIFF
--- a/crates/wasmi/src/engine/regmach/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/utils.rs
@@ -140,23 +140,41 @@ impl RegisterSpanIter {
         self.len() == 0
     }
 
+    /// Returns the [`Register`] with the minimum index of the [`RegisterSpanIter`].
+    fn min_register(&self) -> Register {
+        self.span().head()
+    }
+
+    /// Returns the [`Register`] with the maximum index of the [`RegisterSpanIter`].
+    ///
+    /// # Note
+    ///
+    /// - Returns [`Self::min_register`] in case the [`RegisterSpanIter`] is empty.
+    fn max_register(&self) -> Register {
+        self.clone()
+            .next_back()
+            .unwrap_or_else(|| self.min_register())
+    }
+
+    /// Returns `true` if the [`Register`] is contains in the [`RegisterSpanIter`].
+    pub fn contains(&self, register: Register) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let min = self.min_register();
+        let max = self.max_register();
+        min <= register && register <= max
+    }
+
     /// Returns `true` if both `self` and `other` have overlapping [`Register`].
     pub fn is_overlapping(&self, other: &Self) -> bool {
         if self.is_empty() || other.is_empty() {
             return false;
         }
-        let self_min = self.span().head().to_i16();
-        let other_min = other.span().head().to_i16();
-        let self_max = self
-            .clone()
-            .next_back()
-            .expect("self is non empty")
-            .to_i16();
-        let other_max = other
-            .clone()
-            .next_back()
-            .expect("other is non empty")
-            .to_i16();
+        let self_min = self.min_register();
+        let other_min = other.min_register();
+        let self_max = self.max_register();
+        let other_max = other.max_register();
         if self_min < other_min {
             other_min <= self_max
         } else {

--- a/crates/wasmi/src/engine/regmach/tests/op/return_call/indirect.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/return_call/indirect.rs
@@ -391,15 +391,56 @@ fn test_imm_params_dynamic_index() {
         )
         "#,
     );
-    let params = RegisterSpan::new(Register::from_i16(1)).iter(2);
+    let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
         .expect_func_instrs([
             Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::copy_imm32(Register::from_i16(1), 10),
-            Instruction::copy_imm32(Register::from_i16(2), 20),
+            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
+            Instruction::copy_imm32(Register::from_i16(0), 10),
+            Instruction::copy_imm32(Register::from_i16(1), 20),
             Instruction::return_call_indirect(SignatureIdx::from(0)),
-            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::call_indirect_params(Register::from_i16(2), TableIdx::from(0)),
+            Instruction::call_params(params, 1),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn regression_issue768() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (type $sig (func (param i32 i32) (result i32)))
+            (table funcref (elem $f))
+            (global $g0 (mut i32) (i32.const 0))
+            (global $g1 (mut i32) (i32.const 1))
+            (func $f (param i32 i32) (result i32)
+                (i32.const 0)
+            )
+            (func (result i32)
+                (return_call_indirect (type $sig)
+                    (global.get $g0) (i32.const 20) ;; call params
+                    (global.get $g1) ;; index on dynamic register space
+                )
+            )
+        )
+        "#,
+    );
+    let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_imm32(0_i32)])
+        .expect_func_instrs([
+            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+            Instruction::global_get(Register::from_i16(1), GlobalIdx::from(1)),
+            // copy parameters and index
+            Instruction::copy(Register::from_i16(2), Register::from_i16(1)),
+            // Instruction::copy(Register::from_i16(0), Register::from_i16(0)), // elided
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            // indirect call
+            Instruction::return_call_indirect(SignatureIdx::from(0)),
+            Instruction::call_indirect_params(Register::from_i16(2), TableIdx::from(0)),
             Instruction::call_params(params, 1),
         ])
         .run();

--- a/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
@@ -561,7 +561,7 @@ impl InstrEncoder {
         Ok(())
     }
 
-    /// Encodes the call parameters of a `wasmi` call instruction if neccessary.
+    /// Encodes the call parameters of a `wasmi` `call` instruction if neccessary.
     ///
     /// Returns the contiguous [`RegisterSpanIter`] that makes up the call parameters post encoding.
     ///
@@ -587,6 +587,47 @@ impl InstrEncoder {
         let copy_results = stack.peek_dynamic_n(params.len())?.iter(params.len());
         self.encode_copies(stack, copy_results, params)?;
         Ok(copy_results)
+    }
+
+    /// Encodes the call parameters of a `wasmi` `call_indirect` instruction if neccessary.
+    ///
+    /// Returns the contiguous [`RegisterSpanIter`] that makes up the call parameters post encoding.
+    ///
+    /// # Errors
+    ///
+    /// If the translation runs out of register space during this operation.
+    pub fn encode_call_indirect_params(
+        &mut self,
+        stack: &mut ValueStack,
+        mut index: TypedProvider,
+        params: &[TypedProvider],
+    ) -> Result<(TypedProvider, RegisterSpanIter), TranslationError> {
+        if let Some(register_span) = RegisterSpanIter::from_providers(params) {
+            // Case: we are on the happy path were the providers on the
+            //       stack already are registers with contiguous indices.
+            //
+            //       This allows us to avoid copying over the registers
+            //       to where the call instruction expects them on the stack.
+            return Ok((index, register_span));
+        }
+        // Case: the providers on the stack need to be copied to the
+        //       location where the call instruction expects its parameters
+        //       before executing the call.
+        let copy_results = stack.push_dynamic_n(params.len())?.iter(params.len());
+        if let TypedProvider::Register(index_reg) = index {
+            if copy_results.contains(index_reg) {
+                // Case: the parameters are copied over to a contiguous span of registers
+                //       that overwrites the `index` register. Thus we are required to copy
+                //       the `index` register to a protected register.
+                let copy_index = stack.push_dynamic()?;
+                self.encode_copy(stack, copy_index, index)?;
+                stack.pop();
+                index = TypedProvider::Register(copy_index);
+            }
+        }
+        self.encode_copies(stack, copy_results, params)?;
+        stack.remove_n(params.len());
+        Ok((index, copy_results))
     }
 
     /// Encode conditional branch parameters for `br_if` and `return_if` instructions.

--- a/crates/wasmi/src/engine/regmach/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/regmach/translator/stack/mod.rs
@@ -292,6 +292,13 @@ impl ValueStack {
         result[..].reverse()
     }
 
+    /// Removes the `n` top-most [`Provider`] from the [`ValueStack`].
+    pub fn remove_n(&mut self, n: usize) {
+        for _ in 0..n {
+            self.pop();
+        }
+    }
+
     /// Peeks the `n` top-most [`Provider`] from the [`ValueStack`] and store them in `result`.
     ///
     /// # Note

--- a/crates/wasmi/src/engine/regmach/translator/visit.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit.rs
@@ -692,23 +692,11 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         let index = self.alloc.stack.pop();
         let provider_params = &mut self.alloc.buffer;
         self.alloc.stack.pop_n(params.len(), provider_params);
-        if let TypedProvider::Register(reg) = index {
-            // We need to push `index` back to the providers since
-            // otherwise it would be overriden by `encode_call_params`.
-            self.alloc
-                .stack
-                .push_register(reg)
-                .expect("just popped a at least one provider so this must not fail");
-        }
-        let params_span = self
-            .alloc
-            .instr_encoder
-            .encode_call_params(&mut self.alloc.stack, provider_params)?;
-        if let TypedProvider::Register(_) = index {
-            // Now we pop `index` again and assert that it is still the same.
-            let dummy_index = self.alloc.stack.pop();
-            debug_assert_eq!(index, dummy_index);
-        }
+        let (index, params_span) = self.alloc.instr_encoder.encode_call_indirect_params(
+            &mut self.alloc.stack,
+            index,
+            provider_params,
+        )?;
         let call_params = Instruction::call_params(params_span, len_results);
         let table_params = match index {
             TypedProvider::Const(index) => match <Const16<u32>>::from_u32(u32::from(index)) {
@@ -791,23 +779,11 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         let index = self.alloc.stack.pop();
         let provider_params = &mut self.alloc.buffer;
         self.alloc.stack.pop_n(params.len(), provider_params);
-        if let TypedProvider::Register(reg) = index {
-            // We need to push `index` back to the providers since
-            // otherwise it would be overriden by `encode_call_params`.
-            self.alloc
-                .stack
-                .push_register(reg)
-                .expect("just popped a at least one provider so this must not fail");
-        }
-        let params_span = self
-            .alloc
-            .instr_encoder
-            .encode_call_params(&mut self.alloc.stack, provider_params)?;
-        if let TypedProvider::Register(_) = index {
-            // Now we pop `index` again and assert that it is still the same.
-            let dummy_index = self.alloc.stack.pop();
-            debug_assert_eq!(index, dummy_index);
-        }
+        let (index, params_span) = self.alloc.instr_encoder.encode_call_indirect_params(
+            &mut self.alloc.stack,
+            index,
+            provider_params,
+        )?;
         let call_params = Instruction::call_params(params_span, len_results);
         let table_params = match index {
             TypedProvider::Const(index) => match <Const16<u32>>::from_u32(u32::from(index)) {


### PR DESCRIPTION
Closes #768.

This bug (issue #768) occurred when the call parameters needed to be copied over to a contiguous span in the dynamic register space and at the same time overwriting the index register. The fix is to simply copy the index register to a protected register when detecting this situation.