### PR TITLE
Implement new copy semantics

### DIFF
--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -409,6 +409,18 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::CopyManyNonOverlapping`].
+    pub fn copy_many_non_overlapping(
+        results: RegisterSpan,
+        head0: impl Into<Register>,
+        head1: impl Into<Register>,
+    ) -> Self {
+        Self::CopyManyNonOverlapping {
+            results,
+            values: [head0.into(), head1.into()],
+        }
+    }
+
     /// Creates a new [`Instruction::GlobalGet`].
     pub fn global_get(result: Register, global: bytecode::GlobalIdx) -> Self {
         Self::GlobalGet { result, global }

--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -942,6 +942,34 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::Register`] instruction parameter.
+    pub fn register(reg: impl Into<Register>) -> Self {
+        Self::Register(reg.into())
+    }
+
+    /// Creates a new [`Instruction::Register2`] instruction parameter.
+    pub fn register2(reg0: impl Into<Register>, reg1: impl Into<Register>) -> Self {
+        Self::Register2([reg0.into(), reg1.into()])
+    }
+
+    /// Creates a new [`Instruction::Register3`] instruction parameter.
+    pub fn register3(
+        reg0: impl Into<Register>,
+        reg1: impl Into<Register>,
+        reg2: impl Into<Register>,
+    ) -> Self {
+        Self::Register3([reg0.into(), reg1.into(), reg2.into()])
+    }
+
+    /// Creates a new [`Instruction::RegisterList`] instruction parameter.
+    pub fn register_list(
+        reg0: impl Into<Register>,
+        reg1: impl Into<Register>,
+        reg2: impl Into<Register>,
+    ) -> Self {
+        Self::RegisterList([reg0.into(), reg1.into(), reg2.into()])
+    }
+
     /// Creates a new [`Instruction::CallParams`] for the given `params` and `len_results`.
     pub fn call_params(params: RegisterSpanIter, len_results: u16) -> Self {
         let len_params = params.len_as_u16();

--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -383,6 +383,20 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::CopySpanNonOverlapping`] copying multiple consecutive values.
+    pub fn copy_span_non_overlapping(
+        results: RegisterSpan,
+        values: RegisterSpan,
+        len: u16,
+    ) -> Self {
+        debug_assert!(!results.iter_u16(len).is_overlapping(&values.iter_u16(len)));
+        Self::CopySpanNonOverlapping {
+            results,
+            values,
+            len,
+        }
+    }
+
     /// Creates a new [`Instruction::CopyMany`].
     pub fn copy_many(
         results: RegisterSpan,

--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -184,6 +184,24 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::ReturnReg2`] for the given [`Register`] indices.
+    pub fn return_reg2(reg0: impl Into<Register>, reg1: impl Into<Register>) -> Self {
+        Self::ReturnReg2 {
+            values: [reg0.into(), reg1.into()],
+        }
+    }
+
+    /// Creates a new [`Instruction::ReturnReg3`] for the given [`Register`] indices.
+    pub fn return_reg3(
+        reg0: impl Into<Register>,
+        reg1: impl Into<Register>,
+        reg2: impl Into<Register>,
+    ) -> Self {
+        Self::ReturnReg3 {
+            values: [reg0.into(), reg1.into(), reg2.into()],
+        }
+    }
+
     /// Creates a new [`Instruction::ReturnImm32`] from the given `value`.
     pub fn return_imm32(value: impl Into<AnyConst32>) -> Self {
         Self::ReturnImm32 {
@@ -210,14 +228,42 @@ impl Instruction {
         Self::ReturnSpan { values }
     }
 
+    /// Creates a new [`Instruction::ReturnMany`] for the given [`Register`] indices.
+    pub fn return_many(
+        reg0: impl Into<Register>,
+        reg1: impl Into<Register>,
+        reg2: impl Into<Register>,
+    ) -> Self {
+        Self::ReturnMany {
+            values: [reg0.into(), reg1.into(), reg2.into()],
+        }
+    }
+
     /// Creates a new [`Instruction::ReturnNez`] for the given `condition`.
-    pub fn return_nez(condition: Register) -> Self {
-        Self::ReturnNez { condition }
+    pub fn return_nez(condition: impl Into<Register>) -> Self {
+        Self::ReturnNez {
+            condition: condition.into(),
+        }
     }
 
     /// Creates a new [`Instruction::ReturnNezReg`] for the given `condition` and `value`.
-    pub fn return_nez_reg(condition: Register, value: Register) -> Self {
-        Self::ReturnNezReg { condition, value }
+    pub fn return_nez_reg(condition: impl Into<Register>, value: impl Into<Register>) -> Self {
+        Self::ReturnNezReg {
+            condition: condition.into(),
+            value: value.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::ReturnNezReg2`] for the given `condition` and `value`.
+    pub fn return_nez_reg2(
+        condition: impl Into<Register>,
+        value0: impl Into<Register>,
+        value1: impl Into<Register>,
+    ) -> Self {
+        Self::ReturnNezReg2 {
+            condition: condition.into(),
+            values: [value0.into(), value1.into()],
+        }
     }
 
     /// Creates a new [`Instruction::ReturnNezImm32`] for the given `condition` and `value`.
@@ -249,6 +295,18 @@ impl Instruction {
         Self::ReturnNezSpan { condition, values }
     }
 
+    /// Creates a new [`Instruction::ReturnNezMany`] for the given `condition` and `value`.
+    pub fn return_nez_many(
+        condition: impl Into<Register>,
+        head0: impl Into<Register>,
+        head1: impl Into<Register>,
+    ) -> Self {
+        Self::ReturnNezMany {
+            condition: condition.into(),
+            values: [head0.into(), head1.into()],
+        }
+    }
+
     /// Creates a new [`Instruction::Branch`] for the given `offset`.
     pub fn branch(offset: BranchOffset) -> Self {
         Self::Branch { offset }
@@ -273,8 +331,23 @@ impl Instruction {
     }
 
     /// Creates a new [`Instruction::Copy`].
-    pub fn copy(result: Register, value: Register) -> Self {
-        Self::Copy { result, value }
+    pub fn copy(result: impl Into<Register>, value: impl Into<Register>) -> Self {
+        Self::Copy {
+            result: result.into(),
+            value: value.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::Copy2`].
+    pub fn copy2(
+        results: RegisterSpan,
+        value0: impl Into<Register>,
+        value1: impl Into<Register>,
+    ) -> Self {
+        Self::Copy2 {
+            results,
+            values: [value0.into(), value1.into()],
+        }
     }
 
     /// Creates a new [`Instruction::CopyImm32`].
@@ -308,6 +381,18 @@ impl Instruction {
             results,
             values,
             len,
+        }
+    }
+
+    /// Creates a new [`Instruction::CopyMany`].
+    pub fn copy_many(
+        results: RegisterSpan,
+        head0: impl Into<Register>,
+        head1: impl Into<Register>,
+    ) -> Self {
+        Self::CopyMany {
+            results,
+            values: [head0.into(), head1.into()],
         }
     }
 

--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -206,9 +206,9 @@ impl Instruction {
         }
     }
 
-    /// Creates a new [`Instruction::ReturnMany`] from the given `values`.
-    pub fn return_many(values: RegisterSpanIter) -> Self {
-        Self::ReturnMany { values }
+    /// Creates a new [`Instruction::ReturnSpan`] from the given `values`.
+    pub fn return_span(values: RegisterSpanIter) -> Self {
+        Self::ReturnSpan { values }
     }
 
     /// Creates a new [`Instruction::ReturnNez`] for the given `condition`.
@@ -246,8 +246,8 @@ impl Instruction {
     }
 
     /// Creates a new [`Instruction::ReturnNezMany`] for the given `condition` and `values`.
-    pub fn return_nez_many(condition: Register, values: RegisterSpanIter) -> Self {
-        Self::ReturnNezMany { condition, values }
+    pub fn return_nez_span(condition: Register, values: RegisterSpanIter) -> Self {
+        Self::ReturnNezSpan { condition, values }
     }
 
     /// Creates a new [`Instruction::Branch`] for the given `offset`.

--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -4,7 +4,6 @@ use super::{
     BinInstr,
     BinInstrImm16,
     CallIndirectParams,
-    CallIndirectParamsImm16,
     CallParams,
     Const16,
     Const32,
@@ -967,7 +966,7 @@ impl Instruction {
         index: impl Into<Const16<u32>>,
         table: impl Into<TableIdx>,
     ) -> Self {
-        Self::CallIndirectParamsImm16(CallIndirectParamsImm16 {
+        Self::CallIndirectParamsImm16(CallIndirectParams {
             index: index.into(),
             table: table.into(),
         })

--- a/crates/wasmi/src/engine/regmach/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/construct.rs
@@ -4,7 +4,6 @@ use super::{
     BinInstr,
     BinInstrImm16,
     CallIndirectParams,
-    CallParams,
     Const16,
     Const32,
     Instruction,
@@ -1053,17 +1052,6 @@ impl Instruction {
         reg2: impl Into<Register>,
     ) -> Self {
         Self::RegisterList([reg0.into(), reg1.into(), reg2.into()])
-    }
-
-    /// Creates a new [`Instruction::CallParams`] for the given `params` and `len_results`.
-    pub fn call_params(params: RegisterSpanIter, len_results: u16) -> Self {
-        let len_params = params.len_as_u16();
-        let params = params.span();
-        Self::CallParams(CallParams {
-            params,
-            len_params,
-            len_results,
-        })
     }
 
     /// Creates a new [`Instruction::CallIndirectParams`] for the given `index` and `table`.

--- a/crates/wasmi/src/engine/regmach/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/mod.rs
@@ -483,6 +483,15 @@ pub enum Instruction {
         /// The amount of copied registers.
         len: u16,
     },
+    /// Variant of [`Instruction::CopySpan`] that assumes that `results` and `values` span do not overlap.
+    CopySpanNonOverlapping {
+        /// The registers holding the result of this instruction.
+        results: RegisterSpan,
+        /// The contiguous registers holding the inputs of this instruction.
+        values: RegisterSpan,
+        /// The amount of copied registers.
+        len: u16,
+    },
     /// Copies some [`Register`] values into `results` [`RegisterSpan`].
     ///
     /// # Encoding

--- a/crates/wasmi/src/engine/regmach/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/mod.rs
@@ -509,6 +509,21 @@ pub enum Instruction {
         /// The first two input registers to copy.
         values: [Register; 2],
     },
+    /// Variant of [`Instruction::CopyMany`] that assumes that `results` and `values` do not overlap.
+    ///
+    /// Must be followed by
+    ///
+    /// 1. Zero or more [`Instruction::RegisterList`]
+    /// 2. Followed by one of
+    ///     - [`Instruction::Register`]
+    ///     - [`Instruction::Register2`]
+    ///     - [`Instruction::Register3`]
+    CopyManyNonOverlapping {
+        /// The registers holding the result of this instruction.
+        results: RegisterSpan,
+        /// The first two input registers to copy.
+        values: [Register; 2],
+    },
 
     /// Wasm `return_call` equivalent `wasmi` instruction.
     ///

--- a/crates/wasmi/src/engine/regmach/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/mod.rs
@@ -13,7 +13,6 @@ pub(crate) use self::{
         BinInstr,
         BinInstrImm16,
         CallIndirectParams,
-        CallIndirectParamsImm16,
         CallParams,
         CopysignImmInstr,
         LoadAtInstr,
@@ -147,6 +146,14 @@ pub enum Instruction {
     /// - [`Instruction::Register2`]
     /// - [`Instruction::Register3`]
     RegisterList([Register; 3]),
+    /// Auxiliary [`Instruction`] to encode call parameters for call instructions.
+    ///
+    /// TODO: remove this variant since no longer needed
+    CallParams(CallParams),
+    /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
+    CallIndirectParams(CallIndirectParams<Register>),
+    /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.
+    CallIndirectParamsImm16(CallIndirectParams<Const16<u32>>),
 
     /// Traps the execution with the given [`TrapCode`].
     ///
@@ -498,13 +505,6 @@ pub enum Instruction {
         /// The first two input registers to copy.
         values: [Register; 2],
     },
-
-    /// Auxiliary [`Instruction`] to encode call parameters for call instructions.
-    CallParams(CallParams), // TODO: remove this variant since no longer needed
-    /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
-    CallIndirectParams(CallIndirectParams),
-    /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.
-    CallIndirectParamsImm16(CallIndirectParamsImm16),
 
     /// Wasm `return_call` equivalent `wasmi` instruction.
     ///

--- a/crates/wasmi/src/engine/regmach/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/mod.rs
@@ -182,7 +182,7 @@ pub enum Instruction {
     /// # Note
     ///
     /// Returns values as stored in the [`RegisterSpanIter`].
-    ReturnMany {
+    ReturnSpan {
         /// Identifier for a [`Provider`] slice.
         values: RegisterSpanIter,
     },
@@ -250,7 +250,7 @@ pub enum Instruction {
     /// # Note
     ///
     /// Variant of [`Instruction::ReturnNez`] returning two or more values.
-    ReturnNezMany {
+    ReturnNezSpan {
         /// The register holding the condition to evaluate against zero.
         condition: Register,
         /// The returned values.
@@ -293,12 +293,12 @@ pub enum Instruction {
     /// Must be followed `len_targets` times by any of
     ///
     /// - [`Instruction::Branch`]
-    /// - [`Instruction::Return]
-    /// - [`Instruction::ReturnReg]
-    /// - [`Instruction::ReturnImm32]
-    /// - [`Instruction::ReturnI64Imm32]
-    /// - [`Instruction::ReturnF64Imm32]
-    /// - [`Instruction::ReturnMany]
+    /// - [`Instruction::Return`]
+    /// - [`Instruction::ReturnReg`]
+    /// - [`Instruction::ReturnImm32`]
+    /// - [`Instruction::ReturnI64Imm32`]
+    /// - [`Instruction::ReturnF64Imm32`]
+    /// - [`Instruction::ReturnSpan`]
     BranchTable {
         /// The register holding the index of the instruction.
         index: Register,

--- a/crates/wasmi/src/engine/regmach/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/mod.rs
@@ -355,7 +355,7 @@ pub enum Instruction {
         /// The 32-bit encoded `i64` immediate value to copy.
         value: Const32<f64>,
     },
-    /// Copes `len` contiguous `values` [`RegisterSpan`] into `results` [`RegisterSpan`].
+    /// Copies `len` contiguous `values` [`RegisterSpan`] into `results` [`RegisterSpan`].
     ///
     /// Copies registers: `registers[results..results+len] <- registers[values..values+len]`
     ///

--- a/crates/wasmi/src/engine/regmach/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/mod.rs
@@ -13,7 +13,6 @@ pub(crate) use self::{
         BinInstr,
         BinInstrImm16,
         CallIndirectParams,
-        CallParams,
         CopysignImmInstr,
         LoadAtInstr,
         LoadInstr,
@@ -146,10 +145,6 @@ pub enum Instruction {
     /// - [`Instruction::Register2`]
     /// - [`Instruction::Register3`]
     RegisterList([Register; 3]),
-    /// Auxiliary [`Instruction`] to encode call parameters for call instructions.
-    ///
-    /// TODO: remove this variant since no longer needed
-    CallParams(CallParams),
     /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
     CallIndirectParams(CallIndirectParams<Register>),
     /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.

--- a/crates/wasmi/src/engine/regmach/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/utils.rs
@@ -474,22 +474,9 @@ pub struct CallParams {
 
 /// Auxiliary [`Instruction`] parameter to encode call parameters for indirect call instructions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct CallIndirectParams {
-    /// The index of the called function in the table.
-    pub index: Register,
+pub struct CallIndirectParams<T> {
     /// The table which holds the called function at the index.
     pub table: TableIdx,
-}
-
-/// Auxiliary [`Instruction`] parameter to encode call parameters for indirect call instructions.
-///
-/// # Note
-///
-/// Variant of [`CallIndirectParams`] with a 16-bit encoded constant `index` parameter.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct CallIndirectParamsImm16 {
     /// The index of the called function in the table.
-    pub index: Const16<u32>,
-    /// The table which holds the called function at the index.
-    pub table: TableIdx,
+    pub index: T,
 }

--- a/crates/wasmi/src/engine/regmach/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/regmach/bytecode/utils.rs
@@ -454,24 +454,6 @@ pub struct CopysignImmInstr {
     pub rhs: Sign,
 }
 
-/// Auxiliary [`Instruction`] parameter to encode call parameters for call instructions.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[repr(align(2))]
-pub struct CallParams {
-    /// The contiguous sequence of registers storing the call parameters.
-    pub params: RegisterSpan,
-    /// The number of call parameters.
-    pub len_params: u16,
-    /// The number of call results.
-    ///
-    /// # Note
-    ///
-    /// This is an optimization so that we do not have to query the number
-    /// of results from the called function since we already know and have
-    /// enough space left in the [`Instruction::CallParams`].
-    pub len_results: u16,
-}
-
 /// Auxiliary [`Instruction`] parameter to encode call parameters for indirect call instructions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CallIndirectParams<T> {

--- a/crates/wasmi/src/engine/regmach/code_map.rs
+++ b/crates/wasmi/src/engine/regmach/code_map.rs
@@ -228,4 +228,18 @@ impl InstructionPtr {
         //         of valid bounds using this method.
         unsafe { &*self.ptr }
     }
+
+    /// Returns the [`Instruction`] at the [`InstructionPtr`] and advance to the next [`Instruction`].
+    #[inline(always)]
+    #[must_use]
+    pub fn pull(&mut self) -> &Instruction {
+        // SAFETY: Within Wasm bytecode execution we are guaranteed by
+        //         Wasm validation and `wasmi` codegen to never run out
+        //         of valid bounds using this method.
+        unsafe {
+            let instr = &*self.ptr;
+            self.ptr = self.ptr.add(1);
+            instr
+        }
+    }
 }

--- a/crates/wasmi/src/engine/regmach/code_map.rs
+++ b/crates/wasmi/src/engine/regmach/code_map.rs
@@ -228,18 +228,4 @@ impl InstructionPtr {
         //         of valid bounds using this method.
         unsafe { &*self.ptr }
     }
-
-    /// Returns the [`Instruction`] at the [`InstructionPtr`] and advance to the next [`Instruction`].
-    #[inline(always)]
-    #[must_use]
-    pub fn pull(&mut self) -> &Instruction {
-        // SAFETY: Within Wasm bytecode execution we are guaranteed by
-        //         Wasm validation and `wasmi` codegen to never run out
-        //         of valid bounds using this method.
-        unsafe {
-            let instr = &*self.ptr;
-            self.ptr = self.ptr.add(1);
-            instr
-        }
-    }
 }

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -5,6 +5,7 @@ use crate::{
         bytecode::{BlockFuel, BranchOffset, FuncIdx},
         cache::InstanceCache,
         config::FuelCosts,
+        func_types::FuncTypeRegistry,
         regmach::{
             bytecode::{
                 AnyConst32,
@@ -92,9 +93,11 @@ pub fn execute_instrs<'ctx, 'engine>(
     value_stack: &'engine mut ValueStack,
     call_stack: &'engine mut CallStack,
     code_map: &'engine CodeMap,
+    func_types: &'engine FuncTypeRegistry,
     resource_limiter: &'ctx mut ResourceLimiterRef<'ctx>,
 ) -> Result<WasmOutcome, TrapCode> {
-    Executor::new(ctx, cache, value_stack, call_stack, code_map).execute(resource_limiter)
+    Executor::new(ctx, cache, value_stack, call_stack, code_map, func_types)
+        .execute(resource_limiter)
 }
 
 /// An execution context for executing a `wasmi` function frame.
@@ -129,6 +132,12 @@ struct Executor<'ctx, 'engine> {
     ///
     /// This is used to lookup Wasm function information.
     code_map: &'engine CodeMap,
+    /// The Wasm function type registry.
+    ///
+    /// # Note
+    ///
+    /// This is used to lookup Wasm function information.
+    func_types: &'engine FuncTypeRegistry,
 }
 
 impl<'ctx, 'engine> Executor<'ctx, 'engine> {
@@ -140,6 +149,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         value_stack: &'engine mut ValueStack,
         call_stack: &'engine mut CallStack,
         code_map: &'engine CodeMap,
+        func_types: &'engine FuncTypeRegistry,
     ) -> Self {
         let frame = call_stack
             .peek()
@@ -157,6 +167,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             value_stack,
             call_stack,
             code_map,
+            func_types,
         }
     }
 

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -193,8 +193,8 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 Instr::ReturnF64Imm32 { value } => {
                     forward_return!(self.execute_return_f64imm32(value))
                 }
-                Instr::ReturnMany { values } => {
-                    forward_return!(self.execute_return_many(values))
+                Instr::ReturnSpan { values } => {
+                    forward_return!(self.execute_return_span(values))
                 }
                 Instr::ReturnNez { condition } => {
                     forward_return!(self.execute_return_nez(condition))
@@ -211,8 +211,8 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 Instr::ReturnNezF64Imm32 { condition, value } => {
                     forward_return!(self.execute_return_nez_f64imm32(condition, value))
                 }
-                Instr::ReturnNezMany { condition, values } => {
-                    forward_return!(self.execute_return_nez_many(condition, values))
+                Instr::ReturnNezSpan { condition, values } => {
+                    forward_return!(self.execute_return_nez_span(condition, values))
                 }
                 Instr::Branch { offset } => self.execute_branch(offset),
                 Instr::BranchEqz { condition, offset } => {

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -178,7 +178,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 | Instr::Register(_)
                 | Instr::Register2(_)
                 | Instr::Register3(_)
-                | Instr::RegisterList(_) => self.invalid_instruction_word()?,
+                | Instr::RegisterList(_)
+                | Instr::CallIndirectParams(_)
+                | Instr::CallIndirectParamsImm16(_) => self.invalid_instruction_word()?,
                 Instr::Trap(trap_code) => self.execute_trap(trap_code)?,
                 Instr::ConsumeFuel(block_fuel) => self.execute_consume_fuel(block_fuel)?,
                 Instr::Return => {
@@ -253,9 +255,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                     len,
                 } => self.execute_copy_span(results, values, len),
                 Instr::CopyMany { results, values } => self.execute_copy_many(results, values),
-                Instr::CallParams(_) => self.invalid_instruction_word()?,
-                Instr::CallIndirectParams(_) => self.invalid_instruction_word()?,
-                Instr::CallIndirectParamsImm16(_) => self.invalid_instruction_word()?,
                 Instr::ReturnCallInternal0 { func } => self.execute_return_call_internal_0(func)?,
                 Instr::ReturnCallInternal { func } => self.execute_return_call_internal(func)?,
                 Instr::ReturnCallImported0 { func } => {

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -260,6 +260,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                     len,
                 } => self.execute_copy_span_non_overlapping(results, values, len),
                 Instr::CopyMany { results, values } => self.execute_copy_many(results, values),
+                Instr::CopyManyNonOverlapping { results, values } => {
+                    self.execute_copy_many_non_overlapping(results, values)
+                }
                 Instr::ReturnCallInternal0 { func } => self.execute_return_call_internal_0(func)?,
                 Instr::ReturnCallInternal { func } => self.execute_return_call_internal(func)?,
                 Instr::ReturnCallImported0 { func } => {

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -254,6 +254,11 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                     values,
                     len,
                 } => self.execute_copy_span(results, values, len),
+                Instr::CopySpanNonOverlapping {
+                    results,
+                    values,
+                    len,
+                } => self.execute_copy_span_non_overlapping(results, values, len),
                 Instr::CopyMany { results, values } => self.execute_copy_many(results, values),
                 Instr::ReturnCallInternal0 { func } => self.execute_return_call_internal_0(func)?,
                 Instr::ReturnCallInternal { func } => self.execute_return_call_internal(func)?,

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -195,7 +195,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// Executes an [`Instruction::ReturnCallInternal0`].
     #[inline(always)]
     pub fn execute_return_call_internal_0(&mut self, func: CompiledFunc) -> Result<(), TrapCode> {
-        self.update_instr_ptr_at(1);
         self.execute_return_call_internal_impl(func, CallParams::None)?;
         Ok(())
     }
@@ -203,7 +202,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// Executes an [`Instruction::ReturnCallInternal`].
     #[inline(always)]
     pub fn execute_return_call_internal(&mut self, func: CompiledFunc) -> Result<(), TrapCode> {
-        self.update_instr_ptr_at(2);
         self.execute_return_call_internal_impl(func, CallParams::Some)?;
         Ok(())
     }
@@ -265,7 +263,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         func: FuncIdx,
     ) -> Result<CallOutcome, TrapCode> {
         let func = self.cache.get_func(self.ctx, func);
-        self.update_instr_ptr_at(1);
         self.execute_return_call_imported_impl(&func, CallParams::None)
     }
 
@@ -273,7 +270,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     #[inline(always)]
     pub fn execute_return_call_imported(&mut self, func: FuncIdx) -> Result<CallOutcome, TrapCode> {
         let func = self.cache.get_func(self.ctx, func);
-        self.update_instr_ptr_at(2);
         self.execute_return_call_imported_impl(&func, CallParams::Some)
     }
 
@@ -347,7 +343,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         func_type: SignatureIdx,
     ) -> Result<CallOutcome, TrapCode> {
         let call_indirect_params = self.fetch_call_indirect_params(1);
-        self.update_instr_ptr_at(2);
         let results = self.caller_results();
         self.execute_call_indirect_impl(
             results,
@@ -365,7 +360,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         func_type: SignatureIdx,
     ) -> Result<CallOutcome, TrapCode> {
         let call_indirect_params = self.fetch_call_indirect_params(1);
-        self.update_instr_ptr_at(3);
         let results = self.caller_results();
         self.execute_call_indirect_impl(
             results,

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -1,5 +1,3 @@
-use core::slice;
-
 use super::Executor;
 use crate::{
     core::TrapCode,
@@ -16,6 +14,7 @@ use crate::{
     Func,
     FuncRef,
 };
+use core::slice;
 
 /// Describes whether a `call` instruction has at least one parameter or none.
 #[derive(Debug, Copy, Clone)]

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -144,9 +144,8 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             }
         };
         ip.add(1);
-        while let Instruction::RegisterList(values) = ip.get() {
+        while let Instruction::RegisterList(values) = ip.pull() {
             copy_params(values);
-            ip.add(1);
         }
         let values = match ip.get() {
             Instruction::Register(value) => slice::from_ref(value),

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -200,15 +200,13 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// Executes an [`Instruction::ReturnCallInternal0`].
     #[inline(always)]
     pub fn execute_return_call_internal_0(&mut self, func: CompiledFunc) -> Result<(), TrapCode> {
-        self.execute_return_call_internal_impl(func, CallParams::None)?;
-        Ok(())
+        self.execute_return_call_internal_impl(func, CallParams::None)
     }
 
     /// Executes an [`Instruction::ReturnCallInternal`].
     #[inline(always)]
     pub fn execute_return_call_internal(&mut self, func: CompiledFunc) -> Result<(), TrapCode> {
-        self.execute_return_call_internal_impl(func, CallParams::Some)?;
-        Ok(())
+        self.execute_return_call_internal_impl(func, CallParams::Some)
     }
 
     /// Executes an [`Instruction::ReturnCallInternal`] or [`Instruction::ReturnCallInternal0`].
@@ -218,8 +216,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         params: CallParams,
     ) -> Result<(), TrapCode> {
         let results = self.caller_results();
-        self.prepare_compiled_func_call(results, func, params, CallKind::Tail)?;
-        Ok(())
+        self.prepare_compiled_func_call(results, func, params, CallKind::Tail)
     }
 
     /// Returns the `results` [`RegisterSpan`] of the top-most [`CallFrame`] on the [`CallStack`].
@@ -244,8 +241,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         results: RegisterSpan,
         func: CompiledFunc,
     ) -> Result<(), TrapCode> {
-        self.prepare_compiled_func_call(results, func, CallParams::None, CallKind::Nested)?;
-        Ok(())
+        self.prepare_compiled_func_call(results, func, CallParams::None, CallKind::Nested)
     }
 
     /// Executes an [`Instruction::CallInternal`].
@@ -255,8 +251,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         results: RegisterSpan,
         func: CompiledFunc,
     ) -> Result<(), TrapCode> {
-        self.prepare_compiled_func_call(results, func, CallParams::Some, CallKind::Nested)?;
-        Ok(())
+        self.prepare_compiled_func_call(results, func, CallParams::Some, CallKind::Nested)
     }
 
     /// Executes an [`Instruction::ReturnCallImported0`].
@@ -265,25 +260,24 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         &mut self,
         func: FuncIdx,
     ) -> Result<CallOutcome, TrapCode> {
-        let func = self.cache.get_func(self.ctx, func);
-        self.execute_return_call_imported_impl(&func, CallParams::None)
+        self.execute_return_call_imported_impl(func, CallParams::None)
     }
 
     /// Executes an [`Instruction::ReturnCallImported`].
     #[inline(always)]
     pub fn execute_return_call_imported(&mut self, func: FuncIdx) -> Result<CallOutcome, TrapCode> {
-        let func = self.cache.get_func(self.ctx, func);
-        self.execute_return_call_imported_impl(&func, CallParams::Some)
+        self.execute_return_call_imported_impl(func, CallParams::Some)
     }
 
     /// Executes an [`Instruction::ReturnCallImported`] or [`Instruction::ReturnCallImported0`].
     fn execute_return_call_imported_impl(
         &mut self,
-        func: &Func,
+        func: FuncIdx,
         params: CallParams,
     ) -> Result<CallOutcome, TrapCode> {
+        let func = self.cache.get_func(self.ctx, func);
         let results = self.caller_results();
-        self.execute_call_imported_impl(results, func, params, CallKind::Tail)
+        self.execute_call_imported_impl(results, &func, params, CallKind::Tail)
     }
 
     /// Executes an [`Instruction::CallImported0`].

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -143,8 +143,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             }
         };
         ip.add(1);
-        while let Instruction::RegisterList(values) = ip.pull() {
+        while let Instruction::RegisterList(values) = ip.get() {
             copy_params(values);
+            ip.add(1);
         }
         let values = match ip.get() {
             Instruction::Register(value) => slice::from_ref(value),

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -241,7 +241,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         results: RegisterSpan,
         func: CompiledFunc,
     ) -> Result<(), TrapCode> {
-        self.update_instr_ptr_at(1);
         self.prepare_compiled_func_call(results, func, CallParams::None, CallKind::Nested)?;
         Ok(())
     }
@@ -253,7 +252,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         results: RegisterSpan,
         func: CompiledFunc,
     ) -> Result<(), TrapCode> {
-        self.update_instr_ptr_at(2);
         self.prepare_compiled_func_call(results, func, CallParams::Some, CallKind::Nested)?;
         Ok(())
     }
@@ -293,7 +291,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         func: FuncIdx,
     ) -> Result<CallOutcome, TrapCode> {
         let func = self.cache.get_func(self.ctx, func);
-        self.update_instr_ptr_at(1);
         self.execute_call_imported_impl(results, &func, CallParams::None, CallKind::Nested)
     }
 
@@ -305,7 +302,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         func: FuncIdx,
     ) -> Result<CallOutcome, TrapCode> {
         let func = self.cache.get_func(self.ctx, func);
-        self.update_instr_ptr_at(2);
         self.execute_call_imported_impl(results, &func, CallParams::Some, CallKind::Nested)
     }
 

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -96,7 +96,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 (index, table)
             }
             unexpected => unreachable!(
-                "expected Instruction::CallIndirectParams at this address but found {unexpected:?}"
+                "expected `Instruction::CallIndirectParams[Imm16]` but found {unexpected:?}"
             ),
         }
     }

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -150,7 +150,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             Instruction::Register(value) => slice::from_ref(value),
             Instruction::Register2(values) => values,
             Instruction::Register3(values) => values,
-            unexpected => unreachable!("unexpected Instruction found while executing Instruction::ReturnMany: {unexpected:?}"),
+            unexpected => {
+                unreachable!("unexpected Instruction found while call parameters: {unexpected:?}")
+            }
         };
         copy_params(values);
         // Finally return the instruction pointer to the last call parameter [`Instruction`] if any.

--- a/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
@@ -26,6 +26,12 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         self.execute_copy_impl(result, value, |this, value| this.get_register(value))
     }
 
+    /// Executes an [`Instruction::Copy2`].
+    #[inline(always)]
+    pub fn execute_copy_2(&mut self, _results: RegisterSpan, _values: [Register; 2]) {
+        todo!()
+    }
+
     /// Executes an [`Instruction::CopyImm32`].
     #[inline(always)]
     pub fn execute_copy_imm32(&mut self, result: Register, value: AnyConst32) {
@@ -67,5 +73,11 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             self.set_register(result, value);
         }
         self.next_instr();
+    }
+
+    /// Executes an [`Instruction::CopyMany`].
+    #[inline(always)]
+    pub fn execute_copy_many(&mut self, _results: RegisterSpan, _values: [Register; 2]) {
+        todo!()
     }
 }

--- a/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
@@ -88,10 +88,11 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         let mut ip = self.ip;
         tmp.extend(values.into_iter().map(|value| self.get_register(value)));
         ip.add(1);
-        while let Instruction::RegisterList(values) = ip.pull() {
+        while let Instruction::RegisterList(values) = ip.get() {
             tmp.extend(values.iter().map(|value| self.get_register(*value)));
+            ip.add(1);
         }
-        let values = match ip.pull() {
+        let values = match ip.get() {
             Instruction::Register(value) => slice::from_ref(value),
             Instruction::Register2(values) => values,
             Instruction::Register3(values) => values,
@@ -102,5 +103,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             self.set_register(result, value);
         }
         self.ip = ip;
+        self.next_instr()
     }
 }

--- a/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
@@ -28,8 +28,14 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
 
     /// Executes an [`Instruction::Copy2`].
     #[inline(always)]
-    pub fn execute_copy_2(&mut self, _results: RegisterSpan, _values: [Register; 2]) {
-        todo!()
+    pub fn execute_copy_2(&mut self, results: RegisterSpan, values: [Register; 2]) {
+        let result0 = results.head();
+        let result1 = result0.next();
+        // We need `tmp` in case `results[0] == values[1]` to avoid overwriting `values[1]` before reading it.
+        let tmp = self.get_register(values[1]);
+        self.set_register(result0, self.get_register(values[0]));
+        self.set_register(result1, tmp);
+        self.next_instr()
     }
 
     /// Executes an [`Instruction::CopyImm32`].

--- a/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
@@ -3,6 +3,7 @@ use crate::{
     core::UntypedValue,
     engine::regmach::bytecode::{AnyConst32, Const32, Instruction, Register, RegisterSpan},
 };
+use core::slice;
 use smallvec::SmallVec;
 
 impl<'ctx, 'engine> Executor<'ctx, 'engine> {
@@ -95,7 +96,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             ip.add(1);
         }
         let values = match ip.get() {
-            Instruction::Register(value) => core::slice::from_ref(value),
+            Instruction::Register(value) => slice::from_ref(value),
             Instruction::Register2(values) => values,
             Instruction::Register3(values) => values,
             unexpected => unreachable!("unexpected Instruction found while executing Instruction::CopyMany: {unexpected:?}"),

--- a/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
@@ -73,7 +73,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 for (result, value) in results.into_iter().zip(tmp) {
                     self.set_register(result, value);
                 }
-                self.next_instr();
             }
             false => {
                 // Case: `results` and `values` do _not_ overlap and thus we can
@@ -82,9 +81,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                     let value = self.get_register(value);
                     self.set_register(result, value);
                 }
-                self.next_instr();
             }
         }
+        self.next_instr();
     }
 
     /// Executes an [`Instruction::CopyMany`].

--- a/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/copy.rs
@@ -88,11 +88,10 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         let mut ip = self.ip;
         tmp.extend(values.into_iter().map(|value| self.get_register(value)));
         ip.add(1);
-        while let Instruction::RegisterList(values) = ip.get() {
+        while let Instruction::RegisterList(values) = ip.pull() {
             tmp.extend(values.iter().map(|value| self.get_register(*value)));
-            ip.add(1);
         }
-        let values = match ip.get() {
+        let values = match ip.pull() {
             Instruction::Register(value) => slice::from_ref(value),
             Instruction::Register2(values) => values,
             Instruction::Register3(values) => values,
@@ -102,7 +101,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         for (result, value) in results.iter(tmp.len()).zip(tmp) {
             self.set_register(result, value);
         }
-        ip.add(1);
         self.ip = ip;
     }
 }

--- a/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
@@ -212,10 +212,10 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     #[inline(always)]
     pub fn execute_return_nez_reg2(
         &mut self,
-        _condition: Register,
-        _value: [Register; 2],
+        condition: Register,
+        value: [Register; 2],
     ) -> ReturnOutcome {
-        todo!()
+        self.execute_return_nez_impl(condition, value, Self::execute_return_reg2)
     }
 
     /// Execute an [`Instruction::ReturnNezImm32`] returning a single 32-bit constant value.

--- a/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
@@ -196,8 +196,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         copy_results(values);
         let mut ip = self.ip;
         ip.add(1);
-        while let Instruction::RegisterList(values) = ip.pull() {
+        while let Instruction::RegisterList(values) = ip.get() {
             copy_results(values);
+            ip.add(1);
         }
         let values = match ip.get() {
             Instruction::Register(value) => slice::from_ref(value),

--- a/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
@@ -106,6 +106,18 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         self.execute_return_value(value, Self::get_register)
     }
 
+    /// Execute an [`Instruction::ReturnReg2`] returning two [`Register`] values.
+    #[inline(always)]
+    pub fn execute_return_reg2(&mut self, _values: [Register; 2]) -> ReturnOutcome {
+        todo!()
+    }
+
+    /// Execute an [`Instruction::ReturnReg3`] returning three [`Register`] values.
+    #[inline(always)]
+    pub fn execute_return_reg3(&mut self, _values: [Register; 3]) -> ReturnOutcome {
+        todo!()
+    }
+
     /// Execute an [`Instruction::ReturnImm32`] returning a single 32-bit value.
     #[inline(always)]
     pub fn execute_return_imm32(&mut self, value: AnyConst32) -> ReturnOutcome {
@@ -136,6 +148,12 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
             *cell = self.get_register(value);
         }
         self.return_impl()
+    }
+
+    /// Execute an [`Instruction::ReturnMany`] returning many values.
+    #[inline(always)]
+    pub fn execute_return_many(&mut self, _values: [Register; 3]) -> ReturnOutcome {
+        todo!()
     }
 
     /// Execute a generic conditional return [`Instruction`].
@@ -169,6 +187,16 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         value: Register,
     ) -> ReturnOutcome {
         self.execute_return_nez_impl(condition, value, Self::execute_return_reg)
+    }
+
+    /// Execute an [`Instruction::ReturnNezReg`] returning a single [`Register`] value.
+    #[inline(always)]
+    pub fn execute_return_nez_reg2(
+        &mut self,
+        _condition: Register,
+        _value: [Register; 2],
+    ) -> ReturnOutcome {
+        todo!()
     }
 
     /// Execute an [`Instruction::ReturnNezImm32`] returning a single 32-bit constant value.
@@ -209,5 +237,15 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         values: RegisterSpanIter,
     ) -> ReturnOutcome {
         self.execute_return_nez_impl(condition, values, Self::execute_return_span)
+    }
+
+    /// Execute an [`Instruction::ReturnNezMany`] returning many values.
+    #[inline(always)]
+    pub fn execute_return_nez_many(
+        &mut self,
+        _condition: Register,
+        _values: [Register; 2],
+    ) -> ReturnOutcome {
+        todo!()
     }
 }

--- a/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
@@ -195,9 +195,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         };
         copy_results(values);
         let mut ip = self.ip;
-        while let Instruction::RegisterList(values) = ip.get() {
+        ip.add(1);
+        while let Instruction::RegisterList(values) = ip.pull() {
             copy_results(values);
-            ip.add(1);
         }
         let values = match ip.get() {
             Instruction::Register(value) => slice::from_ref(value),

--- a/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/return_.rs
@@ -124,9 +124,9 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         self.execute_return_value(value, |_, value| f64::from(value).into())
     }
 
-    /// Execute an [`Instruction::ReturnMany`] returning many values.
+    /// Execute an [`Instruction::ReturnSpan`] returning many values.
     #[inline(always)]
-    pub fn execute_return_many(&mut self, values: RegisterSpanIter) -> ReturnOutcome {
+    pub fn execute_return_span(&mut self, values: RegisterSpanIter) -> ReturnOutcome {
         let (mut caller_sp, results) = self.return_caller_results();
         let results = results.iter(values.len());
         for (result, value) in results.zip(values) {
@@ -201,13 +201,13 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         self.execute_return_nez_impl(condition, value, Self::execute_return_f64imm32)
     }
 
-    /// Execute an [`Instruction::ReturnNezMany`] returning many values.
+    /// Execute an [`Instruction::ReturnNezSpan`] returning many values.
     #[inline(always)]
-    pub fn execute_return_nez_many(
+    pub fn execute_return_nez_span(
         &mut self,
         condition: Register,
         values: RegisterSpanIter,
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, values, Self::execute_return_many)
+        self.execute_return_nez_impl(condition, values, Self::execute_return_span)
     }
 }

--- a/crates/wasmi/src/engine/regmach/executor/mod.rs
+++ b/crates/wasmi/src/engine/regmach/executor/mod.rs
@@ -94,6 +94,7 @@ impl<'engine> EngineExecutor<'engine> {
             FuncEntity::Host(host_func) => {
                 func_type = *host_func.ty_dedup();
                 let host_func = *host_func;
+                // TODO: allocate more space for results values on the value stack
                 self.dispatch_host_func(ctx.as_context_mut(), host_func, HostFuncCaller::Root)?;
             }
         };
@@ -231,9 +232,6 @@ impl<'engine> EngineExecutor<'engine> {
         let len_inputs = input_types.len();
         let len_outputs = output_types.len();
         let max_inout = len_inputs.max(len_outputs);
-        self.stack.values.reserve(max_inout)?;
-        let delta = len_outputs.saturating_sub(len_inputs);
-        let offset = self.stack.values.extend_zeros(delta);
         let values = self.stack.values.as_slice_mut();
         let params_results = FuncParams::new(
             values.split_at_mut(values.len() - max_inout).1,
@@ -256,8 +254,7 @@ impl<'engine> EngineExecutor<'engine> {
                 //       called host function. Since the host function failed we
                 //       need to clean up the temporary buffer values here.
                 //       This is required for resumable calls to work properly.
-                // self.stack.values.drop(delta);
-                self.stack.values.truncate(offset);
+                self.stack.values.drop(max_inout);
                 error
             })?;
         if let Some(results) = caller.results() {
@@ -278,7 +275,7 @@ impl<'engine> EngineExecutor<'engine> {
             // provide us with valid result registers.
             let mut caller_sp = unsafe { self.stack.values.stack_ptr_at(caller_offset) };
             // # Safety: See Safety (1) above.
-            let callee_sp = unsafe { self.stack.values.stack_ptr_at(offset) };
+            let callee_sp = unsafe { self.stack.values.stack_ptr_last_n(max_inout) };
             let results = results.iter(len_outputs);
             let values = RegisterSpan::new(Register::from_i16(0)).iter(len_outputs);
             for (result, value) in results.zip(values) {
@@ -289,7 +286,7 @@ impl<'engine> EngineExecutor<'engine> {
                 *result_cell = value_cell;
             }
             // Finally, the value stack needs to be truncated to its original size.
-            self.stack.values.truncate(offset);
+            self.stack.values.drop(max_inout);
         }
         Ok(())
     }
@@ -324,6 +321,7 @@ impl<'engine> EngineExecutor<'engine> {
         let value_stack = &mut self.stack.values;
         let call_stack = &mut self.stack.calls;
         let code_map = &self.res.code_map_2;
+        let func_types = &self.res.func_types;
 
         execute_instrs(
             store_inner,
@@ -331,6 +329,7 @@ impl<'engine> EngineExecutor<'engine> {
             value_stack,
             call_stack,
             code_map,
+            func_types,
             &mut resource_limiter,
         )
         .map_err(make_trap)

--- a/crates/wasmi/src/engine/regmach/stack/values.rs
+++ b/crates/wasmi/src/engine/regmach/stack/values.rs
@@ -118,6 +118,18 @@ impl ValueStack {
         self.root_stack_ptr().apply_offset(offset.into())
     }
 
+    /// Returns the [`ValueStackPtr`] at the given `offset` from the back.
+    ///
+    /// # Panics (Debug)
+    ///
+    /// If `n` is greater than the height of the [`ValueStack`].
+    pub unsafe fn stack_ptr_last_n(&mut self, n: usize) -> ValueStackPtr {
+        let len_values = self.len();
+        debug_assert!(n <= len_values);
+        let offset = len_values - n;
+        self.root_stack_ptr().apply_offset(ValueStackOffset(offset))
+    }
+
     /// Returns the capacity of the [`ValueStack`].
     fn capacity(&self) -> usize {
         self.values.len()
@@ -203,10 +215,27 @@ impl ValueStack {
         ValueStackOffset(old_sp)
     }
 
+    /// Drop the last `amount` cells of the [`ValueStack`].
+    ///
+    /// # Panics (Debug)
+    ///
+    /// If `amount` is greater than the [`ValueStack`] height.
+    #[inline]
+    pub fn drop(&mut self, amount: usize) {
+        debug_assert!(self.sp >= amount);
+        self.sp -= amount;
+    }
+
     /// Shrink the [`ValueStack`] to the [`ValueStackOffset`].
+    ///
+    /// # Panics (Debug)
+    ///
+    /// If `new_sp` is greater than the current [`ValueStack`] pointer.
     #[inline]
     pub fn truncate(&mut self, new_sp: impl Into<ValueStackOffset>) {
-        self.sp = new_sp.into().0;
+        let new_sp = new_sp.into().0;
+        debug_assert!(new_sp <= self.sp);
+        self.sp = new_sp;
     }
 
     /// Allocates a new [`CompiledFunc`] on the [`ValueStack`].

--- a/crates/wasmi/src/engine/regmach/tests/host_calls.rs
+++ b/crates/wasmi/src/engine/regmach/tests/host_calls.rs
@@ -1,0 +1,86 @@
+//! This submodule tests the unusual use case of calling host functions through the engine from the host side.
+
+use crate::{Caller, core::Trap, Config, Engine, Func, Store};
+
+/// Setup a new `Store` for testing with initial value of 5.
+fn setup_store() -> Store<i32> {
+    let config = Config::default();
+    // config.set_engine_backend(EngineBackend::RegisterMachine);
+    let engine = Engine::new(&config);
+    Store::new(&engine, 5_i32)
+}
+
+#[test]
+fn host_call_from_host_params_0_results_0() {
+    let mut store = setup_store();
+    let err_if_zero = Func::wrap(&mut store, |caller: Caller<i32>| {
+        if *caller.data() == 0 {
+            return Err(Trap::new("test trap"))
+        }
+        Ok(())
+    });
+    let err_if_zero = err_if_zero.typed::<(), ()>(&mut store).unwrap();
+    assert!(err_if_zero.call(&mut store, ()).is_ok());
+    *store.data_mut() = 0;
+    assert!(err_if_zero.call(&mut store, ()).is_err());
+}
+
+#[test]
+fn host_call_from_host_params_0_results_1() {
+    let mut store = setup_store();
+    let data_plus_42 = Func::wrap(&mut store, |caller: Caller<i32>| caller.data() + 42_i32);
+    let data_plus_42 = data_plus_42.typed::<(), i32>(&mut store).unwrap();
+    assert_eq!(data_plus_42.call(&mut store, ()).unwrap(), 47_i32);
+    *store.data_mut() = 10;
+    assert_eq!(data_plus_42.call(&mut store, ()).unwrap(), 52_i32);
+}
+
+#[test]
+fn host_call_from_host_params_2_results_1() {
+    let mut store = setup_store();
+    let sum_with_data = Func::wrap(&mut store, |caller: Caller<i32>, a: i32, b: i32| {
+        caller.data() + a + b
+    });
+    let sum_with_data = sum_with_data.typed::<(i32, i32), i32>(&mut store).unwrap();
+    assert_eq!(sum_with_data.call(&mut store, (1, 2)).unwrap(), 8_i32);
+    *store.data_mut() = 10;
+    assert_eq!(sum_with_data.call(&mut store, (10, 15)).unwrap(), 35_i32);
+}
+
+#[test]
+fn host_call_from_host_params_0_results_2() {
+    let mut store = setup_store();
+    let get_data = Func::wrap(&mut store, |caller: Caller<i32>| {
+        let data = *caller.data();
+        (data + data, data * data)
+    });
+    let get_data = get_data.typed::<(), (i32, i32)>(&mut store).unwrap();
+    assert_eq!(get_data.call(&mut store, ()).unwrap(), (10, 25));
+    *store.data_mut() = 10;
+    assert_eq!(get_data.call(&mut store, ()).unwrap(), (20, 100));
+}
+
+#[test]
+fn host_call_from_host_params_4_results_4() {
+    let mut store = setup_store();
+    // Function f(D, a,b,c,d) that outputs (d+D, c+D, b+D, a+D)
+    let reverse_and_add = Func::wrap(
+        &mut store,
+        |caller: Caller<i32>, a: i32, b: i32, c: i32, d: i32| {
+            let offset = caller.data();
+            (d + offset, c + offset, b + offset, a + offset)
+        },
+    );
+    let reverse_and_add = reverse_and_add
+        .typed::<(i32, i32, i32, i32), (i32, i32, i32, i32)>(&mut store)
+        .unwrap();
+    assert_eq!(
+        reverse_and_add.call(&mut store, (1, 2, 3, 4)).unwrap(),
+        (9, 8, 7, 6)
+    );
+    *store.data_mut() = 10;
+    assert_eq!(
+        reverse_and_add.call(&mut store, (40, 30, 20, 10)).unwrap(),
+        (20, 30, 40, 50)
+    );
+}

--- a/crates/wasmi/src/engine/regmach/tests/host_calls.rs
+++ b/crates/wasmi/src/engine/regmach/tests/host_calls.rs
@@ -1,11 +1,11 @@
 //! This submodule tests the unusual use case of calling host functions through the engine from the host side.
 
-use crate::{Caller, core::Trap, Config, Engine, Func, Store};
+use crate::{core::Trap, Caller, Config, Engine, EngineBackend, Func, Store};
 
 /// Setup a new `Store` for testing with initial value of 5.
 fn setup_store() -> Store<i32> {
-    let config = Config::default();
-    // config.set_engine_backend(EngineBackend::RegisterMachine);
+    let mut config = Config::default();
+    config.set_engine_backend(EngineBackend::RegisterMachine);
     let engine = Engine::new(&config);
     Store::new(&engine, 5_i32)
 }
@@ -15,7 +15,7 @@ fn host_call_from_host_params_0_results_0() {
     let mut store = setup_store();
     let err_if_zero = Func::wrap(&mut store, |caller: Caller<i32>| {
         if *caller.data() == 0 {
-            return Err(Trap::new("test trap"))
+            return Err(Trap::new("test trap"));
         }
         Ok(())
     });

--- a/crates/wasmi/src/engine/regmach/tests/mod.rs
+++ b/crates/wasmi/src/engine/regmach/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod display_wasm;
 pub mod driver;
+mod host_calls;
 mod op;
 pub mod wasm_type;
 

--- a/crates/wasmi/src/engine/regmach/tests/op/block.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/block.rs
@@ -323,11 +323,7 @@ fn branched_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_span(
-                RegisterSpan::new(Register::from_i16(2)),
-                RegisterSpan::new(Register::from_i16(0)),
-                2,
-            ),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 0, 1),
             Instruction::branch(BranchOffset::from(1)),
             Instruction::return_reg(Register::from_i16(2)),
         ])

--- a/crates/wasmi/src/engine/regmach/tests/op/br.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br.rs
@@ -1,9 +1,13 @@
 use super::*;
-use crate::engine::{
-    bytecode::BranchOffset,
-    regmach::{
-        bytecode::RegisterSpan,
-        tests::{display_wasm::DisplayValueType, driver::ExpectedFunc, wasm_type::WasmType},
+use crate::{
+    core::UntypedValue,
+    engine::{
+        bytecode::BranchOffset,
+        regmach::tests::{
+            display_wasm::DisplayValueType,
+            driver::ExpectedFunc,
+            wasm_type::WasmType,
+        },
     },
 };
 use core::fmt::Display;
@@ -182,12 +186,13 @@ fn test_br_as_return_values() {
         "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_i64imm32(Register::from_i16(0), 7),
-            Instruction::branch(BranchOffset::from(1)),
-            Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
-            Instruction::copy_imm32(Register::from_i16(0), 2_i32),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::copy_i64imm32(Register::from_i16(0), 7),
+                Instruction::branch(BranchOffset::from(1)),
+                Instruction::return_reg2(-1, 0),
+            ])
+            .consts([UntypedValue::from(2_i32)]),
+        )
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/br.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br.rs
@@ -187,7 +187,7 @@ fn test_br_as_return_values() {
             Instruction::branch(BranchOffset::from(1)),
             Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
             Instruction::copy_imm32(Register::from_i16(0), 2_i32),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
@@ -490,7 +490,7 @@ fn return_if_results_2() {
                 Register::from_i16(2),
                 RegisterSpan::new(Register::from_i16(0)).iter(2),
             ),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_reg2(0, 1),
         ])
         .run()
 }
@@ -518,7 +518,7 @@ fn return_if_results_2_rev() {
                 Register::from_i16(2),
                 RegisterSpan::new(Register::from_i16(3)).iter(2),
             ),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
+            Instruction::return_reg2(3, 4),
         ])
         .run()
 }
@@ -546,7 +546,7 @@ fn return_if_results_2_imm() {
                 Register::from_i16(0),
                 RegisterSpan::new(Register::from_i16(1)).iter(2),
             ),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(2)),
+            Instruction::return_reg2(1, 2),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
@@ -1003,10 +1003,18 @@ fn branch_if_results_4_mixed_1() {
         .expect_func(
             ExpectedFunc::new([
                 Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(4)),
-                Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), -1, 0),
+                Instruction::copy_many_non_overlapping(
+                    RegisterSpan::new(Register::from_i16(3)),
+                    -1,
+                    0,
+                ),
                 Instruction::register2(1, -2),
                 Instruction::branch(BranchOffset::from(3)),
-                Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), -1, 0),
+                Instruction::copy_many_non_overlapping(
+                    RegisterSpan::new(Register::from_i16(3)),
+                    -1,
+                    0,
+                ),
                 Instruction::register2(1, -2),
                 Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
             ])
@@ -1038,10 +1046,10 @@ fn branch_if_results_4_mixed_2() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(4)),
-            Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), 0, 0),
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(3)), 0, 0),
             Instruction::register2(1, 1),
             Instruction::branch(BranchOffset::from(3)),
