### PR TITLE
Implement fuel metering for the register-machine `wasmi` engine backend

### DIFF
--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -105,55 +105,89 @@ pub enum FuelConsumptionMode {
 #[derive(Debug, Copy, Clone)]
 pub struct FuelCosts {
     /// The base fuel costs for all instructions.
-    pub base: u64,
-    /// The fuel cost for instruction operating on Wasm entities.
-    ///
-    /// # Note
-    ///
-    /// A Wasm entity is one of `func`, `global`, `memory` or `table`.
-    /// Those instructions are usually a bit more costly since they need
-    /// multiple indirect accesses through the Wasm instance and store.
-    pub entity: u64,
-    /// The fuel cost offset for `memory.load` instructions.
-    pub load: u64,
-    /// The fuel cost offset for `memory.store` instructions.
-    pub store: u64,
-    /// The fuel cost offset for `call` and `call_indirect` instructions.
-    pub call: u64,
-    /// Determines how many moved stack values consume one fuel upon a branch or return instruction.
-    ///
-    /// # Note
-    ///
-    /// If this is zero then processing [`DropKeep`] costs nothing.
-    branch_kept_per_fuel: u64,
-    /// Determines how many function locals consume one fuel per function call.
-    ///
-    /// # Note
-    ///
-    /// - This is also applied to all function parameters since
-    ///   they are translated to local variable slots.
-    /// - If this is zero then processing function locals costs nothing.
-    func_locals_per_fuel: u64,
-    /// How many memory bytes can be processed per fuel in a `bulk-memory` instruction.
-    ///
-    /// # Note
-    ///
-    /// If this is zero then processing memory bytes costs nothing.
-    memory_bytes_per_fuel: u64,
-    /// How many table elements can be processed per fuel in a `bulk-table` instruction.
-    ///
-    /// # Note
-    ///
-    /// If this is zero then processing table elements costs nothing.
-    table_elements_per_fuel: u64,
+    base: u64,
+    /// The register copies that can be performed per unit of fuel.
+    copies_per_fuel: NonZeroU64,
+    /// The bytes that can be copied per unit of fuel.
+    bytes_per_fuel: NonZeroU64,
 }
 
 impl FuelCosts {
+    /// Returns the base fuel costs for all `wasmi` IR instructions.
+    pub fn base(&self) -> u64 {
+        self.base
+    }
+
+    /// Returns the base fuel costs for all `wasmi` IR entity related instructions.
+    pub fn entity(&self) -> u64 {
+        // Note: For simplicity we currently simply use base costs.
+        self.base
+    }
+
+    /// Returns the base fuel costs for all `wasmi` IR load instructions.
+    pub fn load(&self) -> u64 {
+        // Note: For simplicity we currently simply use base costs.
+        self.base
+    }
+
+    /// Returns the base fuel costs for all `wasmi` IR store instructions.
+    pub fn store(&self) -> u64 {
+        // Note: For simplicity we currently simply use base costs.
+        self.base
+    }
+
+    /// Returns the base fuel costs for all `wasmi` IR call instructions.
+    pub fn call(&self) -> u64 {
+        // Note: For simplicity we currently simply use base costs.
+        self.base
+    }
+
+    /// Returns the number of register copies performed per unit of fuel.
+    fn copies_per_fuel(&self) -> NonZeroU64 {
+        self.copies_per_fuel
+    }
+
+    /// Returns the number of byte copies performed per unit of fuel.
+    fn bytes_per_fuel(&self) -> NonZeroU64 {
+        self.bytes_per_fuel
+    }
+
+    /// Returns the fuel costs for `len_copies` register copies in `wasmi` IR.
+    ///
+    /// # Note
+    ///
+    /// Registers are copied for the following `wasmi` IR instructions:
+    ///
+    /// - calls (parameter passing)
+    /// - `copy_span`
+    /// - `copy_many`
+    /// - `return_span`
+    /// - `return_many`
+    /// - `table.grow` (+ variants)
+    /// - `table.copy` (+ variants)
+    /// - `table.fill` (+ variants)
+    /// - `table.init` (+ variants)
+    pub fn fuel_for_copies(&self, len_copies: u64) -> u64 {
+        Self::costs_per(len_copies, self.copies_per_fuel())
+    }
+
+    /// Returns the fuel costs for `len_copies` register copies in `wasmi` IR.
+    ///
+    /// # Note
+    ///
+    /// Registers are copied for the following `wasmi` IR instructions:
+    ///
+    /// - `memory.grow`
+    /// - `memory.copy`
+    /// - `memory.fill`
+    /// - `memory.init`
+    pub fn fuel_for_bytes(&self, len_bytes: u64) -> u64 {
+        Self::costs_per(len_bytes, self.bytes_per_fuel())
+    }
+
     /// Returns the fuel consumption of the amount of items with costs per items.
-    fn costs_per(len_items: u64, items_per_fuel: u64) -> u64 {
-        NonZeroU64::new(items_per_fuel)
-            .map(|items_per_fuel| len_items / items_per_fuel)
-            .unwrap_or(0)
+    fn costs_per(len_items: u64, items_per_fuel: NonZeroU64) -> u64 {
+        len_items / items_per_fuel
     }
 
     /// Returns the fuel consumption for branches and returns using the given [`DropKeep`].
@@ -161,7 +195,7 @@ impl FuelCosts {
         if drop_keep.drop() == 0 {
             return 0;
         }
-        Self::costs_per(u64::from(drop_keep.keep()), self.branch_kept_per_fuel)
+        Self::costs_per(u64::from(drop_keep.keep()), self.copies_per_fuel())
     }
 
     /// Returns the fuel consumption for calling a function with the amount of local variables.
@@ -170,35 +204,26 @@ impl FuelCosts {
     ///
     /// Function parameters are also treated as local variables.
     pub fn fuel_for_locals(&self, locals: u64) -> u64 {
-        Self::costs_per(locals, self.func_locals_per_fuel)
-    }
-
-    /// Returns the fuel consumption for processing the amount of memory bytes.
-    pub fn fuel_for_bytes(&self, bytes: u64) -> u64 {
-        Self::costs_per(bytes, self.memory_bytes_per_fuel)
+        self.fuel_for_copies(locals)
     }
 
     /// Returns the fuel consumption for processing the amount of table elements.
     pub fn fuel_for_elements(&self, elements: u64) -> u64 {
-        Self::costs_per(elements, self.table_elements_per_fuel)
+        self.fuel_for_copies(elements)
     }
 }
 
 impl Default for FuelCosts {
     fn default() -> Self {
-        let memory_bytes_per_fuel = 64;
+        let bytes_per_fuel = 64;
         let bytes_per_register = size_of::<UntypedValue>() as u64;
-        let registers_per_fuel = memory_bytes_per_fuel / bytes_per_register;
+        let registers_per_fuel = bytes_per_fuel / bytes_per_register;
         Self {
             base: 1,
-            entity: 1,
-            load: 1,
-            store: 1,
-            call: 1,
-            func_locals_per_fuel: registers_per_fuel,
-            branch_kept_per_fuel: registers_per_fuel,
-            memory_bytes_per_fuel,
-            table_elements_per_fuel: registers_per_fuel,
+            copies_per_fuel: NonZeroU64::new(registers_per_fuel)
+                .unwrap_or_else(|| panic!("invalid zero value for copies_per_fuel value")),
+            bytes_per_fuel: NonZeroU64::new(bytes_per_fuel)
+                .unwrap_or_else(|| panic!("invalid zero value for copies_per_fuel value")),
         }
     }
 }

--- a/crates/wasmi/src/engine/func_builder/translator.rs
+++ b/crates/wasmi/src/engine/func_builder/translator.rs
@@ -216,7 +216,7 @@ impl<'parser> FuncTranslator<'parser> {
 
     /// Creates an [`Instruction::ConsumeFuel`] with base costs.
     fn make_consume_fuel_base(&self) -> Instruction {
-        Instruction::consume_fuel(self.fuel_costs().base).expect("base fuel costs must be valid")
+        Instruction::consume_fuel(self.fuel_costs().base()).expect("base fuel costs must be valid")
     }
 
     /// Returns the configured [`FuelCosts`] of the [`Engine`].
@@ -497,7 +497,7 @@ impl<'parser> FuncTranslator<'parser> {
         self.translate_if_reachable(|builder| {
             let (memory_idx, offset) = Self::decompose_memarg(memarg);
             debug_assert_eq!(memory_idx.into_u32(), DEFAULT_MEMORY_INDEX);
-            builder.bump_fuel_consumption(builder.fuel_costs().load)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().load())?;
             builder.stack_height.pop1();
             builder.stack_height.push();
             let offset = AddressOffset::from(offset);
@@ -530,7 +530,7 @@ impl<'parser> FuncTranslator<'parser> {
         self.translate_if_reachable(|builder| {
             let (memory_idx, offset) = Self::decompose_memarg(memarg);
             debug_assert_eq!(memory_idx.into_u32(), DEFAULT_MEMORY_INDEX);
-            builder.bump_fuel_consumption(builder.fuel_costs().store)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().store())?;
             builder.stack_height.pop2();
             let offset = AddressOffset::from(offset);
             builder.alloc.inst_builder.push_inst(make_inst(offset));
@@ -552,7 +552,7 @@ impl<'parser> FuncTranslator<'parser> {
         T: Into<UntypedValue>,
     {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             let value = value.into();
             builder.stack_height.push();
             let cref = builder.engine().alloc_const(value)?;
@@ -578,7 +578,7 @@ impl<'parser> FuncTranslator<'parser> {
         inst: Instruction,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.alloc.inst_builder.push_inst(inst);
             Ok(())
         })
@@ -602,7 +602,7 @@ impl<'parser> FuncTranslator<'parser> {
         inst: Instruction,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.pop2();
             builder.stack_height.push();
             builder.alloc.inst_builder.push_inst(inst);
@@ -632,7 +632,7 @@ impl<'parser> FuncTranslator<'parser> {
         inst: Instruction,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.alloc.inst_builder.push_inst(inst);
             Ok(())
         })
@@ -665,7 +665,7 @@ impl<'parser> FuncTranslator<'parser> {
         inst: Instruction,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.pop2();
             builder.stack_height.push();
             builder.alloc.inst_builder.push_inst(inst);
@@ -696,7 +696,7 @@ impl<'parser> FuncTranslator<'parser> {
         inst: Instruction,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.alloc.inst_builder.push_inst(inst);
             Ok(())
         })
@@ -835,7 +835,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_unreachable(&mut self) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder
                 .alloc
                 .inst_builder
@@ -906,7 +906,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
             let stack_height = self.frame_stack_height(block_type);
             let else_label = self.alloc.inst_builder.new_label();
             let end_label = self.alloc.inst_builder.new_label();
-            self.bump_fuel_consumption(self.fuel_costs().base)?;
+            self.bump_fuel_consumption(self.fuel_costs().base())?;
             let branch_offset = self.branch_offset(else_label)?;
             self.alloc
                 .inst_builder
@@ -960,7 +960,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         // Create the jump from the end of the `then` block to the `if`
         // block's end label in case the end of `then` is reachable.
         if reachable {
-            self.bump_fuel_consumption(self.fuel_costs().base)?;
+            self.bump_fuel_consumption(self.fuel_costs().base())?;
             let offset = self.branch_offset(if_frame.end_label())?;
             self.alloc.inst_builder.push_inst(Instruction::Br(offset));
         }
@@ -1035,7 +1035,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         self.translate_if_reachable(|builder| {
             match builder.acquire_target(relative_depth)? {
                 AcquiredTarget::Branch(end_label, drop_keep) => {
-                    builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+                    builder.bump_fuel_consumption(builder.fuel_costs().base())?;
                     let offset = builder.branch_offset(end_label)?;
                     if drop_keep.is_noop() {
                         builder
@@ -1067,7 +1067,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
             builder.stack_height.pop1();
             match builder.acquire_target(relative_depth)? {
                 AcquiredTarget::Branch(end_label, drop_keep) => {
-                    builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+                    builder.bump_fuel_consumption(builder.fuel_costs().base())?;
                     let offset = builder.branch_offset(end_label)?;
                     if drop_keep.is_noop() {
                         builder
@@ -1163,7 +1163,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
                 })
                 .map(RelativeDepth::from_u32);
 
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             // The maximum fuel costs among all `br_table` arms.
             // We use this to charge fuel once at the entry of a `br_table`
             // for the most expensive arm of all of its arms.
@@ -1198,7 +1198,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
     fn visit_return(&mut self) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
             let drop_keep = builder.drop_keep_return()?;
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.bump_fuel_consumption(builder.fuel_costs().fuel_for_drop_keep(drop_keep))?;
             builder
                 .alloc
@@ -1213,7 +1213,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         self.translate_if_reachable(|builder| {
             let func_type = builder.func_type_of(func_idx.into());
             let drop_keep = builder.drop_keep_return_call(&func_type)?;
-            builder.bump_fuel_consumption(builder.fuel_costs().call)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().call())?;
             builder.bump_fuel_consumption(builder.fuel_costs().fuel_for_drop_keep(drop_keep))?;
             match builder.res.get_compiled_func(func_idx.into()) {
                 Some(compiled_func) => {
@@ -1254,7 +1254,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
             let table = TableIdx::from(table_index);
             builder.stack_height.pop1();
             let drop_keep = builder.drop_keep_return_call(&func_type)?;
-            builder.bump_fuel_consumption(builder.fuel_costs().call)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().call())?;
             builder.bump_fuel_consumption(builder.fuel_costs().fuel_for_drop_keep(drop_keep))?;
             builder
                 .alloc
@@ -1275,7 +1275,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_call(&mut self, func_idx: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().call)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().call())?;
             let func_idx = FuncIdx::from(func_idx);
             let func_type = builder.func_type_of(func_idx);
             builder.adjust_value_stack_for_call(&func_type);
@@ -1309,7 +1309,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         _table_byte: u8,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().call)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().call())?;
             let func_type = SignatureIdx::from(func_type_index);
             let table = TableIdx::from(table_index);
             builder.stack_height.pop1();
@@ -1328,7 +1328,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_drop(&mut self) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.pop1();
             builder.alloc.inst_builder.push_inst(Instruction::Drop);
             Ok(())
@@ -1337,7 +1337,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_select(&mut self) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.pop3();
             builder.stack_height.push();
             builder.alloc.inst_builder.push_inst(Instruction::Select);
@@ -1367,7 +1367,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_ref_func(&mut self, func_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             let func_index = bytecode::FuncIdx::from(func_index);
             builder
                 .alloc
@@ -1380,7 +1380,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_local_get(&mut self, local_idx: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             let local_depth = builder.relative_local_depth(local_idx);
             builder
                 .alloc
@@ -1393,7 +1393,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_local_set(&mut self, local_idx: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.pop1();
             let local_depth = builder.relative_local_depth(local_idx);
             builder
@@ -1406,7 +1406,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_local_tee(&mut self, local_idx: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             let local_depth = builder.relative_local_depth(local_idx);
             builder
                 .alloc
@@ -1418,7 +1418,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_global_get(&mut self, global_idx: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let global_idx = GlobalIdx::from(global_idx);
             builder.stack_height.push();
             let (global_type, init_value) = builder.res.get_global(global_idx);
@@ -1435,7 +1435,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_global_set(&mut self, global_idx: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let global_idx = GlobalIdx::from(global_idx);
             let global_type = builder.res.get_type_of_global(global_idx);
             debug_assert_eq!(global_type.mutability(), Mutability::Var);
@@ -1547,7 +1547,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         _mem_byte: u8,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let memory_idx = MemoryIdx::from(memory_idx);
             debug_assert_eq!(memory_idx.into_u32(), DEFAULT_MEMORY_INDEX);
             builder.stack_height.push();
@@ -1566,7 +1566,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
             debug_assert_eq!(memory_index, DEFAULT_MEMORY_INDEX);
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             builder
                 .alloc
                 .inst_builder
@@ -1582,7 +1582,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
             debug_assert_eq!(memory_index, DEFAULT_MEMORY_INDEX);
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             builder.stack_height.pop3();
             builder
                 .alloc
@@ -1595,7 +1595,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
     fn visit_memory_fill(&mut self, memory_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
             debug_assert_eq!(memory_index, DEFAULT_MEMORY_INDEX);
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             builder.stack_height.pop3();
             builder
                 .alloc
@@ -1609,7 +1609,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         self.translate_if_reachable(|builder| {
             debug_assert_eq!(dst_mem, DEFAULT_MEMORY_INDEX);
             debug_assert_eq!(src_mem, DEFAULT_MEMORY_INDEX);
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             builder.stack_height.pop3();
             builder
                 .alloc
@@ -1621,7 +1621,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_data_drop(&mut self, segment_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let segment_index = DataSegmentIdx::from(segment_index);
             builder
                 .alloc
@@ -1633,7 +1633,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_table_size(&mut self, table_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let table = TableIdx::from(table_index);
             builder.stack_height.push();
             builder
@@ -1646,7 +1646,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_table_grow(&mut self, table_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let table = TableIdx::from(table_index);
             builder.stack_height.pop1();
             builder
@@ -1659,7 +1659,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_table_copy(&mut self, dst_table: u32, src_table: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let dst = TableIdx::from(dst_table);
             let src = TableIdx::from(src_table);
             builder.stack_height.pop3();
@@ -1677,7 +1677,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_table_fill(&mut self, table_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let table = TableIdx::from(table_index);
             builder.stack_height.pop3();
             builder
@@ -1690,7 +1690,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_table_get(&mut self, table_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let table = TableIdx::from(table_index);
             builder
                 .alloc
@@ -1702,7 +1702,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_table_set(&mut self, table_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             let table = TableIdx::from(table_index);
             builder.stack_height.pop2();
             builder
@@ -1719,7 +1719,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         table_index: u32,
     ) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             builder.stack_height.pop3();
             let table = TableIdx::from(table_index);
             let elem = ElementSegmentIdx::from(segment_index);
@@ -1737,7 +1737,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_elem_drop(&mut self, segment_index: u32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().entity)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().entity())?;
             builder
                 .alloc
                 .inst_builder
@@ -1750,7 +1750,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_i32_const(&mut self, value: i32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.push();
             builder
                 .alloc
@@ -1766,7 +1766,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
                 // Case: The constant value is small enough that we can apply
                 //       a small value optimization and use a more efficient
                 //       instruction to encode the constant value instruction.
-                builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+                builder.bump_fuel_consumption(builder.fuel_costs().base())?;
                 builder.stack_height.push();
                 builder
                     .alloc
@@ -1780,7 +1780,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
 
     fn visit_f32_const(&mut self, value: wasmparser::Ieee32) -> Result<(), TranslationError> {
         self.translate_if_reachable(|builder| {
-            builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+            builder.bump_fuel_consumption(builder.fuel_costs().base())?;
             builder.stack_height.push();
             builder
                 .alloc
@@ -1796,7 +1796,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
                 // Case: The constant value can be encoded as 32-bit float so
                 //       it is possible to use a more efficient instruction
                 //       to encode the constant value instruction.
-                builder.bump_fuel_consumption(builder.fuel_costs().base)?;
+                builder.bump_fuel_consumption(builder.fuel_costs().base())?;
                 builder.stack_height.push();
                 builder
                     .alloc

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -51,6 +51,7 @@ use self::{
     trap::TaggedTrap,
 };
 pub(crate) use self::{
+    config::FuelCosts,
     func_args::{FuncFinished, FuncParams, FuncResults},
     func_types::DedupFuncType,
     translator::ChosenFuncTranslatorAllocations,

--- a/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/regmach/translator/instr_encoder.rs
@@ -731,11 +731,6 @@ impl InstrEncoder {
         Ok(())
     }
 
-    /// Pushes an [`Instruction::ConsumeFuel`] with base fuel costs to the [`InstrEncoder`].
-    pub fn push_consume_fuel_instr(&mut self, block_fuel: u64) -> Result<Instr, TranslationError> {
-        self.instrs.push(Instruction::consume_fuel(block_fuel)?)
-    }
-
     /// Notifies the [`InstrEncoder`] that a local variable has been preserved.
     ///
     /// # Note

--- a/crates/wasmi/src/engine/tests.rs
+++ b/crates/wasmi/src/engine/tests.rs
@@ -859,7 +859,7 @@ fn metered_simple_01() {
     );
     let costs = fuel_costs();
     let expected_fuel =
-        3 * costs.base + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
+        3 * costs.base() + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
     let expected = [
         instr::consume_fuel(expected_fuel),
         instr::local_get(1),
@@ -885,7 +885,7 @@ fn metered_simple_02() {
     );
     let costs = fuel_costs();
     let expected_fuel =
-        5 * costs.base + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
+        5 * costs.base() + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
     let expected = [
         instr::consume_fuel(expected_fuel),
         instr::local_get(1),
@@ -915,7 +915,7 @@ fn metered_simple_03() {
     );
     let costs = fuel_costs();
     let expected_fuel =
-        9 * costs.base + costs.fuel_for_locals(2) + costs.fuel_for_drop_keep(drop_keep(2, 1));
+        9 * costs.base() + costs.fuel_for_locals(2) + costs.fuel_for_drop_keep(drop_keep(2, 1));
     let expected = [
         instr::consume_fuel(expected_fuel),
         instr::local_get(2),
@@ -950,8 +950,8 @@ fn metered_if_01() {
     );
     let costs = fuel_costs();
     let expected_fuel_fn =
-        4 * costs.base + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
-    let expected_fuel_then = 3 * costs.base + costs.fuel_for_drop_keep(drop_keep(3, 1));
+        4 * costs.base() + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
+    let expected_fuel_then = 3 * costs.base() + costs.fuel_for_drop_keep(drop_keep(3, 1));
     let expected_fuel_else = expected_fuel_then;
     let expected = [
         /*  0 */ instr::consume_fuel(expected_fuel_fn), // function body
@@ -992,8 +992,8 @@ fn metered_block_in_if_01() {
     );
     let costs = fuel_costs();
     let expected_fuel_fn =
-        5 * costs.base + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
-    let expected_fuel_then = 3 * costs.base + costs.fuel_for_drop_keep(drop_keep(3, 1));
+        5 * costs.base() + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
+    let expected_fuel_then = 3 * costs.base() + costs.fuel_for_drop_keep(drop_keep(3, 1));
     let expected_fuel_else = expected_fuel_then;
     #[rustfmt::skip]
     let expected = [
@@ -1039,8 +1039,8 @@ fn metered_block_in_if_02() {
     );
     let costs = fuel_costs();
     let expected_fuel_fn =
-        5 * costs.base + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
-    let expected_fuel_then = 2 * costs.base;
+        5 * costs.base() + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
+    let expected_fuel_then = 2 * costs.base();
     let expected_fuel_else = expected_fuel_then;
     let expected = [
         /*  0 */ instr::consume_fuel(expected_fuel_fn), // function body
@@ -1080,10 +1080,10 @@ fn metered_loop_in_if() {
     );
     let costs = fuel_costs();
     let expected_fuel_fn =
-        5 * costs.base + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
-    let expected_fuel_then = costs.base;
+        5 * costs.base() + costs.fuel_for_locals(3) + costs.fuel_for_drop_keep(drop_keep(3, 1));
+    let expected_fuel_then = costs.base();
     let expected_fuel_else = expected_fuel_then;
-    let expected_fuel_loop = 2 * costs.base;
+    let expected_fuel_loop = 2 * costs.base();
     let expected = [
         /*  0 */ instr::consume_fuel(expected_fuel_fn), // function body
         /*  1 */ instr::local_get(3), // if condition
@@ -1129,7 +1129,7 @@ fn metered_nested_blocks() {
     );
     let costs = fuel_costs();
     let expected_fuel =
-        11 * costs.base + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
+        11 * costs.base() + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
     let expected = [
         instr::consume_fuel(expected_fuel),
         instr::local_get(1),
@@ -1175,8 +1175,8 @@ fn metered_nested_loops() {
     );
     let costs = fuel_costs();
     let expected_fuel_outer =
-        3 * costs.base + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
-    let expected_fuel_inner = 3 * costs.base;
+        3 * costs.base() + costs.fuel_for_locals(1) + costs.fuel_for_drop_keep(drop_keep(1, 1));
+    let expected_fuel_inner = 3 * costs.base();
     let expected = [
         instr::consume_fuel(expected_fuel_outer),
         instr::local_get(1),
@@ -1217,8 +1217,8 @@ fn metered_global_bump() {
     "#,
     );
     let costs = fuel_costs();
-    let expected_fuel = 3 * costs.entity
-        + 4 * costs.base
+    let expected_fuel = 3 * costs.entity()
+        + 4 * costs.base()
         + costs.fuel_for_locals(1)
         + costs.fuel_for_drop_keep(drop_keep(1, 1));
     let expected = [
@@ -1248,13 +1248,13 @@ fn metered_calls_01() {
     "#,
     );
     let costs = fuel_costs();
-    let expected_fuel_f0 = 3 * costs.base;
+    let expected_fuel_f0 = 3 * costs.base();
     let expected_f0 = [
         instr::consume_fuel(expected_fuel_f0),
         instr::i32_const(0),
         Instruction::Return(drop_keep(0, 1)),
     ];
-    let expected_fuel_f1 = 2 * costs.base + costs.call;
+    let expected_fuel_f1 = 2 * costs.base() + costs.call();
     let expected_f1 = [
         instr::consume_fuel(expected_fuel_f1),
         Instruction::CallInternal(compiled_func(0)),
@@ -1285,7 +1285,7 @@ fn metered_calls_02() {
     );
     let costs = fuel_costs();
     let expected_fuel_f0 =
-        5 * costs.base + costs.fuel_for_locals(2) + costs.fuel_for_drop_keep(drop_keep(2, 1));
+        5 * costs.base() + costs.fuel_for_locals(2) + costs.fuel_for_drop_keep(drop_keep(2, 1));
     let expected_f0 = [
         instr::consume_fuel(expected_fuel_f0),
         instr::local_get(2),
@@ -1293,8 +1293,8 @@ fn metered_calls_02() {
         Instruction::I32Add,
         Instruction::Return(drop_keep(2, 1)),
     ];
-    let expected_fuel_f1 = 4 * costs.base
-        + costs.call
+    let expected_fuel_f1 = 4 * costs.base()
+        + costs.call()
         + costs.fuel_for_locals(2)
         + costs.fuel_for_drop_keep(drop_keep(2, 1));
     let expected_f1 = [
@@ -1330,7 +1330,7 @@ fn metered_calls_03() {
     );
     let costs = fuel_costs();
     let expected_fuel_f0 =
-        7 * costs.base + costs.fuel_for_locals(2) + costs.fuel_for_drop_keep(drop_keep(2, 1));
+        7 * costs.base() + costs.fuel_for_locals(2) + costs.fuel_for_drop_keep(drop_keep(2, 1));
     let expected_f0 = [
         instr::consume_fuel(expected_fuel_f0),
         instr::local_get(2),
@@ -1340,8 +1340,8 @@ fn metered_calls_03() {
         Instruction::I32Add,
         Instruction::Return(drop_keep(2, 1)),
     ];
-    let expected_fuel_f1 = 3 * costs.base
-        + costs.call
+    let expected_fuel_f1 = 3 * costs.base()
+        + costs.call()
         + costs.fuel_for_locals(1)
         + costs.fuel_for_drop_keep(drop_keep(1, 1));
     let expected_f1 = [
@@ -1369,8 +1369,8 @@ fn metered_load_01() {
     "#,
     );
     let costs = fuel_costs();
-    let expected_fuel = 3 * costs.base
-        + costs.load
+    let expected_fuel = 3 * costs.base()
+        + costs.load()
         + costs.fuel_for_locals(1)
         + costs.fuel_for_drop_keep(drop_keep(1, 1));
     let expected = [
@@ -1397,7 +1397,7 @@ fn metered_store_01() {
     "#,
     );
     let costs = fuel_costs();
-    let expected_fuel = 4 * costs.base + costs.store + costs.fuel_for_locals(2);
+    let expected_fuel = 4 * costs.base() + costs.store() + costs.fuel_for_locals(2);
     let expected = [
         instr::consume_fuel(expected_fuel),
         instr::local_get(2),


### PR DESCRIPTION
- [x] Removed fields and fields accesses by methods.
- [x] Added new methods that make more sense for the new register-machine wasmi engine backend.
- [x] Adjusted both stack-machine and register-machine to the new model.
- [x] Reinvent register-machine translation API for fuel metering.
- [ ] Implement fuel metering for all `wasmi` IR instruction of the new register-machine.