### PR TITLE
Refactor `local.set` register preservation

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -22,6 +22,7 @@ spin = { version = "0.9", default-features = false, features = [
     "rwlock",
 ] }
 smallvec = { version = "1.10.0", features = ["union"] }
+multi-stash = { version = "0.2.0" }
 
 [dev-dependencies]
 wat = "1"

--- a/crates/wasmi/src/engine/regmach/translator/stack/provider.rs
+++ b/crates/wasmi/src/engine/regmach/translator/stack/provider.rs
@@ -63,7 +63,10 @@ impl ProviderStack {
             let provider = &mut self.providers[provider_index];
             debug_assert!(matches!(provider, TaggedProvider::Local(_)));
             let preserved_register = match preserved {
-                Some(register) => register,
+                Some(register) => {
+                    reg_alloc.bump_storage(register);
+                    register
+                }
                 None => {
                     let register = reg_alloc.push_storage()?;
                     preserved = Some(register);


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/766

This fixes a bug in preservation of `local.set` for local variables that have been pushed multiple times onto the stack upon preservation and implements recycling of preservation slots to reduce register pressure.