-            Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), 0, 0),
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(3)), 0, 0),
             Instruction::register2(1, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
         ])

--- a/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
@@ -928,17 +928,9 @@ fn branch_if_results_2() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(3)),
-            Instruction::copy_span(
-                RegisterSpan::new(Register::from_i16(3)),
-                RegisterSpan::new(Register::from_i16(0)),
-                2,
-            ),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy_span(
-                RegisterSpan::new(Register::from_i16(3)),
-                RegisterSpan::new(Register::from_i16(0)),
-                2,
-            ),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
             Instruction::i32_add(
                 Register::from_i16(3),
                 Register::from_i16(3),
@@ -1008,19 +1000,18 @@ fn branch_if_results_4_mixed_1() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(6)),
-            Instruction::copy_imm32(Register::from_i16(3), 10),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
-            Instruction::copy_imm32(Register::from_i16(6), 20),
-            Instruction::branch(BranchOffset::from(5)),
-            Instruction::copy_imm32(Register::from_i16(3), 10),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
-            Instruction::copy_imm32(Register::from_i16(6), 20),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(4)),
+                Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), -1, 0),
+                Instruction::register2(1, -2),
+                Instruction::branch(BranchOffset::from(3)),
+                Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), -1, 0),
+                Instruction::register2(1, -2),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
+            ])
+            .consts([10_i32, 20]),
+        )
         .run()
 }
 
