### PR TITLE
Fix `local.set` preservation bug

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_2.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_2.wat
@@ -1,0 +1,11 @@
+(module
+  (func (;0;) (param i32)
+    (local.tee 0 (local.get 0))
+    (local.tee 0 (local.get 0))
+    (if (param i32) ;; label = @1
+      (then (drop))
+      (else (drop))
+    )
+  )
+  (export "" (func 0))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -1,5 +1,5 @@
-use crate::engine::bytecode::{BranchOffset16, BranchOffset};
 use super::*;
+use crate::engine::bytecode::{BranchOffset, BranchOffset16};
 
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -1,3 +1,4 @@
+use crate::engine::bytecode::{BranchOffset16, BranchOffset};
 use super::*;
 
 #[test]
@@ -24,6 +25,20 @@ fn fuzz_regression_1() {
             Instruction::copy(1, 0),
             Instruction::copy_f64imm32(Register::from_i16(0), 13.0_f32),
             Instruction::return_reg(1),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn fuzz_regression_2() {
+    let wat = include_str!("fuzz_2.wat");
+    let wasm = wat2wasm(wat);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(2)),
+            Instruction::branch(BranchOffset::from(1)),
+            Instruction::Return,
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -790,6 +790,15 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
         bail_unreachable!(self);
         let value = self.alloc.stack.pop();
         let local = Register::try_from(local_index)?;
+        if let TypedProvider::Register(value) = value {
+            if value == local {
+                // Case: `(local.set $n (local.get $n))` is a no-op so we can ignore it.
+                //
+                // Note: This does not require any preservation since it won't change
+                //       the value of `local $n`.
+                return Ok(())
+            }
+        }
         let preserved = self.alloc.stack.preserve_locals(local_index)?;
         let fuel_info = self.fuel_info();
         self.alloc.instr_encoder.encode_local_set(

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -796,7 +796,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator<'a> {
                 //
                 // Note: This does not require any preservation since it won't change
                 //       the value of `local $n`.
-                return Ok(())
+                return Ok(());
             }
         }
         let preserved = self.alloc.stack.preserve_locals(local_index)?;


### PR DESCRIPTION
When translating

```wat
(local.set $n (local.get $n))
```
or

```wat
(local.tee $n (local.get $n))
```

The `wasmi` translation now properly ignores this since the whole sequence can be ignored and no longer runs into preservation issues. Note: While this change fixes the tagged test case there might be more bugs in local variable preservation that we might need to fix later.