### PR TITLE
Make CI jobs use `dtolnay/rust-toolchain` instead of `actions-rs`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -317,11 +317,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: clippy
       - name: Set up Cargo cache
         uses: actions/cache@v3
@@ -336,25 +333,13 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-clippy-
       - name: Clippy (default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
       - name: Clippy (all features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-features -- -D warnings
+        run: cargo clippy --workspace --all-features -- -D warnings
       - name: Clippy (no_std)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --no-default-features -- -D warnings
+        run: cargo clippy --workspace --no-default-features -- -D warnings
       - name: Clippy (tests)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --tests -- -D warnings
+        run: cargo clippy --workspace --tests -- -D warnings
 
   coverage:
     name: Coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -292,11 +292,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: miri
       - name: Set up Cargo cache
         uses: actions/cache@v3
@@ -311,15 +308,9 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-miri-
       - name: Miri (--lib)
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test --lib --workspace
+        run: cargo miri test --lib --workspace
       - name: Miri (--doc)
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test --doc --workspace
+        run: cargo miri test --doc --workspace
 
   clippy:
     name: Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,15 +117,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: audit
-          args: ""
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: |
+          # Note: We use `|| true` because cargo install returns an error
+          #       if cargo-audit was already installed on the CI runner.
+          cargo install cargo-audit || true
+      - name: Check Audit
+        run: cargo audit
 
   udeps:
     name: uDeps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,11 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Set up Cargo cache
         uses: actions/cache@v3
         continue-on-error: false
@@ -155,10 +151,8 @@ jobs:
           # Note: We use `|| true` because cargo install returns an error
           #       if cargo-udeps was already installed on the CI runner.
           cargo install --locked cargo-udeps || true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: udeps
-          args: --all-targets
+      - name: Check uDeps
+        run: cargo udeps --all-targets
 
   fuzz_translate:
     name: Fuzz (Translation)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,11 +70,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up Cargo cache
         uses: actions/cache@v3
         continue-on-error: false
@@ -90,19 +86,13 @@ jobs:
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Test (default features)
-        uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        with:
-          command: test
-          args: --workspace --release
+        run: cargo test --workspace --release
       - name: Test (all features)
-        uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        with:
-          command: test
-          args: --workspace --release --all-features
+        run: cargo test --workspace --release --all-features
 
   fmt:
     name: Formatting

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,11 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rust-docs, rust-src
       - name: Set up Cargo cache
         uses: actions/cache@v3
@@ -138,12 +135,10 @@ jobs:
             ~/target/
           key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-doc-
-      - uses: actions-rs/cargo@v1
+      - name: Check Docs
         env:
           RUSTDOCFLAGS: "-D warnings"
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps --document-private-items
+        run: cargo doc --workspace --all-features --no-deps --document-private-items
 
   audit:
     name: Audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions-rs/toolchain@v1
         with:
           targets: wasm32-unknown-unknown, thumbv7em-none-eabi
       - name: Set up Cargo cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -349,11 +349,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up Cargo cache
         uses: actions/cache@v3
         continue-on-error: false
@@ -369,7 +365,7 @@ jobs:
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Run cargo-tarpaulin (default features)
-        uses: actions-rs/tarpaulin@v0.1
+        uses: actions-rs/tarpaulin@v0.1.3
         with:
           version: "0.18.0"
           args: --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,12 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+          targets: wasm32-unknown-unknown, thumbv7em-none-eabi
       - name: Set up Cargo cache
         uses: actions/cache@v3
         continue-on-error: false
@@ -35,30 +33,14 @@ jobs:
             ~/target/
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-build-
-      - name: Add extra targets
-        # Workaround for https://github.com/actions-rs/toolchain/issues/165
-        run: |
-          rustup target add thumbv7em-none-eabi
       - name: Build (default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace
+        run: cargo build --workspace
       - name: Build (all features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-features
+        run: cargo build --workspace --all-features
       - name: Build (no_std)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli --exclude wasmi_wasi
+        run: cargo build --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli --exclude wasmi_wasi
       - name: Build (wasm32)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --lib --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
+        run: cargo build --workspace --lib --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi
 
   test:
     name: Test


### PR DESCRIPTION
The problem is that GitHub Actions `actions-rs` got archived and is no longer expected to be maintained.