@@ -1046,16 +1037,12 @@ fn branch_if_results_4_mixed_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(6)),
-            Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
-            Instruction::copy(Register::from_i16(6), Register::from_i16(1)),
-            Instruction::branch(BranchOffset::from(5)),
-            Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
-            Instruction::copy(Register::from_i16(6), Register::from_i16(1)),
+            Instruction::branch_eqz(Register::from_i16(2), BranchOffset::from(4)),
+            Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), 0, 0),
+            Instruction::register2(1, 1),
+            Instruction::branch(BranchOffset::from(3)),
+            Instruction::copy_many(RegisterSpan::new(Register::from_i16(3)), 0, 0),
+            Instruction::register2(1, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
         ])
         .run()

--- a/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
@@ -486,10 +486,7 @@ fn return_if_results_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::return_nez_span(
-                Register::from_i16(2),
-                RegisterSpan::new(Register::from_i16(0)).iter(2),
-            ),
+            Instruction::return_nez_reg2(Register::from_i16(2), 0, 1),
             Instruction::return_reg2(0, 1),
         ])
         .run()
@@ -512,13 +509,8 @@ fn return_if_results_2_rev() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(3), Register::from_i16(1)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
-            Instruction::return_nez_span(
-                Register::from_i16(2),
-                RegisterSpan::new(Register::from_i16(3)).iter(2),
-            ),
-            Instruction::return_reg2(3, 4),
+            Instruction::return_nez_reg2(Register::from_i16(2), 1, 0),
+            Instruction::return_reg2(1, 0),
         ])
         .run()
 }
