### PR TITLE
Add `Error::host` constructor

### DIFF
--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -47,6 +47,16 @@ impl Error {
         Self::from_kind(ErrorKind::Message(message.into().into_boxed_str()))
     }
 
+    /// Creates a custom [`HostError`].
+    #[inline]
+    #[cold]
+    pub fn host<E>(host_error: E) -> Self
+    where
+        E: HostError,
+    {
+        Self::from_kind(ErrorKind::Host(Box::new(host_error)))
+    }
+
     /// Creates a new `Error` representing an explicit program exit with a classic `i32` exit status value.
     ///
     /// # Note


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/855.

Unfortunately we cannot add From<HostError> for Error since that conflicts with its other From impls which is a slight bummer to user experience.