### PR TITLE
Improve `Error` API

### DIFF
--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -75,19 +75,44 @@ impl Error {
         self.kind().as_i32_exit_status()
     }
 
-    /// Returns a dynamic reference to [`HostError`] if [`ErrorKind`] is a [`HostError`].
-    pub fn as_host(&self) -> Option<&dyn HostError> {
-        self.kind().as_host()
+    /// Downcasts the [`Error`] into the `T: HostError` if possible.
+    ///
+    /// Returns `None` otherwise.
+    #[inline]
+    pub fn downcast_ref<T>(&self) -> Option<&T>
+    where
+        T: HostError,
+    {
+        self.kind
+            .as_host()
+            .and_then(<(dyn HostError + 'static)>::downcast_ref)
     }
 
-    /// Returns a dynamic reference to [`HostError`] if [`ErrorKind`] is a [`HostError`].
-    pub fn as_host_mut(&mut self) -> Option<&mut dyn HostError> {
-        self.kind_mut().as_host_mut()
+    /// Downcasts the [`Error`] into the `T: HostError` if possible.
+    ///
+    /// Returns `None` otherwise.
+    #[inline]
+    pub fn downcast_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: HostError,
+    {
+        self.kind
+            .as_host_mut()
+            .and_then(<(dyn HostError + 'static)>::downcast_mut)
     }
 
-    /// Returns a [`HostError`] if [`ErrorKind`] is a [`HostError`].
-    pub fn into_host(self) -> Option<Box<dyn HostError>> {
-        self.into_kind().into_host()
+    /// Consumes `self` to downcast the [`Error`] into the `T: HostError` if possible.
+    ///
+    /// Returns `None` otherwise.
+    #[inline]
+    pub fn downcast<T>(self) -> Option<T>
+    where
+        T: HostError,
+    {
+        self.kind
+            .into_host()
+            .and_then(|error| error.downcast().ok())
+            .map(|boxed| *boxed)
     }
 }
 

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -58,19 +58,9 @@ impl Error {
         Self::from_kind(ErrorKind::I32ExitStatus(status))
     }
 
-    /// Converts `self` into the underlying [`ErrorKind`].
-    pub fn into_kind(self) -> ErrorKind {
-        *self.kind
-    }
-
     /// Returns the [`ErrorKind`] of the [`Error`].
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
-    }
-
-    /// Returns the [`ErrorKind`] of the [`Error`].
-    pub fn kind_mut(&mut self) -> &mut ErrorKind {
-        &mut self.kind
     }
 
     /// Returns a reference to [`TrapCode`] if [`Error`] is a [`TrapCode`].

--- a/crates/wasmi/tests/e2e/v1/func.rs
+++ b/crates/wasmi/tests/e2e/v1/func.rs
@@ -6,7 +6,6 @@ use assert_matches::assert_matches;
 use wasmi::{
     errors::{ErrorKind, FuncError},
     Engine,
-    Error,
     Func,
     FuncType,
     Store,
@@ -428,8 +427,9 @@ fn dynamic_type_check_works() {
     assert_matches!(
         identity
             .call(&mut store, &[], core::slice::from_mut(&mut result))
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingParameterLen))
+            .unwrap_err()
+            .kind(),
+        ErrorKind::Func(FuncError::MismatchingParameterLen)
     );
     // Case: Too many inputs given to function.
     assert_matches!(
@@ -439,15 +439,17 @@ fn dynamic_type_check_works() {
                 &[Value::I32(0), Value::I32(1)],
                 core::slice::from_mut(&mut result)
             )
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingParameterLen))
+            .unwrap_err()
+            .kind(),
+        ErrorKind::Func(FuncError::MismatchingParameterLen)
     );
     // Case: Too few outputs given to function.
     assert_matches!(
         identity
             .call(&mut store, &[Value::I32(0)], &mut [],)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingResultLen))
+            .unwrap_err()
+            .kind(),
+        ErrorKind::Func(FuncError::MismatchingResultLen)
     );
     // Case: Too many outputs given to function.
     assert_matches!(
@@ -457,8 +459,9 @@ fn dynamic_type_check_works() {
                 &[Value::I32(0)],
                 &mut [Value::I32(0), Value::I32(1)],
             )
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingResultLen))
+            .unwrap_err()
+            .kind(),
+        ErrorKind::Func(FuncError::MismatchingResultLen)
     );
     // Case: Mismatching type given as input to function.
     for input in &[
@@ -473,8 +476,9 @@ fn dynamic_type_check_works() {
                     core::slice::from_ref(input),
                     core::slice::from_mut(&mut result)
                 )
-                .map_err(Error::into_kind),
-            Err(ErrorKind::Func(FuncError::MismatchingParameterType))
+                .unwrap_err()
+                .kind(),
+            ErrorKind::Func(FuncError::MismatchingParameterType)
         );
     }
     // Case: Allow for incorrect result type.
@@ -492,44 +496,38 @@ fn static_type_check_works() {
     let identity = Func::wrap(&mut store, |value: i32| value);
     // Case: Too few inputs given to function.
     assert_matches!(
-        identity
-            .typed::<(), i32>(&mut store)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingParameterLen))
+        identity.typed::<(), i32>(&mut store).unwrap_err().kind(),
+        ErrorKind::Func(FuncError::MismatchingParameterLen)
     );
     // Case: Too many inputs given to function.
     assert_matches!(
         identity
             .typed::<(i32, i32), i32>(&mut store)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingParameterLen))
+            .unwrap_err()
+            .kind(),
+        ErrorKind::Func(FuncError::MismatchingParameterLen)
     );
     // Case: Too few results given to function.
     assert_matches!(
-        identity
-            .typed::<i32, ()>(&mut store)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingResultLen))
+        identity.typed::<i32, ()>(&mut store).unwrap_err().kind(),
+        ErrorKind::Func(FuncError::MismatchingResultLen)
     );
     // Case: Too many results given to function.
     assert_matches!(
         identity
             .typed::<i32, (i32, i32)>(&mut store)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingResultLen))
+            .unwrap_err()
+            .kind(),
+        ErrorKind::Func(FuncError::MismatchingResultLen)
     );
     // Case: Mismatching type given as input to function.
     assert_matches!(
-        identity
-            .typed::<i64, i32>(&mut store)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingParameterType))
+        identity.typed::<i64, i32>(&mut store).unwrap_err().kind(),
+        ErrorKind::Func(FuncError::MismatchingParameterType)
     );
     // Case: Mismatching type given as output of function.
     assert_matches!(
-        identity
-            .typed::<i32, i64>(&mut store)
-            .map_err(Error::into_kind),
-        Err(ErrorKind::Func(FuncError::MismatchingResultType))
+        identity.typed::<i32, i64>(&mut store).unwrap_err().kind(),
+        ErrorKind::Func(FuncError::MismatchingResultType)
     );
 }


### PR DESCRIPTION
This adds the following APIs:

- `Error::downcast`
- `Error::downcast_ref`
- `Error::downcast_mut`

And removes the following API:

- `Error::kind_mut`
- `Error::into_kind`