@@ -539,15 +531,300 @@ fn return_if_results_2_imm() {
         )",
     );
     TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_nez_reg2(Register::from_i16(0), -1, -2),
+                Instruction::return_reg2(-1, -2),
+            ])
+            .consts([10_i32, 20]),
+        )
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_3_span() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (br_if 0
+                    (local.get 3) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(1), 10),
-            Instruction::copy_imm32(Register::from_i16(2), 20),
             Instruction::return_nez_span(
-                Register::from_i16(0),
-                RegisterSpan::new(Register::from_i16(1)).iter(2),
+                Register::from_i16(3),
+                RegisterSpan::new(Register::from_i16(0)).iter(3),
             ),
-            Instruction::return_reg2(1, 2),
+            Instruction::return_reg3(0, 1, 2),
         ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_3() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32 i32 i32) (result i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 0)
+                (br_if 0
+                    (local.get 2) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_nez_many(Register::from_i16(2), 0, 1),
+            Instruction::register(0),
+            Instruction::return_reg3(0, 1, 0),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_3_imm() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32) (result i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (br_if 0
+                    (local.get 0) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_nez_many(Register::from_i16(0), -1, -2),
+                Instruction::register(-3),
+                Instruction::return_reg3(-1, -2, -3),
+            ])
+            .consts([10_i32, 20, 30]),
+        )
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_4_span() {
+    let wasm: Vec<u8> = wat2wasm(
+        r"
+        (module
+            (func (param i32 i32 i32 i32 i32) (result i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (br_if 0
+                    (local.get 4) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_nez_span(
+                Register::from_i16(4),
+                RegisterSpan::new(Register::from_i16(0)).iter(4),
+            ),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(4)),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_4() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32 i32 i32) (result i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 0)
+                (local.get 1)
+                (br_if 0
+                    (local.get 2) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_nez_many(Register::from_i16(2), 0, 1),
+            Instruction::register2(0, 1),
+            Instruction::return_many(0, 1, 0),
+            Instruction::register(1),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_4_imm() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32) (result i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 10)
+                (i32.const 20)
+                (br_if 0
+                    (local.get 0) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_nez_many(Register::from_i16(0), -1, -2),
+                Instruction::register2(-1, -2),
+                Instruction::return_many(-1, -2, -1),
+                Instruction::register(-2),
+            ])
+            .consts([10_i32, 20]),
+        )
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_5() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32 i32 i32) (result i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 0)
+                (local.get 1)
+                (local.get 0)
+                (br_if 0
+                    (local.get 2) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_nez_many(Register::from_i16(2), 0, 1),
+            Instruction::register3(0, 1, 0),
+            Instruction::return_many(0, 1, 0),
+            Instruction::register2(1, 0),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_5_imm() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32) (result i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 10)
+                (br_if 0
+                    (local.get 0) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_nez_many(Register::from_i16(0), -1, -2),
+                Instruction::register3(-1, -2, -1),
+                Instruction::return_many(-1, -2, -1),
+                Instruction::register2(-2, -1),
+            ])
+            .consts([10_i32, 20]),
+        )
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_6() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32 i32 i32) (result i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 0)
+                (local.get 1)
+                (local.get 0)
+                (local.get 1)
+                (br_if 0
+                    (local.get 2) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_nez_many(Register::from_i16(2), 0, 1),
+            Instruction::register_list(0, 1, 0),
+            Instruction::register(1),
+            Instruction::return_many(0, 1, 0),
+            Instruction::register3(1, 0, 1),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn return_if_results_6_imm() {
+    let wasm = wat2wasm(
+        r"
+        (module
+            (func (param i32) (result i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 10)
+                (i32.const 20)
+                (br_if 0
+                    (local.get 0) ;; br_if condition
+                )
+            )
+        )",
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_nez_many(Register::from_i16(0), -1, -2),
+                Instruction::register_list(-1, -2, -1),
+                Instruction::register(-2),
+                Instruction::return_many(-1, -2, -1),
+                Instruction::register3(-2, -1, -2),
+            ])
+            .consts([10_i32, 20]),
+        )
         .run()
 }
 

--- a/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_if.rs
@@ -486,11 +486,11 @@ fn return_if_results_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::return_nez_many(
+            Instruction::return_nez_span(
                 Register::from_i16(2),
                 RegisterSpan::new(Register::from_i16(0)).iter(2),
             ),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .run()
 }
@@ -514,11 +514,11 @@ fn return_if_results_2_rev() {
         .expect_func_instrs([
             Instruction::copy(Register::from_i16(3), Register::from_i16(1)),
             Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
-            Instruction::return_nez_many(
+            Instruction::return_nez_span(
                 Register::from_i16(2),
                 RegisterSpan::new(Register::from_i16(3)).iter(2),
             ),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
         ])
         .run()
 }
@@ -542,11 +542,11 @@ fn return_if_results_2_imm() {
         .expect_func_instrs([
             Instruction::copy_imm32(Register::from_i16(1), 10),
             Instruction::copy_imm32(Register::from_i16(2), 20),
-            Instruction::return_nez_many(
+            Instruction::return_nez_span(
                 Register::from_i16(0),
                 RegisterSpan::new(Register::from_i16(1)).iter(2),
             ),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(1)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(2)),
         ])
         .run()
 }
@@ -742,7 +742,7 @@ fn branch_if_results_4_mixed_1() {
             Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
             Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
             Instruction::copy_imm32(Register::from_i16(6), 20),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(4)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
         ])
         .run()
 }
@@ -779,7 +779,7 @@ fn branch_if_results_4_mixed_2() {
             Instruction::copy(Register::from_i16(4), Register::from_i16(0)),
             Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
             Instruction::copy(Register::from_i16(6), Register::from_i16(1)),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(4)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(4)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_table.rs
@@ -275,23 +275,23 @@ fn reg_params_2_return() {
     let result2 = result.next();
     let results = RegisterSpan::new(result).iter(2);
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
-            Instruction::branch_table(index, 4),
-            Instruction::return_span(results),
-            Instruction::branch(BranchOffset::from(9)),
-            Instruction::branch(BranchOffset::from(5)),
-            Instruction::branch(BranchOffset::from(1)),
-            Instruction::i32_add(result, result, result2),
-            Instruction::copy_imm32(result.next(), 0),
-            Instruction::return_span(results),
-            Instruction::i32_sub(result, result, result2),
-            Instruction::copy_imm32(result.next(), 1),
-            Instruction::return_span(results),
-            Instruction::i32_mul(result, result, result2),
-            Instruction::copy_imm32(result.next(), 2),
-            Instruction::return_span(results),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
+                Instruction::branch_table(index, 4),
+                Instruction::return_span(results),
+                Instruction::branch(BranchOffset::from(7)),
+                Instruction::branch(BranchOffset::from(4)),
+                Instruction::branch(BranchOffset::from(1)),
+                Instruction::i32_add(result, result, result2),
+                Instruction::return_reg2(3, -1),
+                Instruction::i32_sub(result, result, result2),
+                Instruction::return_reg2(3, -2),
+                Instruction::i32_mul(result, result, result2),
+                Instruction::return_reg2(3, -3),
+            ])
+            .consts([0_i32, 1, 2]),
+        )
         .run()
 }
 

--- a/crates/wasmi/src/engine/regmach/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_table.rs
@@ -232,7 +232,7 @@ fn reg_params_2_ops() {
     let result = Register::from_i16(3);
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
+            Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
             Instruction::branch_table(index, 3),
             Instruction::branch(BranchOffset::from(7)),
             Instruction::branch(BranchOffset::from(4)),
@@ -277,7 +277,7 @@ fn reg_params_2_return() {
     TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
+                Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
                 Instruction::branch_table(index, 4),
                 Instruction::return_span(results),
                 Instruction::branch(BranchOffset::from(7)),
@@ -401,15 +401,11 @@ fn reg_params_2_diff() {
             Instruction::branch(BranchOffset::from(5)),
             Instruction::branch(BranchOffset::from(6)),
             Instruction::branch(BranchOffset::from(1)),
-            Instruction::copy_span(
-                RegisterSpan::new(Register::from_i16(4)),
-                RegisterSpan::new(lhs),
-                2,
-            ),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), lhs, lhs.next()),
             Instruction::branch(BranchOffset::from(5)),
-            Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
+            Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
             Instruction::branch(BranchOffset::from(5)),
-            Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
+            Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
             Instruction::branch(BranchOffset::from(5)),
             Instruction::i32_add(
                 Register::from_i16(4),

--- a/crates/wasmi/src/engine/regmach/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/br_table.rs
@@ -278,19 +278,19 @@ fn reg_params_2_return() {
         .expect_func_instrs([
             Instruction::copy_span(RegisterSpan::new(result), RegisterSpan::new(lhs), 2),
             Instruction::branch_table(index, 4),
-            Instruction::return_many(results),
+            Instruction::return_span(results),
             Instruction::branch(BranchOffset::from(9)),
             Instruction::branch(BranchOffset::from(5)),
             Instruction::branch(BranchOffset::from(1)),
             Instruction::i32_add(result, result, result2),
             Instruction::copy_imm32(result.next(), 0),
-            Instruction::return_many(results),
+            Instruction::return_span(results),
             Instruction::i32_sub(result, result, result2),
             Instruction::copy_imm32(result.next(), 1),
-            Instruction::return_many(results),
+            Instruction::return_span(results),
             Instruction::i32_mul(result, result, result2),
             Instruction::copy_imm32(result.next(), 2),
-            Instruction::return_many(results),
+            Instruction::return_span(results),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/call/imported.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/imported.rs
@@ -41,7 +41,7 @@ fn one_param_reg() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(1)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
+            Instruction::register(0),
             Instruction::return_reg(Register::from_i16(1)),
         ])
         .run();
@@ -61,12 +61,17 @@ fn one_param_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::call_imported(RegisterSpan::new(Register::from_i16(0)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
-            Instruction::return_reg(Register::from_i16(0)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_imported(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    FuncIdx::from(0),
+                ),
+                Instruction::register(-1),
+                Instruction::return_reg(Register::from_i16(0)),
+            ])
+            .consts([10_i32]),
+        )
         .run();
 }
 
@@ -86,7 +91,7 @@ fn two_params_reg() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(2)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
+            Instruction::register2(0, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
@@ -107,10 +112,8 @@ fn two_params_reg_rev() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(2), Register::from(1)),
-            Instruction::copy(Register::from_i16(3), Register::from(0)),
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(2)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(2)).iter(2), 2),
+            Instruction::register2(1, 0),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
@@ -130,13 +133,17 @@ fn two_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::call_imported(RegisterSpan::new(Register::from_i16(0)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_imported(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    FuncIdx::from(0),
+                ),
+                Instruction::register2(-1, -2),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            ])
+            .consts([10_i32, 20]),
+        )
         .run();
 }
 
@@ -156,7 +163,7 @@ fn three_params_reg() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(3)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
+            Instruction::register3(0, 1, 2),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
@@ -177,11 +184,8 @@ fn three_params_reg_rev() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(3), Register::from(2)),
-            Instruction::copy(Register::from_i16(4), Register::from(1)),
-            Instruction::copy(Register::from_i16(5), Register::from(0)),
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(3)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(3)).iter(3), 3),
+            Instruction::register3(2, 1, 0),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
@@ -201,13 +205,331 @@ fn three_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_imported(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    FuncIdx::from(0),
+                ),
+                Instruction::register3(-1, -2, -3),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+            ])
+            .consts([10_i32, 20, 30]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            Instruction::call_imported(RegisterSpan::new(Register::from_i16(0)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+            Instruction::call_imported(RegisterSpan::new(Register::from_i16(7)), FuncIdx::from(0)),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register(6),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(7)).iter(7)),
         ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_imported(RegisterSpan::new(Register::from_i16(7)), FuncIdx::from(0)),
+            Instruction::register_list(6, 5, 4),
+            Instruction::register_list(3, 2, 1),
+            Instruction::register(0),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(7)).iter(7)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (result i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_imported(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    FuncIdx::from(0),
+                ),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register(-7),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(7)),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                    (local.get 7)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_imported(RegisterSpan::new(Register::from_i16(8)), FuncIdx::from(0)),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register2(6, 7),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(8)).iter(8)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 7)
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_imported(RegisterSpan::new(Register::from_i16(8)), FuncIdx::from(0)),
+            Instruction::register_list(7, 6, 5),
+            Instruction::register_list(4, 3, 2),
+            Instruction::register2(1, 0),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(8)).iter(8)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                    (i32.const 80)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_imported(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    FuncIdx::from(0),
+                ),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register2(-7, -8),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(8)),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70, 80]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                    (local.get 7)
+                    (local.get 8)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_imported(RegisterSpan::new(Register::from_i16(9)), FuncIdx::from(0)),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register3(6, 7, 8),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(9)).iter(9)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 8)
+                    (local.get 7)
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_imported(RegisterSpan::new(Register::from_i16(9)), FuncIdx::from(0)),
+            Instruction::register_list(8, 7, 6),
+            Instruction::register_list(5, 4, 3),
+            Instruction::register3(2, 1, 0),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(9)).iter(9)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "env" "f" (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                    (i32.const 80)
+                    (i32.const 90)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_imported(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    FuncIdx::from(0),
+                ),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register3(-7, -8, -9),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(9)),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70, 80, 90]),
+        )
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/call/imported.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/imported.rs
@@ -87,7 +87,7 @@ fn two_params_reg() {
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(2)), FuncIdx::from(0)),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
 }
