### PR TITLE
Implement resumable calls via register-machine `wasmi` engine backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,7 +207,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2023-06-15 # we must tag pinned nightly version: https://substrate.stackexchange.com/a/9069
+          toolchain: nightly
           override: true
       - name: Set up Cargo cache
         uses: actions/cache@v3

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -1,4 +1,4 @@
-use self::{call::CallOutcome, return_::ReturnOutcome};
+use self::{call::{CallOutcome}, return_::ReturnOutcome};
 use crate::{
     core::{TrapCode, UntypedValue},
     engine::{
@@ -27,6 +27,7 @@ use crate::{
     FuncRef,
     StoreInner,
 };
+pub use self::call::CallKind;
 
 mod binary;
 mod branch;
@@ -45,8 +46,8 @@ mod unary;
 
 macro_rules! forward_call {
     ($expr:expr) => {{
-        if let CallOutcome::Call { results, host_func } = $expr? {
-            return Ok(WasmOutcome::Call { results, host_func });
+        if let CallOutcome::Call { results, host_func, call_kind } = $expr? {
+            return Ok(WasmOutcome::Call { results, host_func, call_kind });
         }
     }};
 }
@@ -73,6 +74,7 @@ pub enum WasmOutcome {
     Call {
         results: RegisterSpan,
         host_func: Func,
+        call_kind: CallKind,
     },
 }
 

--- a/crates/wasmi/src/engine/regmach/executor/instrs.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs.rs
@@ -1,4 +1,5 @@
-use self::{call::{CallOutcome}, return_::ReturnOutcome};
+pub use self::call::CallKind;
+use self::{call::CallOutcome, return_::ReturnOutcome};
 use crate::{
     core::{TrapCode, UntypedValue},
     engine::{
@@ -27,7 +28,6 @@ use crate::{
     FuncRef,
     StoreInner,
 };
-pub use self::call::CallKind;
 
 mod binary;
 mod branch;
@@ -46,8 +46,17 @@ mod unary;
 
 macro_rules! forward_call {
     ($expr:expr) => {{
-        if let CallOutcome::Call { results, host_func, call_kind } = $expr? {
-            return Ok(WasmOutcome::Call { results, host_func, call_kind });
+        if let CallOutcome::Call {
+            results,
+            host_func,
+            call_kind,
+        } = $expr?
+        {
+            return Ok(WasmOutcome::Call {
+                results,
+                host_func,
+                call_kind,
+            });
         }
     }};
 }

--- a/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/regmach/executor/instrs/call.rs
@@ -321,8 +321,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                 Ok(CallOutcome::Continue)
             }
             FuncEntity::Host(host_func) => {
-                // Note: host function calls cannot be implemented as tail calls.
-                //       The Wasm spec is not mandating tail behavior for host calls.
                 let (input_types, output_types) = self
                     .func_types
                     .resolve_func_type(host_func.ty_dedup())

--- a/crates/wasmi/src/engine/regmach/executor/mod.rs
+++ b/crates/wasmi/src/engine/regmach/executor/mod.rs
@@ -1,6 +1,6 @@
 use self::instrs::{execute_instrs, WasmOutcome};
-use super::stack::CallFrame;
 pub use super::Stack;
+use super::{stack::CallFrame, TaggedTrap};
 use crate::{
     engine::{
         cache::InstanceCache,
@@ -10,10 +10,8 @@ use crate::{
         },
         CallParams,
         CallResults,
-        DedupFuncType,
         EngineResources,
         FuncParams,
-        TaggedTrap,
     },
     func::HostFuncEntity,
     AsContext,
@@ -67,10 +65,8 @@ impl<'engine> EngineExecutor<'engine> {
         Results: CallResults,
     {
         self.stack.reset();
-        let func_type;
         match ctx.as_context().store.inner.resolve_func(func) {
             FuncEntity::Wasm(wasm_func) => {
-                func_type = *wasm_func.ty_dedup();
                 // We reserve space on the stack to write the results of the root function execution.
                 self.stack.values.extend_zeros(results.len_results());
                 let instance = wasm_func.instance();
@@ -92,7 +88,6 @@ impl<'engine> EngineExecutor<'engine> {
                 self.execute_func(ctx.as_context_mut())?;
             }
             FuncEntity::Host(host_func) => {
-                func_type = *host_func.ty_dedup();
                 // The host function signature is required for properly
                 // adjusting, inspecting and manipulating the value stack.
                 let (input_types, output_types) = self
@@ -115,7 +110,44 @@ impl<'engine> EngineExecutor<'engine> {
                 self.dispatch_host_func(ctx.as_context_mut(), host_func, HostFuncCaller::Root)?;
             }
         };
-        let results = self.write_results_back(results, func_type);
+        let results = self.write_results_back(results);
+        Ok(results)
+    }
+
+    /// Resumes the execution of the given [`Func`] using `params`.
+    ///
+    /// Stores the execution result into `results` upon a successful execution.
+    ///
+    /// # Errors
+    ///
+    /// - If the given `params` do not match the expected parameters of `func`.
+    /// - If the given `results` do not match the the length of the expected results of `func`.
+    /// - When encountering a Wasm or host trap during the execution of `func`.
+    pub fn resume_func<T, Results>(
+        &mut self,
+        mut ctx: StoreContextMut<T>,
+        _host_func: Func,
+        params: impl CallParams,
+        caller_results: RegisterSpan,
+        results: Results,
+    ) -> Result<<Results as CallResults>::Results, TaggedTrap>
+    where
+        Results: CallResults,
+    {
+        let caller = self
+            .stack
+            .calls
+            .peek()
+            .expect("must have caller call frame on stack upon function resumption");
+        let mut caller_sp = unsafe { self.stack.values.stack_ptr_at(caller.base_offset()) };
+        let call_params = params.call_params();
+        let len_params = call_params.len();
+        for (result, param) in caller_results.iter(len_params).zip(call_params) {
+            let cell = unsafe { caller_sp.get_mut(result) };
+            *cell = param;
+        }
+        self.execute_func(ctx.as_context_mut())?;
+        let results = self.write_results_back(results);
         Ok(results)
     }
 
@@ -179,7 +211,7 @@ impl<'engine> EngineExecutor<'engine> {
             //
             // This is the default case and we can easily make host function
             // errors return a resumable call handle.
-            result.map_err(|trap| TaggedTrap::host(*func, trap))?;
+            result.map_err(|trap| TaggedTrap::host(*func, trap, results))?;
         } else {
             // Case: No frame is on the call stack. (edge case)
             //
@@ -362,15 +394,11 @@ impl<'engine> EngineExecutor<'engine> {
     ///
     /// - If the `results` buffer length does not match the remaining amount of stack values.
     #[inline]
-    fn write_results_back<Results>(
-        &mut self,
-        results: Results,
-        ty: DedupFuncType,
-    ) -> <Results as CallResults>::Results
+    fn write_results_back<Results>(&mut self, results: Results) -> <Results as CallResults>::Results
     where
         Results: CallResults,
     {
-        let len_results = self.res.func_types.resolve_func_type(&ty).results().len();
+        let len_results = results.len_results();
         results.call_results(&self.stack.values.as_slice()[..len_results])
     }
 }

--- a/crates/wasmi/src/engine/regmach/executor/mod.rs
+++ b/crates/wasmi/src/engine/regmach/executor/mod.rs
@@ -1,4 +1,4 @@
-use self::instrs::{execute_instrs, WasmOutcome, CallKind};
+use self::instrs::{execute_instrs, CallKind, WasmOutcome};
 pub use super::Stack;
 use super::{stack::CallFrame, TaggedTrap};
 use crate::{

--- a/crates/wasmi/src/engine/regmach/mod.rs
+++ b/crates/wasmi/src/engine/regmach/mod.rs
@@ -64,7 +64,7 @@ impl EngineInner {
     /// # Errors
     ///
     /// If the Wasm execution traps or runs out of resources.
-    pub fn execute_func_resumable_regmach<T, Results>(
+    pub(crate) fn execute_func_resumable_regmach<T, Results>(
         &self,
         mut ctx: StoreContextMut<T>,
         func: &Func,
@@ -114,7 +114,7 @@ impl EngineInner {
     /// # Errors
     ///
     /// If the Wasm execution traps or runs out of resources.
-    pub fn resume_func_regmach<T, Results>(
+    pub(crate) fn resume_func_regmach<T, Results>(
         &self,
         ctx: StoreContextMut<T>,
         mut invocation: ResumableInvocation,

--- a/crates/wasmi/src/engine/regmach/mod.rs
+++ b/crates/wasmi/src/engine/regmach/mod.rs
@@ -3,20 +3,25 @@ pub mod code_map;
 mod executor;
 mod stack;
 mod translator;
+mod trap;
 
 #[cfg(test)]
 mod tests;
 
-use self::executor::EngineExecutor;
 pub use self::{
     code_map::CodeMap,
     stack::Stack,
     translator::{FuncLocalConstsIter, FuncTranslator, FuncTranslatorAllocations},
 };
+use self::{executor::EngineExecutor, trap::TaggedTrap};
+use super::resumable::ResumableCallBase;
 use crate::{
     core::Trap,
-    engine::{CallParams, CallResults, EngineInner, TaggedTrap},
+    engine::{CallParams, CallResults, EngineInner},
+    AsContext as _,
+    AsContextMut as _,
     Func,
+    ResumableInvocation,
     StoreContextMut,
 };
 
@@ -49,5 +54,106 @@ impl EngineInner {
             .map_err(TaggedTrap::into_trap);
         self.stacks.lock().recycle_2(stack);
         results
+    }
+
+    /// Executes the given [`Func`] resumably with the given `params` and returns the `results`.
+    ///
+    /// - Uses the `wasmi` register-machine based engine backend.
+    /// - Uses the [`StoreContextMut`] for context information about the Wasm [`Store`].
+    ///
+    /// # Errors
+    ///
+    /// If the Wasm execution traps or runs out of resources.
+    pub fn execute_func_resumable_regmach<T, Results>(
+        &self,
+        mut ctx: StoreContextMut<T>,
+        func: &Func,
+        params: impl CallParams,
+        results: Results,
+    ) -> Result<ResumableCallBase<<Results as CallResults>::Results>, Trap>
+    where
+        Results: CallResults,
+    {
+        let res = self.res.read();
+        let mut stack = self.stacks.lock().reuse_or_new_2();
+        let results = EngineExecutor::new(&res, &mut stack).execute_root_func(
+            ctx.as_context_mut(),
+            func,
+            params,
+            results,
+        );
+        match results {
+            Ok(results) => {
+                self.stacks.lock().recycle_2(stack);
+                Ok(ResumableCallBase::Finished(results))
+            }
+            Err(TaggedTrap::Wasm(trap)) => {
+                self.stacks.lock().recycle_2(stack);
+                Err(trap)
+            }
+            Err(TaggedTrap::Host {
+                host_func,
+                host_trap,
+                caller_results,
+            }) => Ok(ResumableCallBase::Resumable(ResumableInvocation::new(
+                ctx.as_context().store.engine().clone(),
+                *func,
+                host_func,
+                host_trap,
+                Some(caller_results),
+                stack,
+            ))),
+        }
+    }
+
+    /// Resumes the given [`Func`] with the given `params` and returns the `results`.
+    ///
+    /// - Uses the `wasmi` register-machine based engine backend.
+    /// - Uses the [`StoreContextMut`] for context information about the Wasm [`Store`].
+    ///
+    /// # Errors
+    ///
+    /// If the Wasm execution traps or runs out of resources.
+    pub fn resume_func_regmach<T, Results>(
+        &self,
+        ctx: StoreContextMut<T>,
+        mut invocation: ResumableInvocation,
+        params: impl CallParams,
+        results: Results,
+    ) -> Result<ResumableCallBase<<Results as CallResults>::Results>, Trap>
+    where
+        Results: CallResults,
+    {
+        let res = self.res.read();
+        let host_func = invocation.host_func();
+        let caller_results = invocation
+            .caller_results()
+            .expect("register-machine engine required caller results for call resumption");
+        let mut stack = invocation.take_stack().into_regmach();
+        let results = EngineExecutor::new(&res, &mut stack).resume_func(
+            ctx,
+            host_func,
+            params,
+            caller_results,
+            results,
+        );
+        match results {
+            Ok(results) => {
+                self.stacks.lock().recycle_2(stack);
+                Ok(ResumableCallBase::Finished(results))
+            }
+            Err(TaggedTrap::Wasm(trap)) => {
+                self.stacks.lock().recycle_2(stack);
+                Err(trap)
+            }
+            Err(TaggedTrap::Host {
+                host_func,
+                host_trap,
+                caller_results,
+            }) => {
+                invocation.update_2(stack, host_func, host_trap, caller_results);
+                Ok(ResumableCallBase::Resumable(invocation))
+            }
+        }
     }
 }

--- a/crates/wasmi/src/engine/regmach/trap.rs
+++ b/crates/wasmi/src/engine/regmach/trap.rs
@@ -1,0 +1,49 @@
+use super::bytecode::RegisterSpan;
+use crate::{
+    core::{Trap, TrapCode},
+    Func,
+};
+
+/// Either a Wasm trap or a host trap with its originating host [`Func`].
+#[derive(Debug)]
+pub enum TaggedTrap {
+    /// The trap is originating from Wasm.
+    Wasm(Trap),
+    /// The trap is originating from a host function.
+    Host {
+        host_func: Func,
+        host_trap: Trap,
+        caller_results: RegisterSpan,
+    },
+}
+
+impl TaggedTrap {
+    /// Creates a [`TaggedTrap`] from a host error.
+    pub fn host(host_func: Func, host_trap: Trap, caller_results: RegisterSpan) -> Self {
+        Self::Host {
+            host_func,
+            host_trap,
+            caller_results,
+        }
+    }
+
+    /// Returns the [`Trap`] of the [`TaggedTrap`].
+    pub fn into_trap(self) -> Trap {
+        match self {
+            TaggedTrap::Wasm(trap) => trap,
+            TaggedTrap::Host { host_trap, .. } => host_trap,
+        }
+    }
+}
+
+impl From<Trap> for TaggedTrap {
+    fn from(trap: Trap) -> Self {
+        Self::Wasm(trap)
+    }
+}
+
+impl From<TrapCode> for TaggedTrap {
+    fn from(trap_code: TrapCode) -> Self {
+        Self::Wasm(trap_code.into())
+    }
+}

--- a/crates/wasmi/tests/e2e/v1/resumable_call.rs
+++ b/crates/wasmi/tests/e2e/v1/resumable_call.rs
@@ -6,6 +6,7 @@ use wasmi::{
     Caller,
     Config,
     Engine,
+    EngineBackend,
     Error,
     Extern,
     Func,
@@ -21,9 +22,10 @@ use wasmi::{
 };
 use wasmi_core::{Trap, TrapCode, ValueType};
 
-fn test_setup(remaining: u32) -> (Store<TestData>, Linker<TestData>) {
+fn test_setup(remaining: u32, backend: EngineBackend) -> (Store<TestData>, Linker<TestData>) {
     let mut config = Config::default();
     config.wasm_tail_call(true);
+    config.set_engine_backend(backend);
     let engine = Engine::new(&config);
     let store = Store::new(
         &engine,
@@ -41,8 +43,11 @@ pub struct TestData {
     _remaining: u32,
 }
 
-fn resumable_call_smoldot_common(wasm: &str) -> (Store<TestData>, TypedFunc<(), i32>) {
-    let (mut store, mut linker) = test_setup(0);
+fn resumable_call_smoldot_common(
+    backend: EngineBackend,
+    wasm: &str,
+) -> (Store<TestData>, TypedFunc<(), i32>) {
+    let (mut store, mut linker) = test_setup(0, backend);
     // The important part about this test is that this
     // host function has more results than parameters.
     linker
@@ -85,166 +90,194 @@ impl<Results> UnwrapResumable for Result<TypedResumableCall<Results>, Trap> {
 
 #[test]
 fn resumable_call_smoldot_01() {
-    let (mut store, wasm_fn) = resumable_call_smoldot_common(
-        r#"
-        (module
-            (import "env" "host_fn" (func $host_fn (result i32)))
-            (func (export "test") (result i32)
-                (call $host_fn)
+    fn test_with(backend: EngineBackend) {
+        let (mut store, wasm_fn) = resumable_call_smoldot_common(
+            backend,
+            r#"
+            (module
+                (import "env" "host_fn" (func $host_fn (result i32)))
+                (func (export "test") (result i32)
+                    (call $host_fn)
+                )
             )
-        )
-        "#,
-    );
-    let invocation = wasm_fn.call_resumable(&mut store, ()).unwrap_resumable();
-    match invocation.resume(&mut store, &[Value::I32(42)]).unwrap() {
-        TypedResumableCall::Finished(result) => assert_eq!(result, 42),
-        TypedResumableCall::Resumable(_) => panic!("expected TypeResumableCall::Finished"),
+            "#,
+        );
+        let invocation = wasm_fn.call_resumable(&mut store, ()).unwrap_resumable();
+        match invocation.resume(&mut store, &[Value::I32(42)]).unwrap() {
+            TypedResumableCall::Finished(result) => assert_eq!(result, 42),
+            TypedResumableCall::Resumable(_) => panic!("expected TypeResumableCall::Finished"),
+        }
     }
+    test_with(EngineBackend::StackMachine);
+    test_with(EngineBackend::RegisterMachine);
 }
 
 #[test]
 fn resumable_call_smoldot_tail_01() {
-    let (mut store, wasm_fn) = resumable_call_smoldot_common(
-        r#"
-        (module
-            (import "env" "host_fn" (func $host_fn (result i32)))
-            (func (export "test") (result i32)
-                (return_call $host_fn)
+    fn test_with(backend: EngineBackend) {
+        let (mut store, wasm_fn) = resumable_call_smoldot_common(
+            backend,
+            r#"
+            (module
+                (import "env" "host_fn" (func $host_fn (result i32)))
+                (func (export "test") (result i32)
+                    (return_call $host_fn)
+                )
             )
-        )
-        "#,
-    );
-    assert_eq!(
-        wasm_fn
-            .call_resumable(&mut store, ())
-            .unwrap_err()
-            .i32_exit_status(),
-        Some(100),
-    );
+            "#,
+        );
+        assert_eq!(
+            wasm_fn
+                .call_resumable(&mut store, ())
+                .unwrap_err()
+                .i32_exit_status(),
+            Some(100),
+        );
+    }
+    test_with(EngineBackend::StackMachine);
+    test_with(EngineBackend::RegisterMachine);
 }
 
 #[test]
 fn resumable_call_smoldot_tail_02() {
-    let (mut store, wasm_fn) = resumable_call_smoldot_common(
-        r#"
-        (module
-            (import "env" "host_fn" (func $host (result i32)))
-            (func $wasm (result i32)
-                (return_call $host)
+    fn test_with(backend: EngineBackend) {
+        let (mut store, wasm_fn) = resumable_call_smoldot_common(
+            backend,
+            r#"
+            (module
+                (import "env" "host_fn" (func $host (result i32)))
+                (func $wasm (result i32)
+                    (return_call $host)
+                )
+                (func (export "test") (result i32)
+                    (call $wasm)
+                )
             )
-            (func (export "test") (result i32)
-                (call $wasm)
-            )
-        )
-        "#,
-    );
-    let invocation = wasm_fn.call_resumable(&mut store, ()).unwrap_resumable();
-    match invocation.resume(&mut store, &[Value::I32(42)]).unwrap() {
-        TypedResumableCall::Finished(result) => assert_eq!(result, 42),
-        TypedResumableCall::Resumable(_) => panic!("expected TypeResumableCall::Finished"),
+            "#,
+        );
+        let invocation = wasm_fn.call_resumable(&mut store, ()).unwrap_resumable();
+        match invocation.resume(&mut store, &[Value::I32(42)]).unwrap() {
+            TypedResumableCall::Finished(result) => assert_eq!(result, 42),
+            TypedResumableCall::Resumable(_) => panic!("expected TypeResumableCall::Finished"),
+        }
     }
+    test_with(EngineBackend::StackMachine);
+    test_with(EngineBackend::RegisterMachine);
 }
 
 #[test]
 fn resumable_call_smoldot_02() {
-    let (mut store, wasm_fn) = resumable_call_smoldot_common(
-        r#"
-        (module
-            (import "env" "host_fn" (func $host_fn (result i32)))
-            (func (export "test") (result i32)
-                (if (result i32) (i32.ne (call $host_fn) (i32.const 0))
-                    (then
-                        (i32.const 11) ;; EXPECTED
-                    )
-                    (else
-                        (i32.const 22) ;; FAILURE
+    fn test_with(backend: EngineBackend) {
+        let (mut store, wasm_fn) = resumable_call_smoldot_common(
+            backend,
+            r#"
+            (module
+                (import "env" "host_fn" (func $host_fn (result i32)))
+                (func (export "test") (result i32)
+                    (if (result i32) (i32.ne (call $host_fn) (i32.const 0))
+                        (then
+                            (i32.const 11) ;; EXPECTED
+                        )
+                        (else
+                            (i32.const 22) ;; FAILURE
+                        )
                     )
                 )
             )
-        )
-        "#,
-    );
-    let invocation = wasm_fn.call_resumable(&mut store, ()).unwrap_resumable();
-    match invocation.resume(&mut store, &[Value::I32(42)]).unwrap() {
-        TypedResumableCall::Finished(result) => assert_eq!(result, 11),
-        TypedResumableCall::Resumable(_) => panic!("expected TypeResumableCall::Finished"),
+            "#,
+        );
+        let invocation = wasm_fn.call_resumable(&mut store, ()).unwrap_resumable();
+        match invocation.resume(&mut store, &[Value::I32(42)]).unwrap() {
+            TypedResumableCall::Finished(result) => assert_eq!(result, 11),
+            TypedResumableCall::Resumable(_) => panic!("expected TypeResumableCall::Finished"),
+        }
     }
+    test_with(EngineBackend::StackMachine);
+    test_with(EngineBackend::RegisterMachine);
 }
 
 #[test]
 fn resumable_call_host() {
-    let (mut store, _linker) = test_setup(0);
-    let host_fn = Func::wrap(&mut store, || -> Result<(), Trap> {
-        Err(Trap::i32_exit(100))
-    });
-    // Even though the called host function traps we expect a normal error
-    // since the host function is the root function of the call and therefore
-    // it would not make sense to resume it.
-    let error = host_fn
-        .call_resumable(&mut store, &[], &mut [])
-        .unwrap_err();
-    match error {
-        Error::Trap(trap) => {
-            assert_eq!(trap.i32_exit_status(), Some(100));
+    fn test_with(backend: EngineBackend) {
+        let (mut store, _linker) = test_setup(0, backend);
+        let host_fn = Func::wrap(&mut store, || -> Result<(), Trap> {
+            Err(Trap::i32_exit(100))
+        });
+        // Even though the called host function traps we expect a normal error
+        // since the host function is the root function of the call and therefore
+        // it would not make sense to resume it.
+        let error = host_fn
+            .call_resumable(&mut store, &[], &mut [])
+            .unwrap_err();
+        match error {
+            Error::Trap(trap) => {
+                assert_eq!(trap.i32_exit_status(), Some(100));
+            }
+            _ => panic!("expected Wasm trap"),
         }
-        _ => panic!("expected Wasm trap"),
+        // The same test for `TypedFunc`:
+        let trap = host_fn
+            .typed::<(), ()>(&store)
+            .unwrap()
+            .call_resumable(&mut store, ())
+            .unwrap_err();
+        assert_eq!(trap.i32_exit_status(), Some(100));
     }
-    // The same test for `TypedFunc`:
-    let trap = host_fn
-        .typed::<(), ()>(&store)
-        .unwrap()
-        .call_resumable(&mut store, ())
-        .unwrap_err();
-    assert_eq!(trap.i32_exit_status(), Some(100));
+    test_with(EngineBackend::StackMachine);
+    test_with(EngineBackend::RegisterMachine);
 }
 
 #[test]
 fn resumable_call() {
-    let (mut store, mut linker) = test_setup(0);
-    let host_fn = Func::wrap(&mut store, |input: i32| -> Result<i32, Trap> {
-        match input {
-            1 => Err(Trap::i32_exit(10)),
-            2 => Err(Trap::i32_exit(20)),
-            n => Ok(n + 1),
-        }
-    });
-    linker.define("env", "host_fn", host_fn).unwrap();
-    let wasm = wat::parse_str(
-        r#"
-        (module
-            (import "env" "host_fn" (func $host_fn (param i32) (result i32)))
-            (func (export "wasm_fn") (param $wasm_trap i32) (result i32)
-                (local $i i32)
-                (local.set $i (i32.const 0))
-                (local.set $i (call $host_fn (local.get $i))) ;; Ok
-                (local.set $i (call $host_fn (local.get $i))) ;; Trap::i32_exit(1)
-                (local.set $i (call $host_fn (local.get $i))) ;; Trap::i32_exit(2)
-                (local.set $i (call $host_fn (local.get $i))) ;; Ok
-                (if (i32.eq (local.get $wasm_trap) (i32.const 1))
-                    (then unreachable)                        ;; trap in Wasm if $wasm_trap == 1
+    fn test_with(backend: EngineBackend) {
+        let (mut store, mut linker) = test_setup(0, backend);
+        let host_fn = Func::wrap(&mut store, |input: i32| -> Result<i32, Trap> {
+            match input {
+                1 => Err(Trap::i32_exit(10)),
+                2 => Err(Trap::i32_exit(20)),
+                n => Ok(n + 1),
+            }
+        });
+        linker.define("env", "host_fn", host_fn).unwrap();
+        let wasm = wat::parse_str(
+            r#"
+            (module
+                (import "env" "host_fn" (func $host_fn (param i32) (result i32)))
+                (func (export "wasm_fn") (param $wasm_trap i32) (result i32)
+                    (local $i i32)
+                    (local.set $i (i32.const 0))
+                    (local.set $i (call $host_fn (local.get $i))) ;; Ok
+                    (local.set $i (call $host_fn (local.get $i))) ;; Trap::i32_exit(1)
+                    (local.set $i (call $host_fn (local.get $i))) ;; Trap::i32_exit(2)
+                    (local.set $i (call $host_fn (local.get $i))) ;; Ok
+                    (if (i32.eq (local.get $wasm_trap) (i32.const 1))
+                        (then unreachable)                        ;; trap in Wasm if $wasm_trap == 1
+                    )
+                    (local.get $i)                                ;; return i == 4
                 )
-                (local.get $i)                                ;; return i == 4
             )
+            "#,
         )
-        "#,
-    )
-    .unwrap();
-
-    let module = Module::new(store.engine(), &mut &wasm[..]).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
-    let wasm_fn = instance
-        .get_export(&store, "wasm_fn")
-        .and_then(Extern::into_func)
         .unwrap();
 
-    run_test(wasm_fn, &mut store, false);
-    run_test(wasm_fn, &mut store, true);
-    run_test_typed(wasm_fn, &mut store, false);
-    run_test_typed(wasm_fn, &mut store, true);
+        let module = Module::new(store.engine(), &mut &wasm[..]).unwrap();
+        let instance = linker
+            .instantiate(&mut store, &module)
+            .unwrap()
+            .start(&mut store)
+            .unwrap();
+        let wasm_fn = instance
+            .get_export(&store, "wasm_fn")
+            .and_then(Extern::into_func)
+            .unwrap();
+
+        run_test(wasm_fn, &mut store, false);
+        run_test(wasm_fn, &mut store, true);
+        run_test_typed(wasm_fn, &mut store, false);
+        run_test_typed(wasm_fn, &mut store, true);
+    }
+    test_with(EngineBackend::StackMachine);
+    test_with(EngineBackend::RegisterMachine);
 }
 
 trait AssertResumable {


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/811.