### PR TITLE
Add inline annotations to call exec handlers

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -932,6 +932,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Returns the [`ValueStackPtr`] of the [`CallFrame`].
+    #[inline]
     fn frame_stack_ptr(&mut self, frame: &CallFrame) -> ValueStackPtr {
         Self::frame_stack_ptr_impl(self.value_stack, frame)
     }

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -57,6 +57,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// # Note
     ///
     /// The `offset` denotes how many [`Instruction`] words make up the call instruction.
+    #[inline]
     fn update_instr_ptr_at(&mut self, offset: usize) {
         // Note: we explicitly do not mutate `self.ip` since that would make
         // other parts of the code more fragile with respect to instruction ordering.
@@ -100,6 +101,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Creates a [`CallFrame`] for calling the [`CompiledFunc`].
+    #[inline(always)]
     fn dispatch_compiled_func(
         &mut self,
         results: RegisterSpan,
@@ -125,6 +127,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     ///
     /// This will also adjust the instruction pointer to point to the
     /// last call parameter [`Instruction`] if any.
+    #[inline(always)]
     #[must_use]
     fn copy_call_params(&mut self, mut called_regs: ValueStackPtr) -> InstructionPtr {
         let mut dst = Register::from_i16(0);
@@ -162,6 +165,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Prepares a [`CompiledFunc`] call with optional [`CallParams`].
+    #[inline(always)]
     fn prepare_compiled_func_call(
         &mut self,
         results: RegisterSpan,

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -85,6 +85,7 @@ impl Stack {
     /// Any [`ValueStackPtr`] allocated within the range `from..to` on the [`ValueStack`]
     /// may be invalidated by this operation. It is the caller's responsibility to reinstantiate
     /// all [`ValueStackPtr`] affected by this.
+    #[inline(always)]
     pub unsafe fn merge_call_frames(
         call_stack: &mut CallStack,
         value_stack: &mut ValueStack,


### PR DESCRIPTION
Locally this proved to be highly effective in improving call intense work loads while not regression compute intense workloads.