@@ -111,7 +111,7 @@ fn two_params_reg_rev() {
             Instruction::copy(Register::from_i16(3), Register::from(0)),
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(2)), FuncIdx::from(0)),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(2)).iter(2), 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
 }
@@ -135,7 +135,7 @@ fn two_params_imm() {
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(0)), FuncIdx::from(0)),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .run();
 }
@@ -157,7 +157,7 @@ fn three_params_reg() {
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(3)), FuncIdx::from(0)),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
 }
@@ -182,7 +182,7 @@ fn three_params_reg_rev() {
             Instruction::copy(Register::from_i16(5), Register::from(0)),
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(3)), FuncIdx::from(0)),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(3)).iter(3), 3),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
 }
@@ -207,7 +207,7 @@ fn three_params_imm() {
             Instruction::copy_imm32(Register::from_i16(2), 30_i32),
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(0)), FuncIdx::from(0)),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
         ])
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/call/imported.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/imported.rs
@@ -92,7 +92,7 @@ fn two_params_reg() {
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(2)), FuncIdx::from(0)),
             Instruction::register2(0, 1),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_reg2(2, 3),
         ])
         .run();
 }
@@ -114,7 +114,7 @@ fn two_params_reg_rev() {
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(2)), FuncIdx::from(0)),
             Instruction::register2(1, 0),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_reg2(2, 3),
         ])
         .run();
 }
@@ -140,7 +140,7 @@ fn two_params_imm() {
                     FuncIdx::from(0),
                 ),
                 Instruction::register2(-1, -2),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+                Instruction::return_reg2(0, 1),
             ])
             .consts([10_i32, 20]),
         )
@@ -164,7 +164,7 @@ fn three_params_reg() {
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(3)), FuncIdx::from(0)),
             Instruction::register3(0, 1, 2),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_reg3(3, 4, 5),
         ])
         .run();
 }
@@ -186,7 +186,7 @@ fn three_params_reg_rev() {
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(3)), FuncIdx::from(0)),
             Instruction::register3(2, 1, 0),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_reg3(3, 4, 5),
         ])
         .run();
 }
@@ -212,7 +212,7 @@ fn three_params_imm() {
                     FuncIdx::from(0),
                 ),
                 Instruction::register3(-1, -2, -3),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+                Instruction::return_reg3(0, 1, 2),
             ])
             .consts([10_i32, 20, 30]),
         )

--- a/crates/wasmi/src/engine/regmach/tests/op/call/indirect.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/indirect.rs
@@ -88,7 +88,7 @@ fn one_reg_param_reg() {
                 SignatureIdx::from(0),
             ),
             Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
+            Instruction::register(1),
             Instruction::return_reg(Register::from_i16(2)),
         ])
         .run();
@@ -118,7 +118,7 @@ fn one_reg_param_imm16() {
                     SignatureIdx::from(0),
                 ),
                 Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
-                Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
+                Instruction::register(1),
                 Instruction::return_reg(Register::from_i16(2)),
             ])
             .run();
@@ -128,6 +128,44 @@ fn one_reg_param_imm16() {
     test_with(1);
     test_with(u32::from(u16::MAX) - 1);
     test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn one_reg_param_imm() {
+    fn test_with(index: u32) {
+        let wasm = wat2wasm(&format!(
+            r#"
+            (module
+                (import "" "table" (table $table 10 funcref))
+                (type $type (func (param i32) (result i32)))
+                (func (param $index i32) (param i32) (result i32)
+                    (local.get 1)
+                    (i32.const {index})
+                    (call_indirect (type $type))
+                )
+            )
+        "#,
+        ));
+        TranslationTest::new(wasm)
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::call_indirect(
+                        RegisterSpan::new(Register::from_i16(2)),
+                        SignatureIdx::from(0),
+                    ),
+                    Instruction::call_indirect_params(Register::from_i16(-1), TableIdx::from(0)),
+                    Instruction::register(1),
+                    Instruction::return_reg(Register::from_i16(2)),
+                ])
+                .consts([index]),
+            )
+            .run();
+    }
+
+    test_with(u32::from(u16::MAX) + 1);
+    test_with(u32::MAX - 1);
+    test_with(u32::MAX);
 }
 
 #[test]
@@ -147,16 +185,18 @@ fn one_imm_param_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(1), 10),
-            Instruction::call_indirect(
-                RegisterSpan::new(Register::from_i16(1)),
-                SignatureIdx::from(0),
-            ),
-            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
-            Instruction::return_reg(Register::from_i16(1)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_indirect(
+                    RegisterSpan::new(Register::from_i16(1)),
+                    SignatureIdx::from(0),
+                ),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register(-1),
+                Instruction::return_reg(Register::from_i16(1)),
+            ])
+            .consts([10_i32]),
+        )
         .run();
 }
 
@@ -178,16 +218,18 @@ fn one_imm_param_imm16() {
         "#,
         ));
         TranslationTest::new(wasm)
-            .expect_func_instrs([
-                Instruction::copy_imm32(Register::from_i16(1), 10),
-                Instruction::call_indirect(
-                    RegisterSpan::new(Register::from_i16(1)),
-                    SignatureIdx::from(0),
-                ),
-                Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
-                Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
-                Instruction::return_reg(Register::from_i16(1)),
-            ])
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::call_indirect(
+                        RegisterSpan::new(Register::from_i16(1)),
+                        SignatureIdx::from(0),
+                    ),
+                    Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
+                    Instruction::register(-1),
+                    Instruction::return_reg(Register::from_i16(1)),
+                ])
+                .consts([10_i32]),
+            )
             .run();
     }
 
@@ -195,6 +237,44 @@ fn one_imm_param_imm16() {
     test_with(1);
     test_with(u32::from(u16::MAX) - 1);
     test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn one_imm_param_imm() {
+    fn test_with(index: u32) {
+        let wasm = wat2wasm(&format!(
+            r#"
+            (module
+                (import "" "table" (table $table 10 funcref))
+                (type $type (func (param i32) (result i32)))
+                (func (param $index i32) (result i32)
+                    (i32.const 10)
+                    (i32.const {index})
+                    (call_indirect (type $type))
+                )
+            )
+        "#,
+        ));
+        TranslationTest::new(wasm)
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::call_indirect(
+                        RegisterSpan::new(Register::from_i16(1)),
+                        SignatureIdx::from(0),
+                    ),
+                    Instruction::call_indirect_params(Register::from_i16(-1), TableIdx::from(0)),
+                    Instruction::register(-2),
+                    Instruction::return_reg(Register::from_i16(1)),
+                ])
+                .consts([index as i32, 10]),
+            )
+            .run();
+    }
+
+    test_with(u32::from(u16::MAX) + 1);
+    test_with(u32::MAX - 1);
+    test_with(u32::MAX);
 }
 
 #[test]
@@ -216,13 +296,12 @@ fn two_reg_params_reg() {
     );
     let result_reg = Register::from_i16(3);
     let results = RegisterSpan::new(result_reg);
-    let params = RegisterSpan::new(Register::from_i16(1)).iter(2);
     let elem_index = Register::from_i16(0);
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
-            Instruction::call_params(params, 2),
+            Instruction::register2(1, 2),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
         ])
         .run();
@@ -247,15 +326,12 @@ fn two_reg_params_reg_rev() {
     );
     let result_reg = Register::from_i16(3);
     let results = RegisterSpan::new(result_reg);
-    let params = RegisterSpan::new(Register::from_i16(3)).iter(2);
     let elem_index = Register::from_i16(0);
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(3), Register::from_i16(2)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(1)),
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
-            Instruction::call_params(params, 2),
+            Instruction::register2(2, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
         ])
         .run();
@@ -280,17 +356,17 @@ fn two_imm_params_reg() {
     );
     let result_reg = Register::from_i16(1);
     let results = RegisterSpan::new(result_reg);
-    let params = RegisterSpan::new(Register::from_i16(1)).iter(2);
     let elem_index = Register::from_i16(0);
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(1), 10),
-            Instruction::copy_imm32(Register::from_i16(2), 20),
-            Instruction::call_indirect(results, SignatureIdx::from(0)),
-            Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
-            Instruction::call_params(params, 2),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_indirect(results, SignatureIdx::from(0)),
+                Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+                Instruction::register2(-1, -2),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(2)),
+            ])
+            .consts([10_i32, 20_i32]),
+        )
         .run();
 }
 
@@ -314,13 +390,12 @@ fn two_reg_params_imm16() {
         ));
         let result_reg = Register::from_i16(2);
         let results = RegisterSpan::new(result_reg);
-        let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
         let elem_index = u32imm16(index);
         TranslationTest::new(wasm)
             .expect_func_instrs([
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
-                Instruction::call_params(params, 2),
+                Instruction::register2(0, 1),
                 Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
             ])
             .run();
@@ -352,15 +427,12 @@ fn two_reg_params_rev_imm16() {
         ));
         let result_reg = Register::from_i16(2);
         let results = RegisterSpan::new(result_reg);
-        let params = RegisterSpan::new(Register::from_i16(2)).iter(2);
         let elem_index = u32imm16(index);
         TranslationTest::new(wasm)
             .expect_func_instrs([
-                Instruction::copy(Register::from_i16(2), Register::from_i16(1)),
-                Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
-                Instruction::call_params(params, 2),
+                Instruction::register2(1, 0),
                 Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
             ])
             .run();
@@ -392,17 +464,17 @@ fn two_imm_params_imm16() {
         ));
         let result_reg = Register::from_i16(0);
         let results = RegisterSpan::new(result_reg);
-        let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
         let elem_index = u32imm16(index);
         TranslationTest::new(wasm)
-            .expect_func_instrs([
-                Instruction::copy_imm32(Register::from_i16(0), 10),
-                Instruction::copy_imm32(Register::from_i16(1), 20),
-                Instruction::call_indirect(results, SignatureIdx::from(0)),
-                Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
-                Instruction::call_params(params, 2),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-            ])
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::call_indirect(results, SignatureIdx::from(0)),
+                    Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
+                    Instruction::register2(-1, -2),
+                    Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+                ])
+                .consts([10_i32, 20_i32]),
+            )
             .run();
     }
 
@@ -410,6 +482,380 @@ fn two_imm_params_imm16() {
     test_with(1);
     test_with(u32::from(u16::MAX) - 1);
     test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_reg_params_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32) (result i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    let result_reg = Register::from_i16(4);
+    let results = RegisterSpan::new(result_reg);
+    let elem_index = Register::from_i16(0);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_indirect(results, SignatureIdx::from(0)),
+            Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+            Instruction::register3(1, 2, 3),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(4)).iter(3)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_reg_params_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32) (result i32 i32 i32)
+                (local.get 3)
+                (local.get 2)
+                (local.get 1)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    let result_reg = Register::from_i16(4);
+    let results = RegisterSpan::new(result_reg);
+    let elem_index = Register::from_i16(0);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_indirect(results, SignatureIdx::from(0)),
+            Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+            Instruction::register3(3, 2, 1),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(4)).iter(3)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_imm_params_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    let result_reg = Register::from_i16(1);
+    let results = RegisterSpan::new(result_reg);
+    let elem_index = Register::from_i16(0);
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_indirect(results, SignatureIdx::from(0)),
+                Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+                Instruction::register3(-1, -2, -3),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(3)),
+            ])
+            .consts([10_i32, 20, 30]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_imm_params_imm16() {
+    fn test_with(index: u32) {
+        let wasm = wat2wasm(&format!(
+            r#"
+            (module
+                (import "" "table" (table $table 10 funcref))
+                (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+                (func (result i32 i32 i32)
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const {index})
+                    (call_indirect (type $type))
+                )
+            )
+        "#,
+        ));
+        let result_reg = Register::from_i16(0);
+        let results = RegisterSpan::new(result_reg);
+        let elem_index = u32imm16(index);
+        TranslationTest::new(wasm)
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::call_indirect(results, SignatureIdx::from(0)),
+                    Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
+                    Instruction::register3(-1, -2, -3),
+                    Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+                ])
+                .consts([10_i32, 20, 30]),
+            )
+            .run();
+    }
+
+    test_with(0);
+    test_with(1);
+    test_with(u32::from(u16::MAX) - 1);
+    test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_indirect(
+                RegisterSpan::new(Register::from_i16(8)),
+                SignatureIdx::from(0),
+            ),
+            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::register_list(1, 2, 3),
+            Instruction::register_list(4, 5, 6),
+            Instruction::register(7),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(8)).iter(7)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_imm_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (i32.const 40)
+                (i32.const 50)
+                (i32.const 60)
+                (i32.const 70)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_indirect(
+                    RegisterSpan::new(Register::from_i16(1)),
+                    SignatureIdx::from(0),
+                ),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register(-7),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(7)),
+            ])
+            .consts([10_i32, 20, 30, 40, 50, 60, 70]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_indirect(
+                RegisterSpan::new(Register::from_i16(9)),
+                SignatureIdx::from(0),
+            ),
+            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::register_list(1, 2, 3),
+            Instruction::register_list(4, 5, 6),
+            Instruction::register2(7, 8),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(9)).iter(8)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_imm_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (i32.const 40)
+                (i32.const 50)
+                (i32.const 60)
+                (i32.const 70)
+                (i32.const 80)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_indirect(
+                    RegisterSpan::new(Register::from_i16(1)),
+                    SignatureIdx::from(0),
+                ),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register2(-7, -8),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(8)),
+            ])
+            .consts([10_i32, 20, 30, 40, 50, 60, 70, 80]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+                (local.get 9)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::call_indirect(
+                RegisterSpan::new(Register::from_i16(10)),
+                SignatureIdx::from(0),
+            ),
+            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::register_list(1, 2, 3),
+            Instruction::register_list(4, 5, 6),
+            Instruction::register3(7, 8, 9),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(10)).iter(9)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_imm_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (i32.const 40)
+                (i32.const 50)
+                (i32.const 60)
+                (i32.const 70)
+                (i32.const 80)
+                (i32.const 90)
+                (local.get $index)
+                (call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_indirect(
+                    RegisterSpan::new(Register::from_i16(1)),
+                    SignatureIdx::from(0),
+                ),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register3(-7, -8, -9),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(9)),
+            ])
+            .consts([10_i32, 20, 30, 40, 50, 60, 70, 80, 90]),
+        )
+        .run();
 }
 
 #[test]
@@ -435,25 +881,24 @@ fn test_imm_params_dynamic_index() {
     );
     let result = Register::from_i16(0);
     let results = RegisterSpan::new(result);
-    let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
-        .expect_func_instrs([
-            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
-            Instruction::copy_imm32(Register::from_i16(0), 10),
-            Instruction::copy_imm32(Register::from_i16(1), 20),
-            Instruction::call_indirect(results, SignatureIdx::from(0)),
-            Instruction::call_indirect_params(Register::from_i16(2), TableIdx::from(0)),
-            Instruction::call_params(params, 1),
-            Instruction::return_reg(result),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+                Instruction::call_indirect(results, SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register2(-1, -2),
+                Instruction::return_reg(result),
+            ])
+            .consts([10_i32, 20_i32]),
+        )
         .run();
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn regression_issue768() {
+fn regression_issue_768() {
     let wasm = wat2wasm(
         r#"
         (module
@@ -475,21 +920,18 @@ fn regression_issue768() {
     );
     let result = Register::from_i16(0);
     let results = RegisterSpan::new(result);
-    let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
-        .expect_func_instrs([
-            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::global_get(Register::from_i16(1), GlobalIdx::from(1)),
-            // copy parameters and index
-            Instruction::copy(Register::from_i16(2), Register::from_i16(1)),
-            // Instruction::copy(Register::from_i16(0), Register::from_i16(0)), // elided
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            // indirect call
-            Instruction::call_indirect(results, SignatureIdx::from(0)),
-            Instruction::call_indirect_params(Register::from_i16(2), TableIdx::from(0)),
-            Instruction::call_params(params, 1),
-            Instruction::return_reg(result),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+                Instruction::global_get(Register::from_i16(1), GlobalIdx::from(1)),
+                Instruction::call_indirect(results, SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(1), TableIdx::from(0)),
+                Instruction::register2(0, -1),
+                Instruction::return_reg(result),
+            ])
+            .consts([20_i32]),
+        )
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/call/indirect.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/indirect.rs
@@ -302,7 +302,7 @@ fn two_reg_params_reg() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::register2(1, 2),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
+            Instruction::return_reg2(3, 4),
         ])
         .run();
 }
@@ -332,7 +332,7 @@ fn two_reg_params_reg_rev() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::register2(2, 1),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
+            Instruction::return_reg2(3, 4),
         ])
         .run();
 }
@@ -363,7 +363,7 @@ fn two_imm_params_reg() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
                 Instruction::register2(-1, -2),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(2)),
+                Instruction::return_reg2(1, 2),
             ])
             .consts([10_i32, 20_i32]),
         )
@@ -396,7 +396,7 @@ fn two_reg_params_imm16() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::register2(0, 1),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+                Instruction::return_reg2(2, 3),
             ])
             .run();
     }
@@ -433,7 +433,7 @@ fn two_reg_params_rev_imm16() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::register2(1, 0),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+                Instruction::return_reg2(2, 3),
             ])
             .run();
     }
@@ -471,7 +471,7 @@ fn two_imm_params_imm16() {
                     Instruction::call_indirect(results, SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                     Instruction::register2(-1, -2),
-                    Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+                    Instruction::return_reg2(0, 1),
                 ])
                 .consts([10_i32, 20_i32]),
             )
@@ -510,7 +510,7 @@ fn three_reg_params_reg() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::register3(1, 2, 3),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(4)).iter(3)),
+            Instruction::return_reg3(4, 5, 6),
         ])
         .run();
 }
@@ -541,7 +541,7 @@ fn three_reg_params_reg_rev() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::register3(3, 2, 1),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(4)).iter(3)),
+            Instruction::return_reg3(4, 5, 6),
         ])
         .run();
 }
@@ -573,7 +573,7 @@ fn three_imm_params_reg() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
                 Instruction::register3(-1, -2, -3),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(3)),
+                Instruction::return_reg3(1, 2, 3),
             ])
             .consts([10_i32, 20, 30]),
         )
@@ -608,7 +608,7 @@ fn three_imm_params_imm16() {
                     Instruction::call_indirect(results, SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                     Instruction::register3(-1, -2, -3),
-                    Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+                    Instruction::return_reg3(0, 1, 2),
                 ])
                 .consts([10_i32, 20, 30]),
             )

--- a/crates/wasmi/src/engine/regmach/tests/op/call/indirect.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/indirect.rs
@@ -223,7 +223,7 @@ fn two_reg_params_reg() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::call_params(params, 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
         ])
         .run();
 }
@@ -256,7 +256,7 @@ fn two_reg_params_reg_rev() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::call_params(params, 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(2)),
         ])
         .run();
 }
@@ -289,7 +289,7 @@ fn two_imm_params_reg() {
             Instruction::call_indirect(results, SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
             Instruction::call_params(params, 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(1)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter(2)),
         ])
         .run();
 }
@@ -321,7 +321,7 @@ fn two_reg_params_imm16() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::call_params(params, 2),
-                Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
             ])
             .run();
     }
@@ -361,7 +361,7 @@ fn two_reg_params_rev_imm16() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::call_params(params, 2),
-                Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
             ])
             .run();
     }
@@ -401,7 +401,7 @@ fn two_imm_params_imm16() {
                 Instruction::call_indirect(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::call_params(params, 2),
-                Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
             ])
             .run();
     }

--- a/crates/wasmi/src/engine/regmach/tests/op/call/internal.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/internal.rs
@@ -102,16 +102,14 @@ fn two_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(2),
-        )])
+        .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
                 CompiledFunc::from_u32(0),
             ),
             Instruction::register2(0, 1),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_reg2(2, 3),
         ])
         .run();
 }
@@ -133,16 +131,14 @@ fn two_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(2),
-        )])
+        .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
                 CompiledFunc::from_u32(0),
             ),
             Instruction::register2(1, 0),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_reg2(2, 3),
         ])
         .run();
 }
@@ -164,9 +160,7 @@ fn two_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(2),
-        )])
+        .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_internal(
@@ -174,7 +168,7 @@ fn two_params_imm() {
                     CompiledFunc::from_u32(0),
                 ),
                 Instruction::register2(-1, -2),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+                Instruction::return_reg2(0, 1),
             ])
             .consts([10_i32, 20]),
         )
@@ -199,16 +193,14 @@ fn three_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(3),
-        )])
+        .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(3)),
                 CompiledFunc::from_u32(0),
             ),
             Instruction::register3(0, 1, 2),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_reg3(3, 4, 5),
         ])
         .run();
 }
@@ -231,16 +223,14 @@ fn three_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(3),
-        )])
+        .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(3)),
                 CompiledFunc::from_u32(0),
             ),
             Instruction::register3(2, 1, 0),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_reg3(3, 4, 5),
         ])
         .run();
 }
@@ -263,9 +253,7 @@ fn three_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(3),
-        )])
+        .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_internal(
@@ -273,7 +261,7 @@ fn three_params_imm() {
                     CompiledFunc::from_u32(0),
                 ),
                 Instruction::register3(-1, -2, -3),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+                Instruction::return_reg3(0, 1, 2),
             ])
             .consts([10_i32, 20, 30]),
         )

--- a/crates/wasmi/src/engine/regmach/tests/op/call/internal.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/internal.rs
@@ -48,7 +48,7 @@ fn one_param_reg() {
                 RegisterSpan::new(Register::from_i16(1)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
+            Instruction::register(0),
             Instruction::return_reg(Register::from_i16(1)),
         ])
         .run();
@@ -70,16 +70,18 @@ fn one_param_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::call_internal(
-                RegisterSpan::new(Register::from_i16(0)),
-                CompiledFunc::from_u32(0),
-            ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
-            Instruction::return_reg(Register::from_i16(0)),
-        ])
+        .expect_func_instrs([Instruction::return_reg(0)])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_internal(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    CompiledFunc::from_u32(0),
+                ),
+                Instruction::register(-1),
+                Instruction::return_reg(0),
+            ])
+            .consts([10_i32]),
+        )
         .run();
 }
 
@@ -108,7 +110,7 @@ fn two_params_reg() {
                 RegisterSpan::new(Register::from_i16(2)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
+            Instruction::register2(0, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
@@ -135,13 +137,11 @@ fn two_params_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(2), Register::from(1)),
-            Instruction::copy(Register::from_i16(3), Register::from(0)),
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(2)).iter(2), 2),
+            Instruction::register2(1, 0),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
@@ -167,16 +167,17 @@ fn two_params_imm() {
         .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::call_internal(
-                RegisterSpan::new(Register::from_i16(0)),
-                CompiledFunc::from_u32(0),
-            ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_internal(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    CompiledFunc::from_u32(0),
+                ),
+                Instruction::register2(-1, -2),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            ])
+            .consts([10_i32, 20]),
+        )
         .run();
 }
 
@@ -206,7 +207,7 @@ fn three_params_reg() {
                 RegisterSpan::new(Register::from_i16(3)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
+            Instruction::register3(0, 1, 2),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
@@ -234,14 +235,11 @@ fn three_params_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(3), Register::from(2)),
-            Instruction::copy(Register::from_i16(4), Register::from(1)),
-            Instruction::copy(Register::from_i16(5), Register::from(0)),
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(3)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(3)).iter(3), 3),
+            Instruction::register3(2, 1, 0),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
@@ -268,16 +266,457 @@ fn three_params_imm() {
         .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_internal(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    CompiledFunc::from_u32(0),
+                ),
+                Instruction::register3(-1, -2, -3),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+            ])
+            .consts([10_i32, 20, 30]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(7),
+        )])
         .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
             Instruction::call_internal(
-                RegisterSpan::new(Register::from_i16(0)),
+                RegisterSpan::new(Register::from_i16(7)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register(6),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(7)).iter(7)),
         ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(7),
+        )])
+        .expect_func_instrs([
+            Instruction::call_internal(
+                RegisterSpan::new(Register::from_i16(7)),
+                CompiledFunc::from_u32(0),
+            ),
+            Instruction::register_list(6, 5, 4),
+            Instruction::register_list(3, 2, 1),
+            Instruction::register(0),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(7)).iter(7)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+            )
+            (func (result i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(7),
+        )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_internal(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    CompiledFunc::from_u32(0),
+                ),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register(-7),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(7)),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                    (local.get 7)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(8),
+        )])
+        .expect_func_instrs([
+            Instruction::call_internal(
+                RegisterSpan::new(Register::from_i16(8)),
+                CompiledFunc::from_u32(0),
+            ),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register2(6, 7),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(8)).iter(8)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 7)
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(8),
+        )])
+        .expect_func_instrs([
+            Instruction::call_internal(
+                RegisterSpan::new(Register::from_i16(8)),
+                CompiledFunc::from_u32(0),
+            ),
+            Instruction::register_list(7, 6, 5),
+            Instruction::register_list(4, 3, 2),
+            Instruction::register2(1, 0),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(8)).iter(8)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+            )
+            (func (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                    (i32.const 80)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(8),
+        )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_internal(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    CompiledFunc::from_u32(0),
+                ),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register2(-7, -8),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(8)),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70, 80]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                    (local.get 7)
+                    (local.get 8)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(9),
+        )])
+        .expect_func_instrs([
+            Instruction::call_internal(
+                RegisterSpan::new(Register::from_i16(9)),
+                CompiledFunc::from_u32(0),
+            ),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register3(6, 7, 8),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(9)).iter(9)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (local.get 8)
+                    (local.get 7)
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(9),
+        )])
+        .expect_func_instrs([
+            Instruction::call_internal(
+                RegisterSpan::new(Register::from_i16(9)),
+                CompiledFunc::from_u32(0),
+            ),
+            Instruction::register_list(8, 7, 6),
+            Instruction::register_list(5, 4, 3),
+            Instruction::register3(2, 1, 0),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(9)).iter(9)),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+            )
+            (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                    (i32.const 80)
+                    (i32.const 90)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(9),
+        )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::call_internal(
+                    RegisterSpan::new(Register::from_i16(0)),
+                    CompiledFunc::from_u32(0),
+                ),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register3(-7, -8, -9),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(9)),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70, 80, 90]),
+        )
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/call/internal.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/call/internal.rs
@@ -100,7 +100,7 @@ fn two_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
@@ -109,7 +109,7 @@ fn two_params_reg() {
                 CompiledFunc::from_u32(0),
             ),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
 }
@@ -131,7 +131,7 @@ fn two_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
@@ -142,7 +142,7 @@ fn two_params_reg_rev() {
                 CompiledFunc::from_u32(0),
             ),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(2)).iter(2), 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(2)),
         ])
         .run();
 }
@@ -164,7 +164,7 @@ fn two_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
@@ -175,7 +175,7 @@ fn two_params_imm() {
                 CompiledFunc::from_u32(0),
             ),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .run();
 }
@@ -198,7 +198,7 @@ fn three_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
@@ -207,7 +207,7 @@ fn three_params_reg() {
                 CompiledFunc::from_u32(0),
             ),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
 }
@@ -230,7 +230,7 @@ fn three_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
@@ -242,7 +242,7 @@ fn three_params_reg_rev() {
                 CompiledFunc::from_u32(0),
             ),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(3)).iter(3), 3),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(3)).iter(3)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(3)).iter(3)),
         ])
         .run();
 }
@@ -265,7 +265,7 @@ fn three_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
@@ -277,7 +277,7 @@ fn three_params_imm() {
                 CompiledFunc::from_u32(0),
             ),
             Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(3)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(3)),
         ])
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/global_get.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/global_get.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::engine::{bytecode::GlobalIdx, regmach::bytecode::RegisterSpan};
+use crate::engine::bytecode::GlobalIdx;
 use core::fmt::Display;
 use wasm_type::WasmType;
 
@@ -190,12 +190,13 @@ fn test_global_get_as_return_values_0() {
         "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
-            Instruction::copy_imm32(Register::from_i16(0), 2_i32),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+                Instruction::return_reg2(-1, 0),
+            ])
+            .consts([2_i32]),
+        )
         .run()
 }
 
@@ -216,11 +217,12 @@ fn test_global_get_as_return_values_1() {
         "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
-            Instruction::copy_imm32(Register::from_i16(0), 2_i32),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+                Instruction::return_reg2(-1, 0),
+            ])
+            .consts([2_i32]),
+        )
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/global_get.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/global_get.rs
@@ -194,7 +194,7 @@ fn test_global_get_as_return_values_0() {
             Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
             Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
             Instruction::copy_imm32(Register::from_i16(0), 2_i32),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .run()
 }
@@ -220,7 +220,7 @@ fn test_global_get_as_return_values_1() {
             Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
             Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
             Instruction::copy_imm32(Register::from_i16(0), 2_i32),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/if_.rs
@@ -563,7 +563,7 @@ fn test_if_without_else_has_result() {
         .expect_func_instrs([
             Instruction::copy_i64imm32(Register::from_i16(0), 1),
             Instruction::copy_imm32(Register::from_i16(1), 0),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(0)).iter(2)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
         ])
         .expect_func_instrs([
             Instruction::call_internal_0(

--- a/crates/wasmi/src/engine/regmach/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/if_.rs
@@ -4,7 +4,7 @@ use crate::engine::{
     regmach::bytecode::RegisterSpan,
     CompiledFunc,
 };
-use wasmi_core::TrapCode;
+use wasmi_core::{TrapCode, UntypedValue};
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -560,11 +560,10 @@ fn test_if_without_else_has_result() {
         "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_i64imm32(Register::from_i16(0), 1),
-            Instruction::copy_imm32(Register::from_i16(1), 0),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter(2)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([Instruction::return_reg2(-1, -2)])
+                .consts([UntypedValue::from(1_i64), UntypedValue::from(0_i32)]),
+        )
         .expect_func_instrs([
             Instruction::call_internal_0(
                 RegisterSpan::new(Register::from_i16(0)),

--- a/crates/wasmi/src/engine/regmach/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/local_set.rs
@@ -95,7 +95,7 @@ fn overwrite_call_internal_result_1() {
                 RegisterSpan::new(Register::from_i16(0)),
                 CompiledFunc::from_u32(0),
             ),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
+            Instruction::register(0),
             Instruction::return_reg(Register::from_i16(0)),
         ])
         .run()
@@ -118,7 +118,7 @@ fn overwrite_call_imported_result_1() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegisterSpan::new(Register::from_i16(0)), FuncIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
+            Instruction::register(0),
             Instruction::return_reg(Register::from_i16(0)),
         ])
         .run()

--- a/crates/wasmi/src/engine/regmach/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/local_set.rs
@@ -146,7 +146,7 @@ fn overwrite_call_indirect_result_1() {
                 SignatureIdx::from(0),
             ),
             Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
+            Instruction::register(1),
             Instruction::return_reg(Register::from_i16(0)),
         ])
         .run()

--- a/crates/wasmi/src/engine/regmach/tests/op/loop_.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/loop_.rs
@@ -87,11 +87,7 @@ fn identity_loop_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_span(
-                RegisterSpan::new(Register::from_i16(2)),
-                RegisterSpan::new(Register::from_i16(0)),
-                2,
-            ),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 0, 1),
             Instruction::i32_add(
                 Register::from_i16(2),
                 Register::from_i16(2),
@@ -120,11 +116,7 @@ fn identity_loop_2_nested() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_span(
-                RegisterSpan::new(Register::from_i16(2)),
-                RegisterSpan::new(Register::from_i16(0)),
-                2,
-            ),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 0, 1),
             Instruction::i32_add(
                 Register::from_i16(2),
                 Register::from_i16(2),
@@ -212,13 +204,14 @@ fn identity_loop_4_mixed_1() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(2), 10),
-            Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(1)),
-            Instruction::copy_imm32(Register::from_i16(5), 20),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::copy_many(RegisterSpan::new(Register::from_i16(2)), -1, 0),
+                Instruction::register2(1, -2),
+                Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
+            ])
+            .consts([10_i32, 20]),
+        )
         .run()
 }
 
@@ -239,10 +232,8 @@ fn identity_loop_4_mixed_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(1)),
-            Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
+            Instruction::copy_many(RegisterSpan::new(Register::from_i16(2)), 0, 0),
+            Instruction::register2(1, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
         ])
         .run()

--- a/crates/wasmi/src/engine/regmach/tests/op/loop_.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/loop_.rs
@@ -217,7 +217,7 @@ fn identity_loop_4_mixed_1() {
             Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
             Instruction::copy(Register::from_i16(4), Register::from_i16(1)),
             Instruction::copy_imm32(Register::from_i16(5), 20),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(4)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
         ])
         .run()
 }
@@ -243,7 +243,7 @@ fn identity_loop_4_mixed_2() {
             Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
             Instruction::copy(Register::from_i16(4), Register::from_i16(1)),
             Instruction::copy(Register::from_i16(5), Register::from_i16(1)),
-            Instruction::return_many(RegisterSpan::new(Register::from_i16(2)).iter(4)),
+            Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/loop_.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/loop_.rs
@@ -206,7 +206,11 @@ fn identity_loop_4_mixed_1() {
     TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::copy_many(RegisterSpan::new(Register::from_i16(2)), -1, 0),
+                Instruction::copy_many_non_overlapping(
+                    RegisterSpan::new(Register::from_i16(2)),
+                    -1,
+                    0,
+                ),
                 Instruction::register2(1, -2),
                 Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
             ])
@@ -232,7 +236,7 @@ fn identity_loop_4_mixed_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_many(RegisterSpan::new(Register::from_i16(2)), 0, 0),
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(2)), 0, 0),
             Instruction::register2(1, 1),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(2)).iter(4)),
         ])

--- a/crates/wasmi/src/engine/regmach/tests/op/return_call/indirect.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/return_call/indirect.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::engine::{
-    bytecode::{GlobalIdx, SignatureIdx, TableIdx},
-    RegisterSpan,
-};
+use crate::engine::bytecode::{GlobalIdx, SignatureIdx, TableIdx};
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -77,7 +74,7 @@ fn one_reg_param_reg() {
         .expect_func_instrs([
             Instruction::return_call_indirect(SignatureIdx::from(0)),
             Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
+            Instruction::register(1),
         ])
         .run();
 }
@@ -103,7 +100,7 @@ fn one_reg_param_imm16() {
             .expect_func_instrs([
                 Instruction::return_call_indirect(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
-                Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
+                Instruction::register(1),
             ])
             .run();
     }
@@ -112,6 +109,40 @@ fn one_reg_param_imm16() {
     test_with(1);
     test_with(u32::from(u16::MAX) - 1);
     test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn one_reg_param_imm() {
+    fn test_with(index: u32) {
+        let wasm = wat2wasm(&format!(
+            r#"
+            (module
+                (import "" "table" (table $table 10 funcref))
+                (type $type (func (param i32) (result i32)))
+                (func (param $index i32) (param i32) (result i32)
+                    (local.get 1)
+                    (i32.const {index})
+                    (return_call_indirect (type $type))
+                )
+            )
+        "#,
+        ));
+        TranslationTest::new(wasm)
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::call_indirect_params(Register::from_i16(-1), TableIdx::from(0)),
+                    Instruction::register(1),
+                ])
+                .consts([index]),
+            )
+            .run();
+    }
+
+    test_with(u32::from(u16::MAX) + 1);
+    test_with(u32::MAX - 1);
+    test_with(u32::MAX);
 }
 
 #[test]
@@ -131,12 +162,14 @@ fn one_imm_param_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(1), 10),
-            Instruction::return_call_indirect(SignatureIdx::from(0)),
-            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register(-1),
+            ])
+            .consts([10_i32]),
+        )
         .run();
 }
 
@@ -158,12 +191,14 @@ fn one_imm_param_imm16() {
         "#,
         ));
         TranslationTest::new(wasm)
-            .expect_func_instrs([
-                Instruction::copy_imm32(Register::from_i16(1), 10),
-                Instruction::return_call_indirect(SignatureIdx::from(0)),
-                Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
-                Instruction::call_params(RegisterSpan::new(Register::from_i16(1)).iter(1), 1),
-            ])
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
+                    Instruction::register(-1),
+                ])
+                .consts([10_i32]),
+            )
             .run();
     }
 
@@ -171,6 +206,40 @@ fn one_imm_param_imm16() {
     test_with(1);
     test_with(u32::from(u16::MAX) - 1);
     test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn one_imm_param_imm() {
+    fn test_with(index: u32) {
+        let wasm = wat2wasm(&format!(
+            r#"
+            (module
+                (import "" "table" (table $table 10 funcref))
+                (type $type (func (param i32) (result i32)))
+                (func (param $index i32) (result i32)
+                    (i32.const 10)
+                    (i32.const {index})
+                    (return_call_indirect (type $type))
+                )
+            )
+        "#,
+        ));
+        TranslationTest::new(wasm)
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::call_indirect_params(Register::from_i16(-1), TableIdx::from(0)),
+                    Instruction::register(-2),
+                ])
+                .consts([index as i32, 10]),
+            )
+            .run();
+    }
+
+    test_with(u32::from(u16::MAX) + 1);
+    test_with(u32::MAX - 1);
+    test_with(u32::MAX);
 }
 
 #[test]
@@ -190,13 +259,12 @@ fn two_reg_params_reg() {
         )
     "#,
     );
-    let params = RegisterSpan::new(Register::from_i16(1)).iter(2);
     let elem_index = Register::from_i16(0);
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
-            Instruction::call_params(params, 2),
+            Instruction::register2(1, 2),
         ])
         .run();
 }
@@ -218,15 +286,12 @@ fn two_reg_params_reg_rev() {
         )
     "#,
     );
-    let params = RegisterSpan::new(Register::from_i16(3)).iter(2);
     let elem_index = Register::from_i16(0);
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(3), Register::from_i16(2)),
-            Instruction::copy(Register::from_i16(4), Register::from_i16(1)),
             Instruction::return_call_indirect(SignatureIdx::from(0)),
             Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
-            Instruction::call_params(params, 2),
+            Instruction::register2(2, 1),
         ])
         .run();
 }
@@ -248,16 +313,16 @@ fn two_imm_params_reg() {
         )
     "#,
     );
-    let params = RegisterSpan::new(Register::from_i16(1)).iter(2);
     let elem_index = Register::from_i16(0);
     TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(1), 10),
-            Instruction::copy_imm32(Register::from_i16(2), 20),
-            Instruction::return_call_indirect(SignatureIdx::from(0)),
-            Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
-            Instruction::call_params(params, 2),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+                Instruction::register2(-1, -2),
+            ])
+            .consts([10_i32, 20_i32]),
+        )
         .run();
 }
 
@@ -279,13 +344,12 @@ fn two_reg_params_imm16() {
             )
         "#,
         ));
-        let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
         let elem_index = u32imm16(index);
         TranslationTest::new(wasm)
             .expect_func_instrs([
                 Instruction::return_call_indirect(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
-                Instruction::call_params(params, 2),
+                Instruction::register2(0, 1),
             ])
             .run();
     }
@@ -314,15 +378,12 @@ fn two_reg_params_rev_imm16() {
             )
         "#,
         ));
-        let params = RegisterSpan::new(Register::from_i16(2)).iter(2);
         let elem_index = u32imm16(index);
         TranslationTest::new(wasm)
             .expect_func_instrs([
-                Instruction::copy(Register::from_i16(2), Register::from_i16(1)),
-                Instruction::copy(Register::from_i16(3), Register::from_i16(0)),
                 Instruction::return_call_indirect(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
-                Instruction::call_params(params, 2),
+                Instruction::register2(1, 0),
             ])
             .run();
     }
@@ -351,16 +412,16 @@ fn two_imm_params_imm16() {
             )
         "#,
         ));
-        let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
         let elem_index = u32imm16(index);
         TranslationTest::new(wasm)
-            .expect_func_instrs([
-                Instruction::copy_imm32(Register::from_i16(0), 10),
-                Instruction::copy_imm32(Register::from_i16(1), 20),
-                Instruction::return_call_indirect(SignatureIdx::from(0)),
-                Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
-                Instruction::call_params(params, 2),
-            ])
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
+                    Instruction::register2(-1, -2),
+                ])
+                .consts([10_i32, 20_i32]),
+            )
             .run();
     }
 
@@ -368,6 +429,344 @@ fn two_imm_params_imm16() {
     test_with(1);
     test_with(u32::from(u16::MAX) - 1);
     test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_reg_params_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32) (result i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    let elem_index = Register::from_i16(0);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_call_indirect(SignatureIdx::from(0)),
+            Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+            Instruction::register3(1, 2, 3),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_reg_params_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32) (result i32 i32 i32)
+                (local.get 3)
+                (local.get 2)
+                (local.get 1)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    let elem_index = Register::from_i16(0);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_call_indirect(SignatureIdx::from(0)),
+            Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+            Instruction::register3(3, 2, 1),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_imm_params_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    let elem_index = Register::from_i16(0);
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(elem_index, TableIdx::from(0)),
+                Instruction::register3(-1, -2, -3),
+            ])
+            .consts([10_i32, 20, 30]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn three_imm_params_imm16() {
+    fn test_with(index: u32) {
+        let wasm = wat2wasm(&format!(
+            r#"
+            (module
+                (import "" "table" (table $table 10 funcref))
+                (type $type (func (param i32 i32 i32) (result i32 i32 i32)))
+                (func (result i32 i32 i32)
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const {index})
+                    (return_call_indirect (type $type))
+                )
+            )
+        "#,
+        ));
+        let elem_index = u32imm16(index);
+        TranslationTest::new(wasm)
+            .expect_func(
+                ExpectedFunc::new([
+                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
+                    Instruction::register3(-1, -2, -3),
+                ])
+                .consts([10_i32, 20, 30]),
+            )
+            .run();
+    }
+
+    test_with(0);
+    test_with(1);
+    test_with(u32::from(u16::MAX) - 1);
+    test_with(u32::from(u16::MAX));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_call_indirect(SignatureIdx::from(0)),
+            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::register_list(1, 2, 3),
+            Instruction::register_list(4, 5, 6),
+            Instruction::register(7),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_imm_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (i32.const 40)
+                (i32.const 50)
+                (i32.const 60)
+                (i32.const 70)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register(-7),
+            ])
+            .consts([10_i32, 20, 30, 40, 50, 60, 70]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_call_indirect(SignatureIdx::from(0)),
+            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::register_list(1, 2, 3),
+            Instruction::register_list(4, 5, 6),
+            Instruction::register2(7, 8),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_imm_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (i32.const 40)
+                (i32.const 50)
+                (i32.const 60)
+                (i32.const 70)
+                (i32.const 80)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register2(-7, -8),
+            ])
+            .consts([10_i32, 20, 30, 40, 50, 60, 70, 80]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+                (local.get 9)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::return_call_indirect(SignatureIdx::from(0)),
+            Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+            Instruction::register_list(1, 2, 3),
+            Instruction::register_list(4, 5, 6),
+            Instruction::register3(7, 8, 9),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_imm_index_local() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (import "" "table" (table $table 10 funcref))
+            (type $type (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+            (func (param $index i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (i32.const 10)
+                (i32.const 20)
+                (i32.const 30)
+                (i32.const 40)
+                (i32.const 50)
+                (i32.const 60)
+                (i32.const 70)
+                (i32.const 80)
+                (i32.const 90)
+                (local.get $index)
+                (return_call_indirect (type $type))
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register3(-7, -8, -9),
+            ])
+            .consts([10_i32, 20, 30, 40, 50, 60, 70, 80, 90]),
+        )
+        .run();
 }
 
 #[test]
@@ -391,24 +790,23 @@ fn test_imm_params_dynamic_index() {
         )
         "#,
     );
-    let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
-        .expect_func_instrs([
-            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
-            Instruction::copy_imm32(Register::from_i16(0), 10),
-            Instruction::copy_imm32(Register::from_i16(1), 20),
-            Instruction::return_call_indirect(SignatureIdx::from(0)),
-            Instruction::call_indirect_params(Register::from_i16(2), TableIdx::from(0)),
-            Instruction::call_params(params, 1),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(0), TableIdx::from(0)),
+                Instruction::register2(-1, -2),
+            ])
+            .consts([10_i32, 20_i32]),
+        )
         .run();
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn regression_issue768() {
+fn regression_issue_768() {
     let wasm = wat2wasm(
         r#"
         (module
@@ -428,20 +826,17 @@ fn regression_issue768() {
         )
         "#,
     );
-    let params = RegisterSpan::new(Register::from_i16(0)).iter(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
-        .expect_func_instrs([
-            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
-            Instruction::global_get(Register::from_i16(1), GlobalIdx::from(1)),
-            // copy parameters and index
-            Instruction::copy(Register::from_i16(2), Register::from_i16(1)),
-            // Instruction::copy(Register::from_i16(0), Register::from_i16(0)), // elided
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            // indirect call
-            Instruction::return_call_indirect(SignatureIdx::from(0)),
-            Instruction::call_indirect_params(Register::from_i16(2), TableIdx::from(0)),
-            Instruction::call_params(params, 1),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+                Instruction::global_get(Register::from_i16(1), GlobalIdx::from(1)),
+                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::call_indirect_params(Register::from_i16(1), TableIdx::from(0)),
+                Instruction::register2(0, -1),
+            ])
+            .consts([20_i32]),
+        )
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/return_call/internal.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/return_call/internal.rs
@@ -41,7 +41,7 @@ fn one_param_reg() {
         .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
+            Instruction::register(0),
         ])
         .run();
 }
@@ -62,12 +62,14 @@ fn one_param_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(1), 1),
-        ])
+        .expect_func_instrs([Instruction::return_reg(0)])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::register(-1),
+            ])
+            .consts([10_i32]),
+        )
         .run();
 }
 
@@ -93,7 +95,7 @@ fn two_params_reg() {
         )])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
+            Instruction::register2(0, 1),
         ])
         .run();
 }
@@ -119,10 +121,8 @@ fn two_params_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(2), Register::from(1)),
-            Instruction::copy(Register::from_i16(3), Register::from(0)),
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(2)).iter(2), 2),
+            Instruction::register2(1, 0),
         ])
         .run();
 }
@@ -147,12 +147,13 @@ fn two_params_imm() {
         .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
-        .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(2), 2),
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::register2(-1, -2),
+            ])
+            .consts([10_i32, 20]),
+        )
         .run();
 }
 
@@ -179,7 +180,7 @@ fn three_params_reg() {
         )])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
+            Instruction::register3(0, 1, 2),
         ])
         .run();
 }
@@ -206,11 +207,8 @@ fn three_params_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(3), Register::from(2)),
-            Instruction::copy(Register::from_i16(4), Register::from(1)),
-            Instruction::copy(Register::from_i16(5), Register::from(0)),
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(3)).iter(3), 3),
+            Instruction::register3(2, 1, 0),
         ])
         .run();
 }
@@ -236,12 +234,417 @@ fn three_params_imm() {
         .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::register3(-1, -2, -3),
+            ])
+            .consts([10_i32, 20, 30]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(7),
+        )])
         .expect_func_instrs([
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
-            Instruction::call_params(RegisterSpan::new(Register::from_i16(0)).iter(3), 3),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register(6),
         ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(7),
+        )])
+        .expect_func_instrs([
+            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::register_list(6, 5, 4),
+            Instruction::register_list(3, 2, 1),
+            Instruction::register(0),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params7_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+            )
+            (func (result i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(7),
+        )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register(-7),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                    (local.get 7)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(8),
+        )])
+        .expect_func_instrs([
+            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register2(6, 7),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (local.get 7)
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(8),
+        )])
+        .expect_func_instrs([
+            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::register_list(7, 6, 5),
+            Instruction::register_list(4, 3, 2),
+            Instruction::register2(1, 0),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params8_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+            )
+            (func (result i32 i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                    (i32.const 80)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(8),
+        )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register2(-7, -8),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70, 80]),
+        )
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (local.get 0)
+                    (local.get 1)
+                    (local.get 2)
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 5)
+                    (local.get 6)
+                    (local.get 7)
+                    (local.get 8)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(9),
+        )])
+        .expect_func_instrs([
+            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::register_list(0, 1, 2),
+            Instruction::register_list(3, 4, 5),
+            Instruction::register3(6, 7, 8),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_reg_rev() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+            )
+            (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (local.get 8)
+                    (local.get 7)
+                    (local.get 6)
+                    (local.get 5)
+                    (local.get 4)
+                    (local.get 3)
+                    (local.get 2)
+                    (local.get 1)
+                    (local.get 0)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(9),
+        )])
+        .expect_func_instrs([
+            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::register_list(8, 7, 6),
+            Instruction::register_list(5, 4, 3),
+            Instruction::register3(2, 1, 0),
+        ])
+        .run();
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn params9_imm() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func $f (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (local.get 0)
+                (local.get 1)
+                (local.get 2)
+                (local.get 3)
+                (local.get 4)
+                (local.get 5)
+                (local.get 6)
+                (local.get 7)
+                (local.get 8)
+            )
+            (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                (return_call $f
+                    (i32.const 10)
+                    (i32.const 20)
+                    (i32.const 30)
+                    (i32.const 40)
+                    (i32.const 50)
+                    (i32.const 60)
+                    (i32.const 70)
+                    (i32.const 80)
+                    (i32.const 90)
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([Instruction::return_span(
+            RegisterSpan::new(Register::from_i16(0)).iter(9),
+        )])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::register_list(-1, -2, -3),
+                Instruction::register_list(-4, -5, -6),
+                Instruction::register3(-7, -8, -9),
+            ])
+            .consts([10, 20, 30, 40, 50, 60, 70, 80, 90]),
+        )
         .run();
 }

--- a/crates/wasmi/src/engine/regmach/tests/op/return_call/internal.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/return_call/internal.rs
@@ -90,9 +90,7 @@ fn two_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(2),
-        )])
+        .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
             Instruction::register2(0, 1),
@@ -117,9 +115,7 @@ fn two_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(2),
-        )])
+        .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
             Instruction::register2(1, 0),
@@ -144,9 +140,7 @@ fn two_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(2),
-        )])
+        .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_internal(CompiledFunc::from_u32(0)),
@@ -175,9 +169,7 @@ fn three_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(3),
-        )])
+        .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
             Instruction::register3(0, 1, 2),
@@ -203,9 +195,7 @@ fn three_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(3),
-        )])
+        .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func_instrs([
             Instruction::return_call_internal(CompiledFunc::from_u32(0)),
             Instruction::register3(2, 1, 0),
@@ -231,9 +221,7 @@ fn three_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_span(
-            RegisterSpan::new(Register::from_i16(0)).iter(3),
-        )])
+        .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_internal(CompiledFunc::from_u32(0)),

--- a/crates/wasmi/src/engine/regmach/tests/op/return_call/internal.rs
+++ b/crates/wasmi/src/engine/regmach/tests/op/return_call/internal.rs
@@ -88,7 +88,7 @@ fn two_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
@@ -115,7 +115,7 @@ fn two_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
@@ -144,7 +144,7 @@ fn two_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(2),
         )])
         .expect_func_instrs([
@@ -174,7 +174,7 @@ fn three_params_reg() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
@@ -202,7 +202,7 @@ fn three_params_reg_rev() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([
@@ -233,7 +233,7 @@ fn three_params_imm() {
     "#,
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_many(
+        .expect_func_instrs([Instruction::return_span(
             RegisterSpan::new(Register::from_i16(0)).iter(3),
         )])
         .expect_func_instrs([

--- a/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
@@ -493,7 +493,7 @@ impl InstrEncoder {
             }
             _ => {
                 let values = self.encode_call_params(stack, values)?;
-                Instruction::return_many(values)
+                Instruction::return_span(values)
             }
         };
         self.push_instr(instr)?;

--- a/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
@@ -670,7 +670,7 @@ mod tests {
     use crate::engine::regmach::{bytecode::RegisterSpan, translator::typed_value::TypedValue};
 
     #[test]
-    fn is_overlapping_works() {
+    fn has_overlapping_copies_works() {
         assert!(!InstrEncoder::has_overlapping_copies(
             RegisterSpan::new(Register::from_i16(0)).iter(0),
             &[],

--- a/crates/wasmi/src/engine/regmach/translator/mod.rs
+++ b/crates/wasmi/src/engine/regmach/translator/mod.rs
@@ -53,7 +53,7 @@ use crate::{
     FuncType,
 };
 use alloc::vec::Vec;
-use wasmi_core::{TrapCode, UntypedValue, ValueType, F32};
+use wasmi_core::{TrapCode, UntypedValue, ValueType};
 use wasmparser::MemArg;
 
 /// Reusable allocations of a [`FuncTranslator`].
@@ -2062,67 +2062,11 @@ impl<'parser> FuncTranslator<'parser> {
     /// Translates a conditional `br_if` that targets the function enclosing `block`.
     pub fn translate_return_if(&mut self, condition: Register) -> Result<(), TranslationError> {
         bail_unreachable!(self);
-        let instr = match self.func_type().results() {
-            [] => {
-                // Case: Function returns nothing therefore all return statements must return nothing.
-                Instruction::return_nez(condition)
-            }
-            [ValueType::I32] => match self.alloc.stack.peek() {
-                // Case: Function returns a single `i32` value which allows for special operator.
-                TypedProvider::Register(value) => Instruction::return_nez_reg(condition, value),
-                TypedProvider::Const(value) => {
-                    Instruction::return_nez_imm32(condition, i32::from(value))
-                }
-            },
-            [ValueType::I64] => match self.alloc.stack.peek() {
-                // Case: Function returns a single `i64` value which allows for special operator.
-                TypedProvider::Register(value) => Instruction::return_nez_reg(condition, value),
-                TypedProvider::Const(value) => {
-                    if let Some(value) = <Const32<i64>>::from_i64(i64::from(value)) {
-                        Instruction::return_nez_i64imm32(condition, value)
-                    } else {
-                        Instruction::return_nez_reg(condition, self.alloc.stack.alloc_const(value)?)
-                    }
-                }
-            },
-            [ValueType::F32] => match self.alloc.stack.peek() {
-                // Case: Function returns a single `f32` value which allows for special operator.
-                TypedProvider::Register(value) => Instruction::return_nez_reg(condition, value),
-                TypedProvider::Const(value) => {
-                    Instruction::return_nez_imm32(condition, F32::from(value))
-                }
-            },
-            [ValueType::F64] => match self.alloc.stack.peek() {
-                // Case: Function returns a single `f64` value which allows for special operator.
-                TypedProvider::Register(value) => Instruction::return_nez_reg(condition, value),
-                TypedProvider::Const(value) => {
-                    if let Some(value) = <Const32<f64>>::from_f64(f64::from(value)) {
-                        Instruction::return_nez_f64imm32(condition, value)
-                    } else {
-                        Instruction::return_nez_reg(condition, self.alloc.stack.alloc_const(value)?)
-                    }
-                }
-            },
-            [ValueType::FuncRef | ValueType::ExternRef] => {
-                // Case: Function returns a single `externref` or `funcref` value which allows for special operator.
-                match self.alloc.stack.peek() {
-                    TypedProvider::Register(value) => Instruction::return_nez_reg(condition, value),
-                    TypedProvider::Const(value) => {
-                        Instruction::return_nez_reg(condition, self.alloc.stack.alloc_const(value)?)
-                    }
-                }
-            }
-            results => {
-                let providers = &mut self.alloc.buffer;
-                self.alloc.stack.pop_n(results.len(), providers);
-                let values = self
-                    .alloc
-                    .instr_encoder
-                    .encode_conditional_branch_params(&mut self.alloc.stack, providers)?;
-                Instruction::return_nez_span(condition, values)
-            }
-        };
-        self.alloc.instr_encoder.push_instr(instr)?;
-        Ok(())
+        let len_results = self.func_type().results().len();
+        let values = &mut self.alloc.buffer;
+        self.alloc.stack.peek_n(len_results, values);
+        self.alloc
+            .instr_encoder
+            .encode_return_nez(&mut self.alloc.stack, condition, values)
     }
 }

--- a/crates/wasmi/src/engine/regmach/translator/mod.rs
+++ b/crates/wasmi/src/engine/regmach/translator/mod.rs
@@ -2119,7 +2119,7 @@ impl<'parser> FuncTranslator<'parser> {
                     .alloc
                     .instr_encoder
                     .encode_conditional_branch_params(&mut self.alloc.stack, providers)?;
-                Instruction::return_nez_many(condition, values)
+                Instruction::return_nez_span(condition, values)
             }
         };
         self.alloc.instr_encoder.push_instr(instr)?;

--- a/crates/wasmi/src/engine/regmach/translator/mod.rs
+++ b/crates/wasmi/src/engine/regmach/translator/mod.rs
@@ -2054,7 +2054,7 @@ impl<'parser> FuncTranslator<'parser> {
         self.alloc.stack.pop_n(results.len(), values);
         self.alloc
             .instr_encoder
-            .encode_return(&mut self.alloc.stack, results, values)?;
+            .encode_return(&mut self.alloc.stack, values)?;
         self.reachable = false;
         Ok(())
     }

--- a/crates/wasmi/src/engine/regmach/translator/result_mut.rs
+++ b/crates/wasmi/src/engine/regmach/translator/result_mut.rs
@@ -44,20 +44,28 @@ impl Instruction {
             Instruction::I64Const32(_) |
             Instruction::F64Const32(_) |
             Instruction::Register(_) |
+            Instruction::Register2(_) |
+            Instruction::Register3(_) |
+            Instruction::RegisterList(_) |
             Instruction::Trap(_) |
             Instruction::ConsumeFuel(_) |
             Instruction::Return |
             Instruction::ReturnReg { .. } |
+            Instruction::ReturnReg2 { .. } |
+            Instruction::ReturnReg3 { .. } |
             Instruction::ReturnImm32 { .. } |
             Instruction::ReturnI64Imm32 { .. } |
             Instruction::ReturnF64Imm32 { .. } |
             Instruction::ReturnSpan { .. } |
+            Instruction::ReturnMany { .. } |
             Instruction::ReturnNez { .. } |
             Instruction::ReturnNezReg { .. } |
+            Instruction::ReturnNezReg2 { .. } |
             Instruction::ReturnNezImm32 { .. } |
             Instruction::ReturnNezI64Imm32 { .. } |
             Instruction::ReturnNezF64Imm32 { .. } |
             Instruction::ReturnNezSpan { .. } |
+            Instruction::ReturnNezMany { .. } |
             Instruction::Branch { .. } |
             Instruction::BranchEqz { .. } |
             Instruction::BranchNez { .. } |
@@ -66,7 +74,9 @@ impl Instruction {
             Instruction::CopyImm32 { result, .. } |
             Instruction::CopyI64Imm32 { result, .. } |
             Instruction::CopyF64Imm32 { result, .. } => Some(result),
-            Instruction::CopySpan { .. } => None,
+            Instruction::CopySpan { .. } |
+            Instruction::Copy2 { .. } |
+            Instruction::CopyMany { .. } => None,
             Instruction::CallParams(_) |
             Instruction::CallIndirectParams(_) |
             Instruction::CallIndirectParamsImm16(_) |

--- a/crates/wasmi/src/engine/regmach/translator/result_mut.rs
+++ b/crates/wasmi/src/engine/regmach/translator/result_mut.rs
@@ -75,6 +75,7 @@ impl Instruction {
             Instruction::CopyI64Imm32 { result, .. } |
             Instruction::CopyF64Imm32 { result, .. } => Some(result),
             Instruction::CopySpan { .. } |
+            Instruction::CopySpanNonOverlapping { .. } |
             Instruction::Copy2 { .. } |
             Instruction::CopyMany { .. } => None,
             Instruction::CallIndirectParams(_) |

--- a/crates/wasmi/src/engine/regmach/translator/result_mut.rs
+++ b/crates/wasmi/src/engine/regmach/translator/result_mut.rs
@@ -77,7 +77,6 @@ impl Instruction {
             Instruction::CopySpan { .. } |
             Instruction::Copy2 { .. } |
             Instruction::CopyMany { .. } => None,
-            Instruction::CallParams(_) |
             Instruction::CallIndirectParams(_) |
             Instruction::CallIndirectParamsImm16(_) |
             Instruction::ReturnCallInternal0 { .. } |

--- a/crates/wasmi/src/engine/regmach/translator/result_mut.rs
+++ b/crates/wasmi/src/engine/regmach/translator/result_mut.rs
@@ -51,13 +51,13 @@ impl Instruction {
             Instruction::ReturnImm32 { .. } |
             Instruction::ReturnI64Imm32 { .. } |
             Instruction::ReturnF64Imm32 { .. } |
-            Instruction::ReturnMany { .. } |
+            Instruction::ReturnSpan { .. } |
             Instruction::ReturnNez { .. } |
             Instruction::ReturnNezReg { .. } |
             Instruction::ReturnNezImm32 { .. } |
             Instruction::ReturnNezI64Imm32 { .. } |
             Instruction::ReturnNezF64Imm32 { .. } |
-            Instruction::ReturnNezMany { .. } |
+            Instruction::ReturnNezSpan { .. } |
             Instruction::Branch { .. } |
             Instruction::BranchEqz { .. } |
             Instruction::BranchNez { .. } |

--- a/crates/wasmi/src/engine/regmach/translator/result_mut.rs
+++ b/crates/wasmi/src/engine/regmach/translator/result_mut.rs
@@ -78,6 +78,7 @@ impl Instruction {
             Instruction::CopySpanNonOverlapping { .. } |
             Instruction::Copy2 { .. } |
             Instruction::CopyMany { .. } => None,
+            Instruction::CopyManyNonOverlapping { .. } => None,
             Instruction::CallIndirectParams(_) |
             Instruction::CallIndirectParamsImm16(_) |
             Instruction::ReturnCallInternal0 { .. } |

--- a/crates/wasmi/src/engine/regmach/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/regmach/translator/stack/mod.rs
@@ -38,6 +38,11 @@ impl TypedProvider {
             Self::Const(value) => UntypedProvider::Const(UntypedValue::from(value)),
         }
     }
+
+    /// Creates a new [`TypedProvider::Register`].
+    pub fn register(register: impl Into<Register>) -> Self {
+        Self::Register(register.into())
+    }
 }
 
 impl From<TaggedProvider> for TypedProvider {

--- a/crates/wasmi/src/engine/regmach/translator/visit.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit.rs
@@ -554,7 +554,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
             let return_instr = match default_branch_params.len() {
                 0 => Instruction::Return,
                 1 => Instruction::return_reg(default_branch_params.span().head()),
-                _ => Instruction::return_many(default_branch_params),
+                _ => Instruction::return_span(default_branch_params),
             };
             for target in self.alloc.br_table_targets.iter().copied() {
                 match self.alloc.control_stack.acquire_target(target) {

--- a/crates/wasmi/src/engine/regmach/translator/visit.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit.rs
@@ -600,16 +600,10 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         for (depth, label) in shared_targets {
             self.alloc.instr_encoder.pin_label(label);
             match self.alloc.control_stack.acquire_target(depth) {
-                AcquiredTarget::Return(frame) => {
-                    frame
-                        .block_type()
-                        .results_with(self.res.engine(), |types| {
-                            self.alloc.instr_encoder.encode_return(
-                                &mut self.alloc.stack,
-                                types,
-                                values,
-                            )
-                        })?;
+                AcquiredTarget::Return(_frame) => {
+                    self.alloc
+                        .instr_encoder
+                        .encode_return(&mut self.alloc.stack, values)?;
                 }
                 AcquiredTarget::Branch(frame) => {
                     frame.bump_branches();

--- a/crates/wasmi/src/engine/regmach/translator/visit.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit.rs
@@ -641,15 +641,8 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         let func_idx = FuncIdx::from(function_index);
         let func_type = self.func_type_of(func_idx);
         let (params, results) = func_type.params_results();
-        let len_results =
-            u16::try_from(func_type.results().len()).expect("too many function return types");
         let provider_params = &mut self.alloc.buffer;
         self.alloc.stack.pop_n(params.len(), provider_params);
-        let params_span = self
-            .alloc
-            .instr_encoder
-            .encode_call_params(&mut self.alloc.stack, provider_params)?;
-        let call_params = Instruction::call_params(params_span, len_results);
         let results = self.alloc.stack.push_dynamic_n(results.len())?;
         let instr = match self.res.get_compiled_func_2(func_idx) {
             Some(compiled_func) => {
@@ -670,9 +663,9 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
             }
         };
         self.alloc.instr_encoder.push_instr(instr)?;
-        if !params.is_empty() {
-            self.alloc.instr_encoder.append_instr(call_params)?;
-        }
+        self.alloc
+            .instr_encoder
+            .encode_register_list(&mut self.alloc.stack, provider_params)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/regmach/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit_register.rs
@@ -100,6 +100,9 @@ impl VisitInputRegisters for Instruction {
             Instruction::CopySpan { results: _, values, len: _ } => {
                 values.visit_input_registers(f);
             }
+            Instruction::CopySpanNonOverlapping { results: _, values, len: _ } => {
+                values.visit_input_registers(f);
+            }
             Instruction::CopyMany { results: _, values } => {
                 values.visit_input_registers(f);
             }

--- a/crates/wasmi/src/engine/regmach/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit_register.rs
@@ -48,7 +48,7 @@ impl VisitInputRegisters for Instruction {
             Instruction::ReturnImm32 { .. } |
             Instruction::ReturnI64Imm32 { .. } |
             Instruction::ReturnF64Imm32 { .. } => {},
-            Instruction::ReturnMany { values } => {
+            Instruction::ReturnSpan { values } => {
                 values.visit_input_registers(f);
             }
             Instruction::ReturnNez { condition } => f(condition),
@@ -56,7 +56,7 @@ impl VisitInputRegisters for Instruction {
             Instruction::ReturnNezImm32 { condition, .. } => f(condition),
             Instruction::ReturnNezI64Imm32 { condition, .. } => f(condition),
             Instruction::ReturnNezF64Imm32 { condition, .. } => f(condition),
-            Instruction::ReturnNezMany { condition, values } => {
+            Instruction::ReturnNezSpan { condition, values } => {
                 f(condition);
                 values.visit_input_registers(f);
             }

--- a/crates/wasmi/src/engine/regmach/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit_register.rs
@@ -103,9 +103,6 @@ impl VisitInputRegisters for Instruction {
             Instruction::CopyMany { results: _, values } => {
                 values.visit_input_registers(f);
             }
-            Instruction::CallParams(call_params) => {
-                call_params.params.visit_input_registers(f);
-            }
             Instruction::CallIndirectParams(params) => f(&mut params.index),
             Instruction::CallIndirectParamsImm16(_) => {},
             Instruction::ReturnCallInternal0 { .. } |

--- a/crates/wasmi/src/engine/regmach/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/regmach/translator/visit_register.rs
@@ -106,6 +106,9 @@ impl VisitInputRegisters for Instruction {
             Instruction::CopyMany { results: _, values } => {
                 values.visit_input_registers(f);
             }
+            Instruction::CopyManyNonOverlapping { results: _, values } => {
+                values.visit_input_registers(f);
+            }
             Instruction::CallIndirectParams(params) => f(&mut params.index),
             Instruction::CallIndirectParamsImm16(_) => {},
             Instruction::ReturnCallInternal0 { .. } |


### PR DESCRIPTION
This adds some instructions or instruction parameters to account for the new planned copy semantics that replace consecutive copy instructions with a single instruction that handles all the necessary copying between registers.
This will fix a bug that cannot be fixed with the current copy semantics that involves unavoidable overlapping copy instructions.

# New Instruction Parameters
- [x] `Register2`: An array of 2 `Register` elements
- [x] `Register3`: An array of 3 `Register` elements
- [x] `RegisterList`: A list of 3 `Register` elements that is followed by more `Register` elements

# New Instructions
- [x] `ReturnReg2`: Return 2 register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnReg3`: Return 3 register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnMany`: Return 4 or more register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnNezReg2`: Conditionally return 2 register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnNezMany`: Conditionally return 3 or more register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `Copy2`: Copy 2 register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `CopyMany`: Copy 3 or more register values
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `CopyManyNonOverlapping`: Non overlapping version of `CopyMany`.
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `CopySpanNonOverlapping`: Non overlapping version of `CopySpan`.
    - [x] Translation
    - [x] Execution
    - [x] Tests

# Adjusted Instructions

- [x] `CallInternal`
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `CallImported`
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `CallIndirect`
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnCallInternal`
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnCallImported`
    - [x] Translation
    - [x] Execution
    - [x] Tests
- [x] `ReturnCallIndirect`
    - [x] Translation
    - [x] Execution
    - [x] Tests

# Removed Instructions
- [x] `CallParams`: No longer needed due to change or call parameter encoding

# TODO

- [x] Adjust parameter copying for host functions called from Wasm.
- [x] Adjust parameter copying for host functions called from the host side. (edge case)