### PR TITLE
New spelling for Wasmi in the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 ### Dev. Note
 
 - We now publish and record graphs of benchmarks over time. (https://github.com/paritytech/wasmi/pull/740)
-  - This allows `wasmi` developers to better inspect performance changes over longer periods of time.
+  - This allows Wasmi developers to better inspect performance changes over longer periods of time.
 - Updated dev. dependencies:
   - `criterion 0.4.0` -> `0.5.0`
   - `wast 0.52.0` -> `0.62.0`
@@ -106,17 +106,17 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Changed
 
-- Optimized `wasmi` bytecode memory consumption. (https://github.com/paritytech/wasmi/pull/718)
-  - This reduced the memory consumption of `wasmi` bytecode by organizing the instructions
+- Optimized Wasmi bytecode memory consumption. (https://github.com/paritytech/wasmi/pull/718)
+  - This reduced the memory consumption of Wasmi bytecode by organizing the instructions
     into so-called instruction words, effectively reducing the amount of bytes required per
-    `wasmi` instruction 16 bytes to 8 bytes.
+    Wasmi instruction 16 bytes to 8 bytes.
     There was an experiment with 4 bytes but experiments confirmed that 8 bytes per instruction
-    word was the sweetspot for `wasmi` execution and translation performance.
+    word was the sweetspot for Wasmi execution and translation performance.
   - This did not affect execution performance too much but we saw performance improvements
-    for translation from Wasm to `wasmi` bytecode by roughly 15-20%.
+    for translation from Wasm to Wasmi bytecode by roughly 15-20%.
 - Optimized `call` and `return_call` for Wasm module internal calls. (https://github.com/paritytech/wasmi/pull/724)
-  - `wasmi` bytecode now differentiates between calls to Wasm module internal functions
-    and imported functions which allows the `wasmi` bytecode executor to perform the common
+  - Wasmi bytecode now differentiates between calls to Wasm module internal functions
+    and imported functions which allows the Wasmi bytecode executor to perform the common
     internal calls more efficiently.
   - This led to an execution performance improvement across the board but especially for
     call intense workloads of up to 30% in some test cases.
@@ -138,7 +138,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 - Normalize fuel costs of all instructions. (https://github.com/paritytech/wasmi/pull/705)
   - With this change most instructions cost roughly 1 fuel upon execution.
     This is more similar to how Wasmtime deals with fuel metered instruction costs.
-    Before this change `wasmi` tried to have fuel costs that more closely mirror
+    Before this change Wasmi tried to have fuel costs that more closely mirror
     the computation intensity of the respective instruction according to benchmarks.
 
 ## [`0.28.0`] - 2023-03-01
@@ -160,7 +160,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Internal
 
-- Refactor the `wasmi` Wasm engine to handle Wasm calls and returns in its core. [(#694)]
+- Refactor the Wasmi Wasm engine to handle Wasm calls and returns in its core. [(#694)]
   - This improved performance of Wasm function calls significantly at the cost of host function call performance.
   - Also this seemed to have impacts Wasm target performance quite positively, too.
 - The `Store` now handles Wasm functions and host functions separately. (https://github.com/paritytech/wasmi/pull/686)
@@ -168,11 +168,11 @@ Dates in this file are formattes as `YYYY-MM-DD`.
     step towards the major refactoring in [(#694)]
   - It was expected that host function call performance would degrade by this PR but our tests
     actually showed that the opposite was true and Wasm target performance was improved overall.
-- Introduce `ValueStackPtr` abstraction for the `wasmi` engine core. (https://github.com/paritytech/wasmi/pull/688)
+- Introduce `ValueStackPtr` abstraction for the Wasmi engine core. (https://github.com/paritytech/wasmi/pull/688)
   - This change significantly improved performance especially on the Wasm target according to our tests.
 - Optimize `memory.{load,store}` when reading or writing single bytes. (https://github.com/paritytech/wasmi/pull/689)
   - The performance wins were more modest than we hoped but still measurable.
-- Use `StoreContextMut<T>` instead of `impl AsContextMut` in the `wasmi` engine core. (https://github.com/paritytech/wasmi/pull/685)
+- Use `StoreContextMut<T>` instead of `impl AsContextMut` in the Wasmi engine core. (https://github.com/paritytech/wasmi/pull/685)
   - This is a simple refactoring with the goal to make the Rust compiler have a simpler job at
     optimizing certain functions in the engine's inner workings since `StoreContextMut` provides
     more information to the compiler.
@@ -183,15 +183,15 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Added
 
-- Added support for fuel metering in the `wasmi` CLI. (https://github.com/paritytech/wasmi/pull/679)
+- Added support for fuel metering in the Wasmi CLI. (https://github.com/paritytech/wasmi/pull/679)
   - Users can now specify an amount of fuel via `--fuel N` to commit for the execution.
-    Upon success the `wasmi` CLI will display the total amount of consumed and remaining fuel.
+    Upon success the Wasmi CLI will display the total amount of consumed and remaining fuel.
 
 ### Fixed
 
-- Fixed a bug that `wasmi` CLI did not preserve the WASI exit status. (https://github.com/paritytech/wasmi/pull/677)
+- Fixed a bug that Wasmi CLI did not preserve the WASI exit status. (https://github.com/paritytech/wasmi/pull/677)
   - Thanks to [YAMAMOTO Takashi @yamt](https://github.com/yamt) for reporting the issue.
-- The `wasmi` CLI now properly displays exported functions if `--invoke x` was provided and `x` was not found. (https://github.com/paritytech/wasmi/pull/678)
+- The Wasmi CLI now properly displays exported functions if `--invoke x` was provided and `x` was not found. (https://github.com/paritytech/wasmi/pull/678)
 - Applied minor fixes to `Config` docs. (https://github.com/paritytech/wasmi/pull/673)
 
 ### Changed
@@ -214,12 +214,12 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Added
 
-- `wasmi` CLI: Add WASI support. (https://github.com/paritytech/wasmi/pull/597)
-  - Big shoutout to [Onigbinde Oluwamuyiwa Elijah](https://github.com/OLUWAMUYIWA) for contributing this to `wasmi`!
+- Wasmi CLI: Add WASI support. (https://github.com/paritytech/wasmi/pull/597)
+  - Big shoutout to [Onigbinde Oluwamuyiwa Elijah](https://github.com/OLUWAMUYIWA) for contributing this to Wasmi!
 - Add built-in support for fuel metering. (https://github.com/paritytech/wasmi/pull/653)
   - This allows to control the runtime of Wasm executions in a deterministic fasion
     effectively avoiding the halting problem by charging for executed instructions.
-    Not using the feature will not affect the execution efficiency of `wasmi` for users.
+    Not using the feature will not affect the execution efficiency of Wasmi for users.
 - Add `Pages::checked_sub` method. (https://github.com/paritytech/wasmi/pull/660)
 - Add `Func::new` constructor. (https://github.com/paritytech/wasmi/pull/662)
   - This allows to create `Func` instances from closures without statically known types.
@@ -245,7 +245,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Removed
 
-- Removed from `From` impls from `wasmparser-nostd` types to `wasmi` types.
+- Removed from `From` impls from `wasmparser-nostd` types to Wasmi types.
   - For example `From<wasmparser::FuncType> for wasmi::FuncType` got removed.
 
 ### Changed
@@ -255,7 +255,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Internal
 
-- Resolved plenty of technical debt and improved structure of the `wasmi` crate.
+- Resolved plenty of technical debt and improved structure of the Wasmi crate.
   - PRs: https://github.com/paritytech/wasmi/pull/648, https://github.com/paritytech/wasmi/pull/647, https://github.com/paritytech/wasmi/pull/646, https://github.com/paritytech/wasmi/pull/645, https://github.com/paritytech/wasmi/pull/644, https://github.com/paritytech/wasmi/pull/641
 
 ## [`0.24.0`] - 2023-01-31
@@ -281,7 +281,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 - Use more references in places to provide the compiler with more optimization opportunities. (https://github.com/paritytech/wasmi/pull/634)
   - This led to a speed-up across the board for Wasm targets of about 15-20%.
-- Move the `Value` type from `wasmi_core` to `wasmi`. (https://github.com/paritytech/wasmi/pull/636)
+- Move the `Value` type from `wasmi_core` to Wasmi. (https://github.com/paritytech/wasmi/pull/636)
   - This change was necessary in order to support the [`reference-types`] Wasm proposal.
 - There has been some consequences from implementing the [`reference-types`] Wasm proposal which are listed below:
   - The `Value` type no longer implements `Copy` and `PartialEq`.
@@ -366,7 +366,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
     which greatly simplifies the API surface for users.
   - The `UntypedValue` type gained some new methods to replace functionality
     that was provided in parts by the removed traits.
-- The `wasmi` crate now follows the Wasmtime API a bit more closely. (https://github.com/paritytech/wasmi/pull/613)
+- The Wasmi crate now follows the Wasmtime API a bit more closely. (https://github.com/paritytech/wasmi/pull/613)
   - `StoreContext` new methods:
     - `fn engine(&self) -> &Engine`
     - `fn data(&self) -> &T` 
@@ -389,26 +389,26 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 - Add support for resumable function calls. (https://github.com/paritytech/wasmi/pull/598)
   - This feature allows to resume a function call upon encountering a host trap.
-- Add support for concurrently running function executions using a single `wasmi` engine.
+- Add support for concurrently running function executions using a single Wasmi engine.
   - This feature also allows to call Wasm functions from host functions. (https://github.com/paritytech/wasmi/pull/590)
-- Add initial naive WASI support for `wasmi` using the new `wasmi_wasi` crate. (https://github.com/paritytech/wasmi/pull/557)
+- Add initial naive WASI support for Wasmi using the new `wasmi_wasi` crate. (https://github.com/paritytech/wasmi/pull/557)
   - Special thanks to [Onigbinde Oluwamuyiwa Elijah](https://github.com/OLUWAMUYIWA) for carrying the WASI support efforts!
   - Also thanks to [Yuyi Wang](https://github.com/Berrysoft) for testing and improving initial WASI support. (https://github.com/paritytech/wasmi/pull/592, https://github.com/paritytech/wasmi/pull/571, https://github.com/paritytech/wasmi/pull/568)
-  - **Note:** There is ongoing work to integrate WASI support in `wasmi_cli` so that the `wasmi` CLI will then
+  - **Note:** There is ongoing work to integrate WASI support in `wasmi_cli` so that the Wasmi CLI will then
               be able to execute arbitrary `wasm-wasi` files out of the box in the future.
 - Add `Module::imports` that allows to query Wasm module imports. (https://github.com/paritytech/wasmi/pull/573, https://github.com/paritytech/wasmi/pull/583)
 
 ### Fixed
 
 - Fix a bug that imported linear memories and tables were initialized twice upon instantiation. (https://github.com/paritytech/wasmi/pull/593)
-- The `wasmi` CLI now properly hints for file path arguments. (https://github.com/paritytech/wasmi/pull/596)
+- The Wasmi CLI now properly hints for file path arguments. (https://github.com/paritytech/wasmi/pull/596)
 
 ### Changed
 
 - The `wasmi::Trap` type is now more similar to Wasmtime's `Trap` type. (https://github.com/paritytech/wasmi/pull/559)
 - The `wasmi::Store` type is now `Send` and `Sync` as intended. (https://github.com/paritytech/wasmi/pull/566)
-- The `wasmi` CLI now prints exported functions names if the function name CLI argument is missing. (https://github.com/paritytech/wasmi/pull/579)
-- Improve feedback when running a Wasm module without exported function using `wasmi` CLI. (https://github.com/paritytech/wasmi/pull/584)
+- The Wasmi CLI now prints exported functions names if the function name CLI argument is missing. (https://github.com/paritytech/wasmi/pull/579)
+- Improve feedback when running a Wasm module without exported function using Wasmi CLI. (https://github.com/paritytech/wasmi/pull/584)
 
 ## [`0.20.0`] - 2022-11-04
 
@@ -430,7 +430,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 ### Changed
 
 - Fixed handling of edge cases with respect to Wasm linear memory. (https://github.com/paritytech/wasmi/pull/449)
-  - This allows for `wasmi` to properly setup and use linear memory instances of up to 4GB.
+  - This allows for Wasmi to properly setup and use linear memory instances of up to 4GB.
 - Optimize and improve Wasm instantiation. (https://github.com/paritytech/wasmi/pull/531)
 - Optimize `global.get` of immutable non-imported globals. (https://github.com/paritytech/wasmi/pull/533)
   - Also added a benchmark test for this. (https://github.com/paritytech/wasmi/pull/532)
@@ -439,7 +439,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 - Implemented miscellaneous improvements to our CI system.
   - https://github.com/paritytech/wasmi/pull/539 (and more)
-- Miscellaneous clean ups in `wasmi_core` and `wasmi`'s executor.
+- Miscellaneous clean ups in `wasmi_core` and Wasmi's executor.
   - https://github.com/paritytech/wasmi/pull/542 https://github.com/paritytech/wasmi/pull/541
   https://github.com/paritytech/wasmi/pull/508 https://github.com/paritytech/wasmi/pull/543
 
@@ -452,7 +452,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Changed
 
-- Optimized Wasm to `wasmi` translation phase by removing unnecessary Wasm
+- Optimized Wasm to Wasmi translation phase by removing unnecessary Wasm
   validation type checks. (https://github.com/paritytech/wasmi/pull/527)
     - Speedups were in the range of 15%.
 - `Linker::instantiate` now takes `&self` instead of `&mut self`. (https://github.com/paritytech/wasmi/pull/512)
@@ -470,7 +470,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
   - https://github.com/paritytech/wasmi/pull/525
   https://github.com/paritytech/wasmi/pull/526
   https://github.com/paritytech/wasmi/pull/521
-- Add `miri` testing to `wasmi` CI (https://github.com/paritytech/wasmi/pull/523)
+- Add `miri` testing to Wasmi CI (https://github.com/paritytech/wasmi/pull/523)
 
 ## [`0.18.1`] - 2022-10-13
 
@@ -504,7 +504,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Changed
 
-- Optimized instruction dispatch in the `wasmi` interpreter.
+- Optimized instruction dispatch in the Wasmi interpreter.
   (https://github.com/paritytech/wasmi/pull/478, https://github.com/paritytech/wasmi/pull/482)
   - This yielded combined speed-ups of ~20% across the board.
   - As a side effect we also refactored the way we compute branching offsets
@@ -513,9 +513,9 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Internal
 
-- Our CI now also benchmarks `wasmi` when ran inside Wasmtime as Wasm.
+- Our CI now also benchmarks Wasmi when ran inside Wasmtime as Wasm.
   (https://github.com/paritytech/wasmi/pull/483, https://github.com/paritytech/wasmi/pull/487)
-  - This allows us to optimize `wasmi` towards Wasm performance more easily in the future.
+  - This allows us to optimize Wasmi towards Wasm performance more easily in the future.
 
 ## [`0.17.0`] - 2022-09-23
 
@@ -532,7 +532,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
     - We measured a performance improvement of 6000% or in other words those
       instructions are now 60 times faster than before.
     - This allowed us to remove the big `num-rational` dependency from `wasmi_core`
-      for some nice speed-ups in compilation time of `wasmi` itself.
+      for some nice speed-ups in compilation time of Wasmi itself.
 - Optimized `global.get` and `global.set` Wasm instruction execution. (https://github.com/paritytech/wasmi/pull/427)
     - This improved performance of those instructions by up to 17%.
 - Optimized Wasm value stack emulation. (https://github.com/paritytech/wasmi/pull/459)
@@ -540,14 +540,14 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Internal
 
-- Added automated continuous benchmarking to `wasmi`. (https://github.com/paritytech/wasmi/pull/422)
-    - This allows us to have a more consistent overview over the performance of `wasmi`.
+- Added automated continuous benchmarking to Wasmi. (https://github.com/paritytech/wasmi/pull/422)
+    - This allows us to have a more consistent overview over the performance of Wasmi.
 - Updated `criterion` benchmarking framework to version `0.4.0`.
 - Reuse allocations during Wasm validation and translation:
      - Wasm validation and translation combined. (https://github.com/paritytech/wasmi/pull/462)
      - Wasm `br_table` translations. (https://github.com/paritytech/wasmi/pull/440)
-- Enabled more useful `clippy` lints for `wasmi` and `wasmi_core`. (https://github.com/paritytech/wasmi/pull/438)
-- Reorganized the `wasmi` workspace. (https://github.com/paritytech/wasmi/pull/466)
+- Enabled more useful `clippy` lints for Wasmi and `wasmi_core`. (https://github.com/paritytech/wasmi/pull/438)
+- Reorganized the Wasmi workspace. (https://github.com/paritytech/wasmi/pull/466)
 
 ## [`0.16.0`] - 2022-08-30
 
@@ -555,22 +555,22 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 - Update `wasmparser-nostd` dependency from version `0.83.0` -> `0.90.0`.
   [**Link:**](https://github.com/paritytech/wasmi/commit/e9b0463817e277cd9daccca7e66e52e4fd147d8e)
-    - This significantly improved `wasmi`'s Wasm parsing, validation and
-      Wasm to `wasmi` bytecode translation performance.
+    - This significantly improved Wasmi's Wasm parsing, validation and
+      Wasm to Wasmi bytecode translation performance.
 
 ### Internal
 
 - Transition to the new `wasmparser::VisitOperator` API.
   [**Link**](https://github.com/paritytech/wasmi/commit/225c8224729661ea091e650e3278c4980bd1d405)
-    - This again significantly improved `wasmi`'s Wasm parsing, validation and
-      Wasm to `wasmi` bytecode translation performance by avoiding many
+    - This again significantly improved Wasmi's Wasm parsing, validation and
+      Wasm to Wasmi bytecode translation performance by avoiding many
       unnecessary unpredictable branches in the process.
 
 ## [`0.15.0`] - 2022-08-22
 
 ### Fixed
 
-- Fixed bugs found during fuzzing the translation phase of `wasmi`.
+- Fixed bugs found during fuzzing the translation phase of Wasmi.
   [**Link**](https://github.com/paritytech/wasmi/commit/43d7037745a266ece2baccd9e78f7d983dacbb93)
 - Fix `Read` trait implementation for `no_std` compilations.
   [**Link**](https://github.com/paritytech/wasmi/commit/baab359de955240fbb9c89ebbc369d7a6e6d8569)
@@ -597,21 +597,21 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 - The `wasmi::Engine` now caches the bytes of the default linear memory for
   performance wins in `memory.store` and `memory.load` intense work loads.
   [**Link**](https://github.com/paritytech/wasmi/commit/c0df344e970bcdd4c6ce25f64265c854a1239220)
-- The `wasmi` engine internals have been reorganized and modernised to improve
+- The Wasmi engine internals have been reorganized and modernised to improve
   performance on function call intense work loads. This resulted in performance
   improvements across the board.
   [**Link**](https://github.com/paritytech/wasmi/commit/d789570b51effb3a0c397c2d4ea1dc03c5d76918)
-- The Wasm to `wasmi` bytecode translation now properly reuses heap allocations
+- The Wasm to Wasmi bytecode translation now properly reuses heap allocations
   across function translation units which improved translation performance by
   roughly 10%.
   [**Link**](https://github.com/paritytech/wasmi/commit/71a913fc508841b3b7f799c8e4406e1e48feb046)
-- Optimized the `wasmi` engine Wasm value stack implementation for significant
+- Optimized the Wasmi engine Wasm value stack implementation for significant
   performance wins across the board.
   [**Link**](https://github.com/paritytech/wasmi/commit/3886d9190e89d44a701ad5cbbda0c7457feba510)
 - Shrunk size of some internal identifier types for minor performance wins.
   [**Link**](https://github.com/paritytech/wasmi/commit/3d544b82a5089ae4331024b1e6762dcb48a02898)
 - Added initial naive fuzz testing for Wasm parsing, validation and Wasm to
-  `wasmi` bytecode translation.
+  Wasmi bytecode translation.
   [**Link**](https://github.com/paritytech/wasmi/commit/4d1f2ad6cbf07e61656185101bbd0bd5a941335f)
 
 ## [`0.14.0`] - 2022-07-26
@@ -638,12 +638,12 @@ Dates in this file are formattes as `YYYY-MM-DD`.
   using the battle tested [`wasmparser`](https://crates.io/crates/wasmparser)
   crate by the BytecodeAlliance.
 
-  The new `wasmi` design allows to reuse the Wasm execution engine
+  The new Wasmi design allows to reuse the Wasm execution engine
   resources instead of spinning up a new Wasm execution engine for every
   function call.
 
-  **Note:** If you plan to use `wasmi` it is of critical importance
-  to compile `wasmi` using the following Cargo `profile` settings:
+  **Note:** If you plan to use Wasmi it is of critical importance
+  to compile Wasmi using the following Cargo `profile` settings:
 
   ```toml
   [profile.release]
@@ -652,14 +652,14 @@ Dates in this file are formattes as `YYYY-MM-DD`.
   ```
 
   If you do not use these profile settings you might risk regressing
-  performance of `wasmi` by up to 400%. You can read more about this
+  performance of Wasmi by up to 400%. You can read more about this
   issue [here](https://github.com/paritytech/wasmi/issues/339).
 
 ### Removed
 
 - Removed support for resuming function execution.
   We may consider to add this feature back into the new engine.
-  If you are a user of `wasmi` and want this feature please feel
+  If you are a user of Wasmi and want this feature please feel
   free to [open an issue](https://github.com/paritytech/wasmi/issues)
   and provide us with your use case.
 
@@ -675,7 +675,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ## [`0.13.0`] - 2022-07-25
 
-**Note:** This is the last major release of the legacy `wasmi` engine.
+**Note:** This is the last major release of the legacy Wasmi engine.
           Future releases are using the new Wasm execution engines
           that are currently in development.
           We may consider to publish new major versions of this Wasm engine
@@ -689,14 +689,14 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Changed
 
-- `wasmi` now depends on the [`wasmi_core`](https://crates.io/crates/wasmi_core) crate.
+- Wasmi now depends on the [`wasmi_core`](https://crates.io/crates/wasmi_core) crate.
 - Deprecated `RuntimeValue::decode_{f32,f64}` methods.
     - **Reason**: These methods expose details about the `F32` and `F64` types.
                   The `RuntimeValue` type provides `from_bits` methods for similar purposes.
     - **Replacement:** Replace those deprecated methods with `F{32,64}::from_bits().into()` respectively.
-- Refactor traps in `wasmi`: [PR](https://github.com/paritytech/wasmi/commit/cd59462bc946a52a7e3e4db491ac6675e3a2f53f)
+- Refactor traps in Wasmi: [PR](https://github.com/paritytech/wasmi/commit/cd59462bc946a52a7e3e4db491ac6675e3a2f53f)
     - This change also renames `TrapKind` to `TrapCode`.
-    - The `wasmi` crate now properly reuses the `TrapCode` definitions from the `wasmi_core` crate.
+    - The Wasmi crate now properly reuses the `TrapCode` definitions from the `wasmi_core` crate.
 - Updated dependency:
     - `parity-wasm v0.42 -> v0.45`
     - `memory_units v0.3.0 -> v0.4.0`
@@ -714,7 +714,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Fixed
 
-- Make `wasmi` traps more conformant with the Wasm specification. (https://github.com/paritytech/wasmi/pull/300)
+- Make Wasmi traps more conformant with the Wasm specification. (https://github.com/paritytech/wasmi/pull/300)
 - Fixed a bug in `{f32, f64}_copysign` implementations. (https://github.com/paritytech/wasmi/pull/293)
 - Fixed a bug in `{f32, f64}_{min, max}` implementations. (https://github.com/paritytech/wasmi/pull/295)
 
@@ -743,7 +743,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 
 ### Changed
 
-- The `wasmi` and `wasmi-validation` crates now both use Rust edition 2021.
+- The Wasmi and `wasmi-validation` crates now both use Rust edition 2021.
 - The `README` now better teaches how to test and benchmark the crate.
 - Updated `num-rational` from version `0.2.2` -> `0.4.0`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,28 @@
 # Contribution Guidelines
 
-First of all, thank you for taking your time to contribute to `wasmi`!
+First of all, thank you for taking your time to contribute to Wasmi!
 
 Reading these contribution guidelines is your best initial step towards
-successfully driving the development of `wasmi` forward with your own ideas
+successfully driving the development of Wasmi forward with your own ideas
 and use cases.
 
 ## Code of Conduct
 
 Please respect our [code of conduct](./CODE_OF_CONDUCT.md) in every
-communication and discussion related to the `wasmi` project.
+communication and discussion related to the Wasmi project.
 
 ## I don't want to contribute, I just have some questions
 
-For technical questions about `wasmi` feel free to contact
+For technical questions about Wasmi feel free to contact
 us via one of the following communication channels:
 
 - GitHub Discussions
     - Write a [**new GitHub Discussions post**](https://github.com/paritytech/wasmi/discussions/new).
-    - For simple questions around usage or development of `wasmi`.
+    - For simple questions around usage or development of Wasmi.
 - Polkadot Forums
     - Write a new post in the [**Polkadot Forum**](https://forum.polkadot.network/).
     - For public Pokadot, smart contract, ink! or `pallet-contracts`
-      related `wasmi` questions.
+      related Wasmi questions.
 - GitHub Issue
     - Write a [**new GitHub issue**](https://github.com/paritytech/wasmi/issues/new).
     - To initiate a technical (design) discussion or debate.
@@ -40,7 +40,7 @@ People from all around the globe with different cultures and native tongues
 come together to work towards a common goal.
 
 English naturally is the language of choice for developing and communicating
-technicalities concerning `wasmi`. If you feel like your English skills are not
+technicalities concerning Wasmi. If you feel like your English skills are not
 on par to properly communicate your intent don't feel ashamed to use any of
 the well known translators in order to make everyone's lifes simpler.
 Feeding properly articulated sentences in your language to an established
@@ -48,7 +48,7 @@ translation engine usually yields good translation results.
 
 ## Feature Development
 
-Before developing a new feature for the `wasmi` interpreter on your own
+Before developing a new feature for the Wasmi interpreter on your own
 we recommend checking in on the maintainers via a GitHub issue to discuss
 your proposed feature in technical details.
 Maintainers usually have a fundamental understanding of the codebase and
@@ -75,7 +75,7 @@ components installed via `rustup component add`:
 Furthermore you are going to need `git` version control on your system which
 you usually can install via your package manager.
 
-Checkout the `wasmi` repository using
+Checkout the Wasmi repository using
 ```
 git clone git@github.com:paritytech/wasmi.git
 ```
@@ -99,7 +99,7 @@ they need in order to help unblock you.
 
 ### Fuzz Testing
 
-Run `wasmi` fuzz tests using the following command:
+Run Wasmi fuzz tests using the following command:
 
 ```
 cargo +nightly fuzz run <target>
@@ -110,7 +110,7 @@ does not work on the stable Rust channel.
 
 ## Optimizations
 
-If you are working on changes that are going to optimize any part of the `wasmi`
+If you are working on changes that are going to optimize any part of the Wasmi
 interpreter please provide proper benchmarks and make sure that the optimized
 code parts are properly tested.
 

--- a/README.md
+++ b/README.md
@@ -15,30 +15,30 @@
 [license-mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license-apache-badge]: https://img.shields.io/badge/license-APACHE-orange.svg
 
-# `wasmi`- WebAssembly (Wasm) Interpreter
+# Wasmi- WebAssembly (Wasm) Interpreter
 
 <p align="center">
   <img src="./resources/wasmi-logo.png" width="100" height="100">
 </p>
 
-`wasmi` is an efficient WebAssembly interpreter with low-overhead and support
+Wasmi is an efficient WebAssembly interpreter with low-overhead and support
 for embedded environment such as WebAssembly itself.
 
-At Parity we are using `wasmi` in [Substrate](https://github.com/paritytech/substrate)
+At Parity we are using Wasmi in [Substrate](https://github.com/paritytech/substrate)
 as the execution engine for our WebAssembly based smart contracts.
-Furthermore we run `wasmi` within the Substrate runtime which is a WebAssembly
+Furthermore we run Wasmi within the Substrate runtime which is a WebAssembly
 environment itself and driven via [Wasmtime] at the time of this writing.
-As such `wasmi`'s implementation requires a high degree of correctness and
+As such Wasmi's implementation requires a high degree of correctness and
 Wasm specification conformance.
 
-Since `wasmi` is relatively lightweight compared to other Wasm virtual machines
+Since Wasmi is relatively lightweight compared to other Wasm virtual machines
 such as Wasmtime it is also a decent option for initial prototyping.
 
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
 
 ## Distinct Features
 
-The following list states some of the distinct features of `wasmi`.
+The following list states some of the distinct features of Wasmi.
 
 - Focus on simple, correct and deterministic WebAssembly execution.
 - Can itself run inside of WebAssembly.
@@ -50,7 +50,7 @@ The following list states some of the distinct features of `wasmi`.
 
 ## WebAssembly Proposals
 
-The new `wasmi` engine supports a variety of WebAssembly proposals and will support even more of them in the future.
+The new Wasmi engine supports a variety of WebAssembly proposals and will support even more of them in the future.
 
 | WebAssembly Proposal | Status | Comment |
 |:--|:--:|:--|
@@ -69,7 +69,7 @@ The new `wasmi` engine supports a variety of WebAssembly proposals and will supp
 | [`threads`] | 📅 | Planned but not yet implemented. [(#777)] |
 | [`relaxed-simd`] | ❌ | Unlikely to be supported since `simd` is unlikely to be supported. |
 | | |
-| [WASI] | 👨‍🔬 | Experimental support via the [`wasmi_wasi` crate] or the `wasmi` CLI application. |
+| [WASI] | 👨‍🔬 | Experimental support via the [`wasmi_wasi` crate] or the Wasmi CLI application. |
 
 [`mutable-global`]: https://github.com/WebAssembly/mutable-global
 [`saturating-float-to-int`]: https://github.com/WebAssembly/nontrapping-float-to-int-conversions
@@ -106,7 +106,7 @@ The new `wasmi` engine supports a variety of WebAssembly proposals and will supp
 
 ### As CLI Application
 
-Install the newest `wasmi` CLI version via:
+Install the newest Wasmi CLI version via:
 ```console
 cargo install wasmi_cli
 ```
@@ -117,16 +117,16 @@ wasmi_cli <WASM_FILE> <FUNC_NAME> [<FUNC_ARGS>]*
 
 ### As Rust Library
 
-Any Rust crate can depend on the [`wasmi` crate](https://crates.io/crates/wasmi)
+Any Rust crate can depend on the [Wasmi crate](https://crates.io/crates/wasmi)
 in order to integrate a WebAssembly intepreter into their stack.
 
-Refer to the [`wasmi` crate docs](https://docs.rs/wasmi) to learn how to use the `wasmi` crate as library.
+Refer to the [Wasmi crate docs](https://docs.rs/wasmi) to learn how to use the Wasmi crate as library.
 
 ## Development
 
 ### Building
 
-Clone `wasmi` from our official repository and then build using the standard `cargo` procedure:
+Clone Wasmi from our official repository and then build using the standard `cargo` procedure:
 
 ```console
 git clone https://github.com/paritytech/wasmi.git
@@ -136,7 +136,7 @@ cargo build
 
 ### Testing
 
-In order to test `wasmi` you need to initialize and update the Git submodules using:
+In order to test Wasmi you need to initialize and update the Git submodules using:
 
 ```console
 git submodule update --init --recursive
@@ -156,7 +156,7 @@ cargo test --workspace
 
 ### Benchmarks
 
-In order to benchmark `wasmi` use the following command:
+In order to benchmark Wasmi use the following command:
 
 ```console
 cargo bench
@@ -177,7 +177,7 @@ We maintain a timeline for benchmarks of every commit to `master` that [can be v
 ## Supported Platforms
 
 Supported platforms are primarily Linux, MacOS, Windows and WebAssembly.  
-Other platforms might be working but are not guaranteed to be so by the `wasmi` maintainers.
+Other platforms might be working but are not guaranteed to be so by the Wasmi maintainers.
 
 Use the following command in order to produce a WebAssembly build:
 
@@ -187,8 +187,8 @@ cargo build --no-default-features --target wasm32-unknown-unknown
 
 ## Production Builds
 
-In order to reap the most performance out of `wasmi` we highly recommended
-to compile the `wasmi` crate using the following Cargo `profile`:
+In order to reap the most performance out of Wasmi we highly recommended
+to compile the Wasmi crate using the following Cargo `profile`:
 
 ```toml
 [profile.release]
@@ -197,7 +197,7 @@ codegen-units = 1
 ```
 
 When compiling for the WebAssembly target we highly recommend to post-optimize
-`wasmi` using [Binaryen]'s `wasm-opt` tool since our experiments displayed a
+Wasmi using [Binaryen]'s `wasm-opt` tool since our experiments displayed a
 80-100% performance improvements when executed under Wasmtime and also
 slightly smaller Wasm binaries.
 
@@ -205,7 +205,7 @@ slightly smaller Wasm binaries.
 
 ## License
 
-`wasmi` is primarily distributed under the terms of both the MIT
+Wasmi is primarily distributed under the terms of both the MIT
 license and the APACHE license (Version 2.0), at your choice.
 
 See `LICENSE-APACHE` and `LICENSE-MIT` for details.
@@ -213,5 +213,5 @@ See `LICENSE-APACHE` and `LICENSE-MIT` for details.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `wasmi` by you, as defined in the APACHE 2.0 license, shall be
+for inclusion in Wasmi by you, as defined in the APACHE 2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -36,7 +36,7 @@ impl FromStr for KeyValue {
     }
 }
 
-/// The `wasmi` CLI application arguments.
+/// The Wasmi CLI application arguments.
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None, trailing_var_arg = true)]
 pub struct Args {
@@ -75,9 +75,9 @@ pub struct Args {
 
     /// The function to invoke.
     ///
-    /// If this argument is missing, `wasmi` CLI will try to run `""` or `_start`.
+    /// If this argument is missing, Wasmi CLI will try to run `""` or `_start`.
     ///
-    /// If neither are exported the `wasmi` CLI will display out all exported
+    /// If neither are exported the Wasmi CLI will display out all exported
     /// functions of the Wasm module and return with an error.
     #[clap(long = "invoke", value_name = "FUNCTION")]
     invoke: Option<String>,

--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use wasmi::{CompilationMode, Config, ExternType, Func, FuncType, Instance, Module, Store};
 use wasmi_wasi::WasiCtx;
 
-/// The [`Context`] for the `wasmi` CLI application.
+/// The [`Context`] for the Wasmi CLI application.
 ///
 /// This simply stores all the necessary data.
 pub struct Context {

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -280,7 +280,7 @@ pub enum TrapCode {
 
     /// This trap is raised when a WebAssembly execution ran out of fuel.
     ///
-    /// The `wasmi` execution engine can be configured to instrument its
+    /// The Wasmi execution engine can be configured to instrument its
     /// internal bytecode so that fuel is consumed for each executed instruction.
     /// This is useful to deterministically halt or yield a WebAssembly execution.
     OutOfFuel,

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,6 +1,6 @@
-//! This crate provides support for WASI `preview1` for the `wasmi` interpreter.
+//! This crate provides support for WASI `preview1` for the Wasmi interpreter.
 //!
-//! Use [`add_to_linker`] to add all supported WASI definitions to the `wasmi` linker.
+//! Use [`add_to_linker`] to add all supported WASI definitions to the Wasmi linker.
 
 mod guest_memory;
 

--- a/crates/wasmi/benches/bench/mod.rs
+++ b/crates/wasmi/benches/bench/mod.rs
@@ -5,7 +5,7 @@ use wasmi::{Config, StackLimits};
 ///
 /// # Note
 ///
-/// This includes validation and compilation to `wasmi` bytecode.
+/// This includes validation and compilation to Wasmi bytecode.
 ///
 /// # Panics
 ///
@@ -28,11 +28,11 @@ pub fn bench_config() -> Config {
     config
 }
 
-/// Parses the Wasm binary at the given `file_name` into a `wasmi` module.
+/// Parses the Wasm binary at the given `file_name` into a Wasmi module.
 ///
 /// # Note
 ///
-/// This includes validation and compilation to `wasmi` bytecode.
+/// This includes validation and compilation to Wasmi bytecode.
 ///
 /// # Panics
 ///
@@ -48,11 +48,11 @@ pub fn load_module_from_file(file_name: &str) -> wasmi::Module {
     })
 }
 
-/// Parses the Wasm binary from the given `file_name` into a `wasmi` module.
+/// Parses the Wasm binary from the given `file_name` into a Wasmi module.
 ///
 /// # Note
 ///
-/// This includes validation and compilation to `wasmi` bytecode.
+/// This includes validation and compilation to Wasmi bytecode.
 ///
 /// # Panics
 ///
@@ -74,11 +74,11 @@ pub fn wat2wasm(bytes: &[u8]) -> Vec<u8> {
     wat::parse_bytes(bytes).unwrap().into_owned()
 }
 
-/// Parses the Wasm source from the given `.wat` bytes into a `wasmi` module.
+/// Parses the Wasm source from the given `.wat` bytes into a Wasmi module.
 ///
 /// # Note
 ///
-/// This includes validation and compilation to `wasmi` bytecode.
+/// This includes validation and compilation to Wasmi bytecode.
 ///
 /// # Panics
 ///

--- a/crates/wasmi/src/engine/bytecode/immediate.rs
+++ b/crates/wasmi/src/engine/bytecode/immediate.rs
@@ -492,7 +492,7 @@ impl From<AnyConst16> for u64 {
 /// Upon use the small 32-bit value has to be sign-extended to
 /// the actual integer type, e.g. `i32` or `i64`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[repr(align(2))] // 2-byte alignment is sufficient for `wasmi` bytecode
+#[repr(align(2))] // 2-byte alignment is sufficient for Wasmi bytecode
 pub struct AnyConst32([u8; 4]);
 
 impl TryFrom<u64> for AnyConst32 {

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -45,16 +45,16 @@ use crate::{engine::CompiledFunc, Error};
 use core::num::{NonZeroI32, NonZeroI64, NonZeroU32, NonZeroU64};
 use wasmi_core::TrapCode;
 
-/// A `wasmi` instruction.
+/// A Wasmi instruction.
 ///
-/// Actually `wasmi` instructions are composed of so-called instruction words.
+/// Actually Wasmi instructions are composed of so-called instruction words.
 /// In fact this type represents single instruction words but for simplicity
 /// we call the type [`Instruction`] still.
 /// Most instructions are composed of a single instruction words. An example of
 /// this is [`Instruction::I32Add`]. However, some instructions like
 /// [`Instruction::Select`] are composed of two or more instruction words.
-/// The `wasmi` bytecode translation phase makes sure that those instruction words
-/// always appear in valid sequences. The `wasmi` executor relies on this guarantee.
+/// The Wasmi bytecode translation phase makes sure that those instruction words
+/// always appear in valid sequences. The Wasmi executor relies on this guarantee.
 /// The documentation of each [`Instruction`] variant describes its encoding in the
 /// `#Encoding` section of its documentation if it requires more than a single
 /// instruction word for its encoding.
@@ -658,7 +658,7 @@ pub enum Instruction {
     ///
     /// # Note
     ///
-    /// This is a `wasmi` utility instruction used to translate Wasm control flow.
+    /// This is a Wasmi utility instruction used to translate Wasm control flow.
     Copy {
         /// The register holding the result of the instruction.
         result: Register,
@@ -669,7 +669,7 @@ pub enum Instruction {
     ///
     /// # Note
     ///
-    /// This is a `wasmi` utility instruction used to translate Wasm control flow.
+    /// This is a Wasmi utility instruction used to translate Wasm control flow.
     Copy2 {
         /// The registers holding the result of the instruction.
         results: RegisterSpan,
@@ -772,7 +772,7 @@ pub enum Instruction {
         values: [Register; 2],
     },
 
-    /// Wasm `return_call` equivalent `wasmi` instruction.
+    /// Wasm `return_call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -781,7 +781,7 @@ pub enum Instruction {
         /// The called internal function.
         func: CompiledFunc,
     },
-    /// Wasm `return_call` equivalent `wasmi` instruction.
+    /// Wasm `return_call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -801,7 +801,7 @@ pub enum Instruction {
         func: CompiledFunc,
     },
 
-    /// Wasm `return_call` equivalent `wasmi` instruction.
+    /// Wasm `return_call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -810,7 +810,7 @@ pub enum Instruction {
         /// The called imported function.
         func: FuncIdx,
     },
-    /// Wasm `return_call` equivalent `wasmi` instruction.
+    /// Wasm `return_call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -830,7 +830,7 @@ pub enum Instruction {
         func: FuncIdx,
     },
 
-    /// Wasm `return_call_indirect` equivalent `wasmi` instruction.
+    /// Wasm `return_call_indirect` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -847,7 +847,7 @@ pub enum Instruction {
         /// The called internal function.
         func_type: SignatureIdx,
     },
-    /// Wasm `return_call_indirect` equivalent `wasmi` instruction.
+    /// Wasm `return_call_indirect` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -870,7 +870,7 @@ pub enum Instruction {
         func_type: SignatureIdx,
     },
 
-    /// Wasm `call` equivalent `wasmi` instruction.
+    /// Wasm `call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -881,7 +881,7 @@ pub enum Instruction {
         /// The called internal function.
         func: CompiledFunc,
     },
-    /// Wasm `call` equivalent `wasmi` instruction.
+    /// Wasm `call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -903,7 +903,7 @@ pub enum Instruction {
         func: CompiledFunc,
     },
 
-    /// Wasm `call` equivalent `wasmi` instruction.
+    /// Wasm `call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -914,7 +914,7 @@ pub enum Instruction {
         /// The called imported function.
         func: FuncIdx,
     },
-    /// Wasm `call` equivalent `wasmi` instruction.
+    /// Wasm `call` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -936,7 +936,7 @@ pub enum Instruction {
         func: FuncIdx,
     },
 
-    /// Wasm `call_indirect` equivalent `wasmi` instruction.
+    /// Wasm `call_indirect` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -955,7 +955,7 @@ pub enum Instruction {
         /// The called internal function.
         func_type: SignatureIdx,
     },
-    /// Wasm `call_indirect` equivalent `wasmi` instruction.
+    /// Wasm `call_indirect` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -1068,7 +1068,7 @@ pub enum Instruction {
         lhs_or_rhs: Const32<f64>,
     },
 
-    /// A Wasm `ref.func` equivalent `wasmi` instruction.
+    /// A Wasm `ref.func` equivalent Wasmi instruction.
     RefFunc {
         /// The register storing the result of the instruction.
         result: Register,
@@ -1516,9 +1516,9 @@ pub enum Instruction {
         value: Register,
     },
 
-    /// A Wasm `elem.drop` equalivalent `wasmi` instruction.
+    /// A Wasm `elem.drop` equalivalent Wasmi instruction.
     ElemDrop(ElementSegmentIdx),
-    /// A Wasm `data.drop` equalivalent `wasmi` instruction.
+    /// A Wasm `data.drop` equalivalent Wasmi instruction.
     DataDrop(DataSegmentIdx),
 
     /// Wasm `memory.size` instruction.
@@ -1831,21 +1831,21 @@ pub enum Instruction {
         len: Const16<u32>,
     },
 
-    /// Wasm `global.get` equivalent `wasmi` instruction.
+    /// Wasm `global.get` equivalent Wasmi instruction.
     GlobalGet {
         /// The register storing the result of the instruction.
         result: Register,
         /// The index identifying the global variable for the `global.get` instruction.
         global: GlobalIdx,
     },
-    /// Wasm `global.set` equivalent `wasmi` instruction.
+    /// Wasm `global.set` equivalent Wasmi instruction.
     GlobalSet {
         /// The index identifying the global variable for the `global.set` instruction.
         global: GlobalIdx,
         /// The register holding the value to be stored in the global variable.
         input: Register,
     },
-    /// Wasm `global.set` equivalent `wasmi` instruction.
+    /// Wasm `global.set` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -1856,7 +1856,7 @@ pub enum Instruction {
         /// The 16-bit encoded `i32` value.
         input: Const16<i32>,
     },
-    /// Wasm `global.set` equivalent `wasmi` instruction.
+    /// Wasm `global.set` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
@@ -1868,287 +1868,287 @@ pub enum Instruction {
         input: Const16<i64>,
     },
 
-    /// Wasm `i32.load` equivalent `wasmi` instruction.
+    /// Wasm `i32.load` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I32Load(LoadInstr),
-    /// Wasm `i32.load` equivalent `wasmi` instruction.
+    /// Wasm `i32.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load`] with a constant load address.
     I32LoadAt(LoadAtInstr),
-    /// Wasm `i32.load` equivalent `wasmi` instruction.
+    /// Wasm `i32.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load`] for small offset values.
     I32LoadOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load` equivalent `wasmi` instruction.
+    /// Wasm `i64.load` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load(LoadInstr),
-    /// Wasm `i64.load` equivalent `wasmi` instruction.
+    /// Wasm `i64.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load`] with a constant load address.
     I64LoadAt(LoadAtInstr),
-    /// Wasm `i64.load` equivalent `wasmi` instruction.
+    /// Wasm `i64.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load`] for small offset values.
     I64LoadOffset16(LoadOffset16Instr),
 
-    /// Wasm `f32.load` equivalent `wasmi` instruction.
+    /// Wasm `f32.load` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     F32Load(LoadInstr),
-    /// Wasm `f32.load` equivalent `wasmi` instruction.
+    /// Wasm `f32.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::F32Load`] with a constant load address.
     F32LoadAt(LoadAtInstr),
-    /// Wasm `f32.load` equivalent `wasmi` instruction.
+    /// Wasm `f32.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::F32Load`] for small offset values.
     F32LoadOffset16(LoadOffset16Instr),
 
-    /// Wasm `f64.load` equivalent `wasmi` instruction.
+    /// Wasm `f64.load` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     F64Load(LoadInstr),
-    /// Wasm `f64.load` equivalent `wasmi` instruction.
+    /// Wasm `f64.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::F64Load`] with a constant load address.
     F64LoadAt(LoadAtInstr),
-    /// Wasm `f64.load` equivalent `wasmi` instruction.
+    /// Wasm `f64.load` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::F64Load`] for small offset values.
     F64LoadOffset16(LoadOffset16Instr),
 
-    /// Wasm `i32.load8_s` equivalent `wasmi` instruction.
+    /// Wasm `i32.load8_s` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I32Load8s(LoadInstr),
-    /// Wasm `i32.load8_s` equivalent `wasmi` instruction.
+    /// Wasm `i32.load8_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load8s`] with a constant load address.
     I32Load8sAt(LoadAtInstr),
-    /// Wasm `i32.load8_s` equivalent `wasmi` instruction.
+    /// Wasm `i32.load8_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load8s`] for small offset values.
     I32Load8sOffset16(LoadOffset16Instr),
 
-    /// Wasm `i32.load8_u` equivalent `wasmi` instruction.
+    /// Wasm `i32.load8_u` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I32Load8u(LoadInstr),
-    /// Wasm `i32.load8_u` equivalent `wasmi` instruction.
+    /// Wasm `i32.load8_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load8u`] with a constant load address.
     I32Load8uAt(LoadAtInstr),
-    /// Wasm `i32.load8_u` equivalent `wasmi` instruction.
+    /// Wasm `i32.load8_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load8u`] for small offset values.
     I32Load8uOffset16(LoadOffset16Instr),
 
-    /// Wasm `i32.load16_s` equivalent `wasmi` instruction.
+    /// Wasm `i32.load16_s` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I32Load16s(LoadInstr),
-    /// Wasm `i32.load16_s` equivalent `wasmi` instruction.
+    /// Wasm `i32.load16_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load16s`] with a constant load address.
     I32Load16sAt(LoadAtInstr),
-    /// Wasm `i32.load16_s` equivalent `wasmi` instruction.
+    /// Wasm `i32.load16_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load16s`] for small offset values.
     I32Load16sOffset16(LoadOffset16Instr),
 
-    /// Wasm `i32.load16_u` equivalent `wasmi` instruction.
+    /// Wasm `i32.load16_u` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I32Load16u(LoadInstr),
-    /// Wasm `i32.load16_u` equivalent `wasmi` instruction.
+    /// Wasm `i32.load16_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load16u`] with a constant load address.
     I32Load16uAt(LoadAtInstr),
-    /// Wasm `i32.load16_u` equivalent `wasmi` instruction.
+    /// Wasm `i32.load16_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I32Load16u`] for small offset values.
     I32Load16uOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load8_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load8_s` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load8s(LoadInstr),
-    /// Wasm `i64.load8_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load8_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load8s`] with a constant load address.
     I64Load8sAt(LoadAtInstr),
-    /// Wasm `i64.load8_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load8_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load8s`] for small offset values.
     I64Load8sOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load8_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load8_u` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load8u(LoadInstr),
-    /// Wasm `i64.load8_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load8_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load8u`] with a constant load address.
     I64Load8uAt(LoadAtInstr),
-    /// Wasm `i64.load8_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load8_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load8u`] for small offset values.
     I64Load8uOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load16_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load16_s` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load16s(LoadInstr),
-    /// Wasm `i64.load16_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load16_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load16s`] with a constant load address.
     I64Load16sAt(LoadAtInstr),
-    /// Wasm `i64.load16_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load16_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load16s`] for small offset values.
     I64Load16sOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load16_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load16_u` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load16u(LoadInstr),
-    /// Wasm `i64.load16_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load16_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load16u`] with a constant load address.
     I64Load16uAt(LoadAtInstr),
-    /// Wasm `i64.load16_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load16_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load16u`] for small offset values.
     I64Load16uOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load32_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load32_s` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load32s(LoadInstr),
-    /// Wasm `i64.load32_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load32_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load32s`] with a constant load address.
     I64Load32sAt(LoadAtInstr),
-    /// Wasm `i64.load32_s` equivalent `wasmi` instruction.
+    /// Wasm `i64.load32_s` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load32s`] for small offset values.
     I64Load32sOffset16(LoadOffset16Instr),
 
-    /// Wasm `i64.load32_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load32_u` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::Const32`]
     /// that represents the `offset` for the load/store operation.
     I64Load32u(LoadInstr),
-    /// Wasm `i64.load32_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load32_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load32u`] with a constant load address.
     I64Load32uAt(LoadAtInstr),
-    /// Wasm `i64.load32_u` equivalent `wasmi` instruction.
+    /// Wasm `i64.load32_u` equivalent Wasmi instruction.
     ///
     /// # Note
     ///
     /// Variant of [`Instruction::I64Load32u`] for small offset values.
     I64Load32uOffset16(LoadOffset16Instr),
 
-    /// Wasm `i32.store` equivalent `wasmi` instruction.
+    /// Wasm `i32.store` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2163,7 +2163,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I32StoreAt`] for constant 16-bit `value`.
     I32StoreAtImm16(StoreAtInstr<Const16<i32>>),
 
-    /// Wasm `i32.store8` equivalent `wasmi` instruction.
+    /// Wasm `i32.store8` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2178,7 +2178,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I32Store8At`] for constant `value`.
     I32Store8AtImm(StoreAtInstr<i8>),
 
-    /// Wasm `i32.store16` equivalent `wasmi` instruction.
+    /// Wasm `i32.store16` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2193,7 +2193,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I32Store16At`] for constant `value`.
     I32Store16AtImm(StoreAtInstr<i16>),
 
-    /// Wasm `i64.store` equivalent `wasmi` instruction.
+    /// Wasm `i64.store` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2208,7 +2208,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I64StoreAt`] for 16-bit `value`.
     I64StoreAtImm16(StoreAtInstr<Const16<i64>>),
 
-    /// Wasm `i64.store8` equivalent `wasmi` instruction.
+    /// Wasm `i64.store8` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2223,7 +2223,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I64Store8At`] for constant `value`.
     I64Store8AtImm(StoreAtInstr<i8>),
 
-    /// Wasm `i64.store16` equivalent `wasmi` instruction.
+    /// Wasm `i64.store16` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2238,7 +2238,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I64Store16At`] for constant `value`.
     I64Store16AtImm(StoreAtInstr<i16>),
 
-    /// Wasm `i64.store32` equivalent `wasmi` instruction.
+    /// Wasm `i64.store32` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2253,7 +2253,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::I64Store32At`] for constant 16-bit `value`.
     I64Store32AtImm16(StoreAtInstr<Const16<i32>>),
 
-    /// Wasm `f32.store` equivalent `wasmi` instruction.
+    /// Wasm `f32.store` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
@@ -2264,7 +2264,7 @@ pub enum Instruction {
     /// Variant of [`Instruction::F32Store`] for constant `address`.
     F32StoreAt(StoreAtInstr<Register>),
 
-    /// Wasm `f32.store` equivalent `wasmi` instruction.
+    /// Wasm `f32.store` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///

--- a/crates/wasmi/src/engine/bytecode/provider.rs
+++ b/crates/wasmi/src/engine/bytecode/provider.rs
@@ -52,7 +52,7 @@ impl<T> Provider<T> {
 /// # Note
 ///
 /// The [`UntypedProvider`] is primarily used for execution of
-/// `wasmi` bytecode where typing usually no longer plays a role.
+/// Wasmi bytecode where typing usually no longer plays a role.
 pub type UntypedProvider = Provider<UntypedValue>;
 
 impl From<Register> for UntypedProvider {

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -738,7 +738,7 @@ impl InstructionPtr {
     #[inline(always)]
     pub fn offset(&mut self, by: isize) {
         // SAFETY: Within Wasm bytecode execution we are guaranteed by
-        //         Wasm validation and `wasmi` codegen to never run out
+        //         Wasm validation and Wasmi codegen to never run out
         //         of valid bounds using this method.
         self.ptr = unsafe { self.ptr.offset(by) };
     }
@@ -746,7 +746,7 @@ impl InstructionPtr {
     #[inline(always)]
     pub fn add(&mut self, delta: usize) {
         // SAFETY: Within Wasm bytecode execution we are guaranteed by
-        //         Wasm validation and `wasmi` codegen to never run out
+        //         Wasm validation and Wasmi codegen to never run out
         //         of valid bounds using this method.
         self.ptr = unsafe { self.ptr.add(delta) };
     }
@@ -761,7 +761,7 @@ impl InstructionPtr {
     #[inline(always)]
     pub fn get(&self) -> &Instruction {
         // SAFETY: Within Wasm bytecode execution we are guaranteed by
-        //         Wasm validation and `wasmi` codegen to never run out
+        //         Wasm validation and Wasmi codegen to never run out
         //         of valid bounds using this method.
         unsafe { &*self.ptr }
     }

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -33,17 +33,17 @@ pub struct Config {
     extended_const: bool,
     /// Is `true` if Wasm instructions on `f32` and `f64` types are allowed.
     floats: bool,
-    /// Is `true` if `wasmi` executions shall consume fuel.
+    /// Is `true` if Wasmi executions shall consume fuel.
     consume_fuel: bool,
-    /// The fuel consumption mode of the `wasmi` [`Engine`](crate::Engine).
+    /// The fuel consumption mode of the Wasmi [`Engine`](crate::Engine).
     fuel_consumption_mode: FuelConsumptionMode,
-    /// The configured fuel costs of all `wasmi` bytecode instructions.
+    /// The configured fuel costs of all Wasmi bytecode instructions.
     fuel_costs: FuelCosts,
-    /// The mode of Wasm to `wasmi` bytecode compilation.
+    /// The mode of Wasm to Wasmi bytecode compilation.
     compilation_mode: CompilationMode,
 }
 
-/// The fuel consumption mode of the `wasmi` [`Engine`].
+/// The fuel consumption mode of the Wasmi [`Engine`].
 ///
 /// This mode affects when fuel is charged for Wasm bulk-operations.
 /// Affected Wasm instructions are:
@@ -103,30 +103,30 @@ pub struct FuelCosts {
 }
 
 impl FuelCosts {
-    /// Returns the base fuel costs for all `wasmi` IR instructions.
+    /// Returns the base fuel costs for all Wasmi IR instructions.
     pub fn base(&self) -> u64 {
         self.base
     }
 
-    /// Returns the base fuel costs for all `wasmi` IR entity related instructions.
+    /// Returns the base fuel costs for all Wasmi IR entity related instructions.
     pub fn entity(&self) -> u64 {
         // Note: For simplicity we currently simply use base costs.
         self.base
     }
 
-    /// Returns the base fuel costs for all `wasmi` IR load instructions.
+    /// Returns the base fuel costs for all Wasmi IR load instructions.
     pub fn load(&self) -> u64 {
         // Note: For simplicity we currently simply use base costs.
         self.base
     }
 
-    /// Returns the base fuel costs for all `wasmi` IR store instructions.
+    /// Returns the base fuel costs for all Wasmi IR store instructions.
     pub fn store(&self) -> u64 {
         // Note: For simplicity we currently simply use base costs.
         self.base
     }
 
-    /// Returns the base fuel costs for all `wasmi` IR call instructions.
+    /// Returns the base fuel costs for all Wasmi IR call instructions.
     pub fn call(&self) -> u64 {
         // Note: For simplicity we currently simply use base costs.
         self.base
@@ -142,11 +142,11 @@ impl FuelCosts {
         self.bytes_per_fuel
     }
 
-    /// Returns the fuel costs for `len_copies` register copies in `wasmi` IR.
+    /// Returns the fuel costs for `len_copies` register copies in Wasmi IR.
     ///
     /// # Note
     ///
-    /// Registers are copied for the following `wasmi` IR instructions:
+    /// Registers are copied for the following Wasmi IR instructions:
     ///
     /// - calls (parameter passing)
     /// - `copy_span`
@@ -161,11 +161,11 @@ impl FuelCosts {
         Self::costs_per(len_copies, self.copies_per_fuel())
     }
 
-    /// Returns the fuel costs for `len_copies` register copies in `wasmi` IR.
+    /// Returns the fuel costs for `len_copies` register copies in Wasmi IR.
     ///
     /// # Note
     ///
-    /// Registers are copied for the following `wasmi` IR instructions:
+    /// Registers are copied for the following Wasmi IR instructions:
     ///
     /// - `memory.grow`
     /// - `memory.copy`
@@ -196,10 +196,10 @@ impl Default for FuelCosts {
     }
 }
 
-/// The chosen mode of Wasm to `wasmi` bytecode compilation.
+/// The chosen mode of Wasm to Wasmi bytecode compilation.
 #[derive(Debug, Default, Copy, Clone)]
 pub enum CompilationMode {
-    /// The Wasm code is compiled eagerly to `wasmi` bytecode.
+    /// The Wasm code is compiled eagerly to Wasmi bytecode.
     #[default]
     Eager,
     /// The Wasm code is validated eagerly and translated lazily on first use.
@@ -367,11 +367,11 @@ impl Config {
         self
     }
 
-    /// Configures whether `wasmi` will consume fuel during execution to either halt execution as desired.
+    /// Configures whether Wasmi will consume fuel during execution to either halt execution as desired.
     ///
     /// # Note
     ///
-    /// This configuration can be used to make `wasmi` instrument its internal bytecode
+    /// This configuration can be used to make Wasmi instrument its internal bytecode
     /// so that it consumes fuel as it executes. Once an execution runs out of fuel
     /// a [`TrapCode::OutOfFuel`](crate::core::TrapCode::OutOfFuel) trap is raised.
     /// This way users can deterministically halt or yield the execution of WebAssembly code.

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -111,7 +111,7 @@ pub fn execute_instrs<'ctx, 'engine>(
         .execute(resource_limiter)
 }
 
-/// An execution context for executing a `wasmi` function frame.
+/// An execution context for executing a Wasmi function frame.
 #[derive(Debug)]
 struct Executor<'ctx, 'engine> {
     /// Stores the value stack of live values on the Wasm stack.
@@ -152,7 +152,7 @@ struct Executor<'ctx, 'engine> {
 }
 
 impl<'ctx, 'engine> Executor<'ctx, 'engine> {
-    /// Creates a new [`Executor`] for executing a `wasmi` function frame.
+    /// Creates a new [`Executor`] for executing a Wasmi function frame.
     #[inline(always)]
     pub fn new(
         ctx: &'ctx mut StoreInner,
@@ -899,7 +899,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     ///
     /// # Note
     ///
-    /// This is used by `wasmi` instructions that have a fixed
+    /// This is used by Wasmi instructions that have a fixed
     /// encoding size of two instruction words such as [`Instruction::Branch`].
     #[inline(always)]
     fn next_instr_at(&mut self, skip: usize) {

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -158,7 +158,7 @@ impl EngineInner {
     }
 }
 
-/// The internal state of the `wasmi` engine.
+/// The internal state of the Wasmi engine.
 #[derive(Debug)]
 pub struct EngineExecutor<'engine> {
     /// Shared and reusable generic engine resources.

--- a/crates/wasmi/src/engine/func_types.rs
+++ b/crates/wasmi/src/engine/func_types.rs
@@ -58,7 +58,7 @@ impl DedupFuncType {
 /// The big advantage of deduplicated [`FuncType`] entities is that we can use
 /// this for indirect calls to speed up the signature checks since comparing
 /// deduplicated [`FuncType`] instances is as fast as comparing integer values.
-/// Also with respect to `wasmi` bytecode deduplicated [`FuncType`] entities
+/// Also with respect to Wasmi bytecode deduplicated [`FuncType`] entities
 /// require a lot less space to be stored.
 #[derive(Debug)]
 pub struct FuncTypeRegistry {

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -1,4 +1,4 @@
-//! The `wasmi` interpreter.
+//! The Wasmi interpreter.
 
 mod block_type;
 pub mod bytecode;
@@ -106,11 +106,11 @@ impl EngineIdx {
 /// An entity owned by the [`Engine`].
 type Guarded<Idx> = GuardedEntity<EngineIdx, Idx>;
 
-/// The `wasmi` interpreter.
+/// The Wasmi interpreter.
 ///
 /// # Note
 ///
-/// - The current `wasmi` engine implements a bytecode interpreter.
+/// - The current Wasmi engine implements a bytecode interpreter.
 /// - This structure is intentionally cheap to copy.
 ///   Most of its API has a `&self` receiver, so can be shared easily.
 #[derive(Debug, Clone)]
@@ -307,7 +307,7 @@ impl Engine {
             .init_lazy_func(func_idx, func, bytes, module, func_to_validate)
     }
 
-    /// Resolves the [`CompiledFunc`] to the underlying `wasmi` bytecode instructions.
+    /// Resolves the [`CompiledFunc`] to the underlying Wasmi bytecode instructions.
     ///
     /// # Note
     ///
@@ -315,11 +315,11 @@ impl Engine {
     ///   machine based bytecode instructions.
     /// - This API is mainly intended for unit testing purposes and shall not be used
     ///   outside of this context. The function bodies are intended to be data private
-    ///   to the `wasmi` interpreter.
+    ///   to the Wasmi interpreter.
     ///
     /// # Errors
     ///
-    /// If the `func` fails Wasm to `wasmi` bytecode translation after it was lazily initialized.
+    /// If the `func` fails Wasm to Wasmi bytecode translation after it was lazily initialized.
     ///
     /// # Panics
     ///
@@ -340,11 +340,11 @@ impl Engine {
     ///
     /// This API is intended for unit testing purposes and shall not be used
     /// outside of this context. The function bodies are intended to be data
-    /// private to the `wasmi` interpreter.
+    /// private to the Wasmi interpreter.
     ///
     /// # Errors
     ///
-    /// If the `func` fails Wasm to `wasmi` bytecode translation after it was lazily initialized.
+    /// If the `func` fails Wasm to Wasmi bytecode translation after it was lazily initialized.
     ///
     /// # Panics
     ///
@@ -471,7 +471,7 @@ impl Engine {
     }
 }
 
-/// The internal state of the `wasmi` [`Engine`].
+/// The internal state of the Wasmi [`Engine`].
 #[derive(Debug)]
 pub struct EngineInner {
     /// The [`Config`] of the engine.
@@ -748,7 +748,7 @@ impl EngineInner {
     ///
     /// # Errors
     ///
-    /// If the `func` fails Wasm to `wasmi` bytecode translation after it was lazily initialized.
+    /// If the `func` fails Wasm to Wasmi bytecode translation after it was lazily initialized.
     ///
     /// # Pancis
     ///
@@ -768,7 +768,7 @@ impl EngineInner {
     ///
     /// # Errors
     ///
-    /// If the `func` fails Wasm to `wasmi` bytecode translation after it was lazily initialized.
+    /// If the `func` fails Wasm to Wasmi bytecode translation after it was lazily initialized.
     ///
     /// # Pancis
     ///

--- a/crates/wasmi/src/engine/resumable.rs
+++ b/crates/wasmi/src/engine/resumable.rs
@@ -87,7 +87,7 @@ pub struct ResumableInvocation {
     ///
     /// # Note
     ///
-    /// This is only needed for the register-machine `wasmi` engine backend.
+    /// This is only needed for the register-machine Wasmi engine backend.
     caller_results: RegisterSpan,
     /// The value and call stack in use by the [`ResumableInvocation`].
     ///
@@ -145,7 +145,7 @@ impl ResumableInvocation {
     ///
     /// # Note
     ///
-    /// This should only be called from the register-machine `wasmi` engine backend.
+    /// This should only be called from the register-machine Wasmi engine backend.
     pub(super) fn update(
         &mut self,
         host_func: Func,
@@ -191,7 +191,7 @@ impl ResumableInvocation {
     ///
     /// # Note
     ///
-    /// This is `Some` only for [`ResumableInvocation`] originating from the register-machine `wasmi` engine.
+    /// This is `Some` only for [`ResumableInvocation`] originating from the register-machine Wasmi engine.
     pub(crate) fn caller_results(&self) -> RegisterSpan {
         self.caller_results
     }

--- a/crates/wasmi/src/engine/translator/driver.rs
+++ b/crates/wasmi/src/engine/translator/driver.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use wasmparser::FunctionBody;
 
-/// Translates Wasm bytecode into `wasmi` bytecode for a single Wasm function.
+/// Translates Wasm bytecode into Wasmi bytecode for a single Wasm function.
 pub struct FuncTranslationDriver<'parser, T> {
     /// The function body that shall be translated.
     func_body: FunctionBody<'parser>,
@@ -15,7 +15,7 @@ pub struct FuncTranslationDriver<'parser, T> {
 }
 
 impl<'parser, T> FuncTranslationDriver<'parser, T> {
-    /// Creates a new Wasm to `wasmi` bytecode function translator.
+    /// Creates a new Wasm to Wasmi bytecode function translator.
     pub fn new(
         offset: impl Into<Option<usize>>,
         bytes: &'parser [u8],
@@ -35,7 +35,7 @@ impl<'parser, T> FuncTranslationDriver<'parser, T>
 where
     T: WasmTranslator<'parser>,
 {
-    /// Starts translation of the Wasm stream into `wasmi` bytecode.
+    /// Starts translation of the Wasm stream into Wasmi bytecode.
     pub fn translate(
         mut self,
         finalize: impl FnOnce(CompiledFuncEntity),

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -79,7 +79,7 @@ impl Instr {
     }
 }
 
-/// Encodes `wasmi` bytecode instructions to an [`Instruction`] stream.
+/// Encodes Wasmi bytecode instructions to an [`Instruction`] stream.
 #[derive(Debug, Default)]
 pub struct InstrEncoder {
     /// Already encoded [`Instruction`] words.

--- a/crates/wasmi/src/engine/translator/labels.rs
+++ b/crates/wasmi/src/engine/translator/labels.rs
@@ -6,7 +6,7 @@ use core::{
     slice::Iter as SliceIter,
 };
 
-/// A label during the `wasmi` compilation process.
+/// A label during the Wasmi compilation process.
 #[derive(Debug, Copy, Clone)]
 pub enum Label {
     /// The label has already been pinned to a particular [`Instr`].

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -1,4 +1,4 @@
-//! Function translation for the register-machine bytecode based `wasmi` engine.
+//! Function translation for the register-machine bytecode based Wasmi engine.
 
 mod control_frame;
 mod control_stack;
@@ -102,7 +102,7 @@ impl FuncTranslatorAllocations {
 /// The used function validator type.
 type FuncValidator = wasmparser::FuncValidator<wasmparser::ValidatorResources>;
 
-/// A Wasm to `wasmi` IR function translator that also validates its input.
+/// A Wasm to Wasmi IR function translator that also validates its input.
 pub struct ValidatingFuncTranslator<T> {
     /// The current position in the Wasm binary while parsing operators.
     pos: usize,
@@ -198,7 +198,7 @@ impl<T> ValidatingFuncTranslator<T> {
         self.pos
     }
 
-    /// Translates into `wasmi` bytecode if the current code path is reachable.
+    /// Translates into Wasmi bytecode if the current code path is reachable.
     fn validate_then_translate<Validate, Translate>(
         &mut self,
         validate: Validate,
@@ -431,7 +431,7 @@ impl<'a> VisitOperator<'a> for LazyFuncTranslator {
     wasmparser::for_each_operator!(impl_visit_operator);
 }
 
-/// Type concerned with translating from Wasm bytecode to `wasmi` bytecode.
+/// Type concerned with translating from Wasm bytecode to Wasmi bytecode.
 pub struct FuncTranslator {
     /// The reference to the Wasm module function under construction.
     func: FuncIdx,
@@ -443,7 +443,7 @@ pub struct FuncTranslator {
     /// the `module` field. However, this acts like a faster access since `module`
     /// only holds a weak reference to the engine.
     engine: Engine,
-    /// The immutable `wasmi` module resources.
+    /// The immutable Wasmi module resources.
     module: ModuleHeader,
     /// This represents the reachability of the currently translated code.
     ///
@@ -1231,7 +1231,7 @@ impl FuncTranslator {
         Ok(())
     }
 
-    /// Translate a non-commutative binary `wasmi` integer instruction.
+    /// Translate a non-commutative binary Wasmi integer instruction.
     ///
     /// # Note
     ///
@@ -1249,7 +1249,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64}.{sub, lt_s, lt_u, le_s, le_u, gt_s, gt_u, ge_s, ge_u}`
     #[allow(clippy::too_many_arguments)]
@@ -1303,7 +1303,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translate a non-commutative binary `wasmi` float instruction.
+    /// Translate a non-commutative binary Wasmi float instruction.
     ///
     /// # Note
     ///
@@ -1321,7 +1321,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{f32, f64}.{sub, div}`
     #[allow(clippy::too_many_arguments)]
@@ -1375,7 +1375,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translate `wasmi` float `{f32,f64}.copysign` instructions.
+    /// Translate Wasmi float `{f32,f64}.copysign` instructions.
     ///
     /// # Note
     ///
@@ -1417,7 +1417,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translate a commutative binary `wasmi` integer instruction.
+    /// Translate a commutative binary Wasmi integer instruction.
     ///
     /// # Note
     ///
@@ -1433,7 +1433,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64}.{eq, ne, add, mul, and, or, xor}`
     #[allow(clippy::too_many_arguments)]
@@ -1475,7 +1475,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translate a commutative binary `wasmi` float instruction.
+    /// Translate a commutative binary Wasmi float instruction.
     ///
     /// # Note
     ///
@@ -1491,7 +1491,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{f32, f64}.{add, mul, min, max}`
     #[allow(clippy::too_many_arguments)]
@@ -1533,7 +1533,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translate a shift or rotate `wasmi` instruction.
+    /// Translate a shift or rotate Wasmi instruction.
     ///
     /// # Note
     ///
@@ -1546,7 +1546,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64}.{shl, shr_s, shr_u, rotl, rotr}`
     #[allow(clippy::too_many_arguments)]
@@ -1603,7 +1603,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translate an integer division or remainder `wasmi` instruction.
+    /// Translate an integer division or remainder Wasmi instruction.
     ///
     /// # Note
     ///
@@ -1616,7 +1616,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64}.{div_u, div_s, rem_u, rem_s}`
     #[allow(clippy::too_many_arguments)]
@@ -1684,7 +1684,7 @@ impl FuncTranslator {
         Ok(false)
     }
 
-    /// Translates a unary Wasm instruction to `wasmi` bytecode.
+    /// Translates a unary Wasm instruction to Wasmi bytecode.
     fn translate_unary(
         &mut self,
         make_instr: fn(result: Register, input: Register) -> Instruction,
@@ -1704,7 +1704,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translates a fallible unary Wasm instruction to `wasmi` bytecode.
+    /// Translates a fallible unary Wasm instruction to Wasmi bytecode.
     fn translate_unary_fallible(
         &mut self,
         make_instr: fn(result: Register, input: Register) -> Instruction,
@@ -1756,7 +1756,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translates a Wasm `load` instruction to `wasmi` bytecode.
+    /// Translates a Wasm `load` instruction to Wasmi bytecode.
     ///
     /// # Note
     ///
@@ -1765,7 +1765,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64, f32, f64}.load`
     /// - `i32.{load8_s, load8_u, load16_s, load16_u}`
@@ -1813,7 +1813,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translates Wasm integer `store` and `storeN` instructions to `wasmi` bytecode.
+    /// Translates Wasm integer `store` and `storeN` instructions to Wasmi bytecode.
     ///
     /// # Note
     ///
@@ -1822,7 +1822,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64}.{store, store8, store16, store32}`
     fn translate_istore<T, U>(
@@ -1921,7 +1921,7 @@ impl FuncTranslator {
         }
     }
 
-    /// Translates Wasm float `store` instructions to `wasmi` bytecode.
+    /// Translates Wasm float `store` instructions to Wasmi bytecode.
     ///
     /// # Note
     ///
@@ -1930,7 +1930,7 @@ impl FuncTranslator {
     ///
     /// # Usage
     ///
-    /// Used for translating the following Wasm operators to `wasmi` bytecode:
+    /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{f32, f64}.store`
     fn translate_fstore(

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -19,13 +19,13 @@ use crate::{
 use alloc::vec::Vec;
 use wasmi_core::UntypedValue;
 
-/// Typed inputs to `wasmi` bytecode instructions.
+/// Typed inputs to Wasmi bytecode instructions.
 ///
 /// Either a [`Register`] or a constant [`UntypedValue`].
 ///
 /// # Note
 ///
-/// The [`TypedProvider`] is used primarily during translation of a `wasmi`
+/// The [`TypedProvider`] is used primarily during translation of a Wasmi
 /// function where types of constant values play an important role.
 pub type TypedProvider = Provider<TypedValue>;
 

--- a/crates/wasmi/src/engine/translator/stack/provider.rs
+++ b/crates/wasmi/src/engine/translator/stack/provider.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 #[cfg(doc)]
 use wasmi_core::UntypedValue;
 
-/// Tagged providers are inputs to `wasmi` bytecode instructions.
+/// Tagged providers are inputs to Wasmi bytecode instructions.
 ///
 /// Either a [`Register`] or a constant [`UntypedValue`].
 #[derive(Debug, Copy, Clone)]

--- a/crates/wasmi/src/engine/translator/tests/driver.rs
+++ b/crates/wasmi/src/engine/translator/tests/driver.rs
@@ -40,7 +40,7 @@ pub struct ExpectedFunc {
 }
 
 impl ExpectedFunc {
-    /// Create a new [`ExpectedFunc`] with the given `wasmi` bytecode [`Instruction`] sequence.
+    /// Create a new [`ExpectedFunc`] with the given Wasmi bytecode [`Instruction`] sequence.
     pub fn new<I>(instrs: I) -> Self
     where
         I: IntoIterator<Item = Instruction>,

--- a/crates/wasmi/src/engine/translator/tests/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/mod.rs
@@ -1,4 +1,4 @@
-//! Tests for the register-machine `wasmi` engine translation implementation.
+//! Tests for the register-machine Wasmi engine translation implementation.
 
 mod display_wasm;
 pub mod driver;

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/mod.rs
@@ -10,7 +10,7 @@
 //! # Note
 //!
 //! Technically `{i32, i64}.eqz` are unary instructions but we still
-//! include them here since in `wasmi` bytecode these are represented by
+//! include them here since in Wasmi bytecode these are represented by
 //! more generic comparison instructions.
 
 use super::*;

--- a/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 use wasm_type::WasmType;
 use wasmi_core::{TrapCode, UntypedValue};
 
-/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary `wasmi` instruction.
+/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary Wasmi instruction.
 fn conversion_reg_with<I, O, E>(wasm_op: &str, expected: E)
 where
     I: WasmType,
@@ -33,7 +33,7 @@ where
         .run();
 }
 
-/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary `wasmi` instruction.
+/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary Wasmi instruction.
 fn conversion_reg<I, O>(
     wasm_op: &str,
     make_instr: fn(result: Register, input: Register) -> Instruction,
@@ -48,7 +48,7 @@ fn conversion_reg<I, O>(
     conversion_reg_with::<I, O, _>(wasm_op, expected)
 }
 
-/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary `wasmi` instruction.
+/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary Wasmi instruction.
 fn unary_reg<T>(wasm_op: &str, make_instr: fn(result: Register, input: Register) -> Instruction)
 where
     T: WasmType,
@@ -56,7 +56,7 @@ where
     conversion_reg::<T, T>(wasm_op, make_instr)
 }
 
-/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary `wasmi` instruction.
+/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary Wasmi instruction.
 fn conversion_imm<I, O>(wasm_op: &str, input: I, eval: fn(input: I) -> O)
 where
     I: WasmType,
@@ -88,7 +88,7 @@ where
     testcase.run();
 }
 
-/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary `wasmi` instruction.
+/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary Wasmi instruction.
 fn unary_imm<T>(wasm_op: &str, input: T, eval: fn(input: T) -> T)
 where
     T: WasmType,
@@ -97,7 +97,7 @@ where
     conversion_imm::<T, T>(wasm_op, input, eval)
 }
 
-/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary `wasmi` instruction.
+/// Asserts that the unary Wasm operator `wasm_op` translates properly to a unary Wasmi instruction.
 fn fallible_conversion_imm_err<I, O>(wasm_op: &str, input: I, eval: fn(input: I) -> TrapCode)
 where
     I: WasmType,

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -16,7 +16,7 @@ use alloc::{boxed::Box, string::String};
 use core::{fmt, fmt::Display};
 use wasmparser::BinaryReaderError as WasmError;
 
-/// The generic `wasmi` root error type.
+/// The generic Wasmi root error type.
 #[derive(Debug)]
 pub struct Error {
     /// The underlying kind of the error and its specific information.
@@ -165,7 +165,7 @@ pub enum ErrorKind {
     Read(ReadError),
     /// Encountered when there is a Wasm parsing or validation error.
     Wasm(WasmError),
-    /// Encountered when there is a Wasm to `wasmi` translation error.
+    /// Encountered when there is a Wasm to Wasmi translation error.
     Translation(TranslationError),
 }
 

--- a/crates/wasmi/src/func/func_type.rs
+++ b/crates/wasmi/src/func/func_type.rs
@@ -126,7 +126,7 @@ impl FuncType {
     /// # Note
     ///
     /// This is required by an implementation detail of how function result passing is current
-    /// implemented in the `wasmi` execution engine and might change in the future.
+    /// implemented in the Wasmi execution engine and might change in the future.
     ///
     /// # Panics
     ///

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -23,7 +23,7 @@ pub trait IntoFunc<T, Params, Results>: Send + Sync + 'static {
     #[doc(hidden)]
     type Results: WasmTypeList;
 
-    /// Converts the function into its `wasmi` signature and its trampoline.
+    /// Converts the function into its Wasmi signature and its trampoline.
     #[doc(hidden)]
     fn into_func(self) -> (FuncType, TrampolineEntity<T>);
 }

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -424,7 +424,7 @@ impl Func {
     ///
     /// This is a non-standard WebAssembly API and might not be available
     /// at other WebAssembly engines. Please be aware that depending on this
-    /// feature might mean a lock-in to `wasmi` for users.
+    /// feature might mean a lock-in to Wasmi for users.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/func/typed_func.rs
+++ b/crates/wasmi/src/func/typed_func.rs
@@ -113,7 +113,7 @@ where
     ///
     /// This is a non-standard WebAssembly API and might not be available
     /// at other WebAssembly engines. Please be aware that depending on this
-    /// feature might mean a lock-in to `wasmi` for users.
+    /// feature might mean a lock-in to Wasmi for users.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -1,4 +1,4 @@
-//! The `wasmi` virtual machine definitions.
+//! The Wasmi virtual machine definitions.
 //!
 //! These closely mirror the WebAssembly specification definitions.
 //! The overall structure is heavily inspired by the `wasmtime` virtual
@@ -106,7 +106,7 @@ mod value;
 #[doc(inline)]
 pub use wasmi_core as core;
 
-/// Defines some errors that may occur upon interaction with `wasmi`.
+/// Defines some errors that may occur upon interaction with Wasmi.
 pub mod errors {
     pub use super::{
         error::ErrorKind,

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -2,7 +2,7 @@
 //! https://github.com/paritytech/wasmi/issues/587
 //!
 //! The problem was that Wasm memories (and tables) were defined twice for a
-//! `wasmi` instance for every imported Wasm memory (or table). Since `wasmi`
+//! Wasmi instance for every imported Wasm memory (or table). Since Wasmi
 //! does not support the `multi-memory` Wasm proposal this resulted Wasm
 //! instances with more than 1 memory (or table) if the Wasm module imported
 //! those entities.

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -197,7 +197,7 @@ impl Module {
     /// - If the Wasm bytecode yielded by `stream` is not valid.
     /// - If the Wasm bytecode yielded by `stream` violates restrictions
     ///   set in the [`Config`] used by the `engine`.
-    /// - If `wasmi` cannot translate the Wasm bytecode yielded by `stream`.
+    /// - If Wasmi cannot translate the Wasm bytecode yielded by `stream`.
     ///
     /// [`Config`]: crate::Config
     pub fn new(engine: &Engine, stream: impl Read) -> Result<Self, Error> {
@@ -246,7 +246,7 @@ impl Module {
     ///
     /// - The input `wasm` must be in binary form, the text format is not accepted by this function.
     /// - This will only validate the `wasm` but not try to translate it. Therefore `Module::new`
-    ///   might still fail if translation of the Wasm binary input fails to translate via the `wasmi`
+    ///   might still fail if translation of the Wasm binary input fails to translate via the Wasmi
     ///   [`Engine`].
     /// - Validation automatically happens as part of [`Module::new`].
     ///

--- a/crates/wasmi/src/module/parser.rs
+++ b/crates/wasmi/src/module/parser.rs
@@ -390,7 +390,7 @@ impl ModuleParser {
     /// # Note
     ///
     /// This is part of the module linking Wasm proposal and not yet supported
-    /// by `wasmi`.
+    /// by Wasmi.
     fn process_instances(
         &mut self,
         section: wasmparser::InstanceSectionReader,
@@ -471,7 +471,7 @@ impl ModuleParser {
     /// # Note
     ///
     /// This is part of the module linking Wasm proposal and not yet supported
-    /// by `wasmi`.
+    /// by Wasmi.
     fn process_tags(&mut self, section: wasmparser::TagSectionReader) -> Result<(), Error> {
         self.validator.tag_section(&section).map_err(Into::into)
     }
@@ -570,7 +570,7 @@ impl ModuleParser {
     /// # Note
     ///
     /// This is part of the bulk memory operations Wasm proposal and not yet supported
-    /// by `wasmi`.
+    /// by Wasmi.
     fn process_data_count(&mut self, count: u32, range: Range<usize>) -> Result<(), Error> {
         self.validator
             .data_count_section(count, &range)
@@ -634,7 +634,7 @@ impl ModuleParser {
     ///
     /// This contains the local variables and Wasm instructions of
     /// a single function body.
-    /// This procedure is translating the Wasm bytecode into `wasmi` bytecode.
+    /// This procedure is translating the Wasm bytecode into Wasmi bytecode.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/module/utils.rs
+++ b/crates/wasmi/src/module/utils.rs
@@ -75,7 +75,7 @@ impl FuncType {
         ///
         /// # Panics
         ///
-        /// If the [`wasmparser::Type`] is not supported by `wasmi`.
+        /// If the [`wasmparser::Type`] is not supported by Wasmi.
         fn extract_value_type(value_type: &wasmparser::ValType) -> ValueType {
             WasmiValueType::from(*value_type).into_inner()
         }
@@ -85,7 +85,7 @@ impl FuncType {
     }
 }
 
-/// A `wasmi` [`ValueType`].
+/// A Wasmi [`ValueType`].
 ///
 /// # Note
 ///

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -907,7 +907,7 @@ impl<T> Store<T> {
     }
 }
 
-/// A trait used to get shared access to a [`Store`] in `wasmi`.
+/// A trait used to get shared access to a [`Store`] in Wasmi.
 pub trait AsContext {
     /// The user state associated with the [`Store`], aka the `T` in `Store<T>`.
     type UserState;
@@ -916,7 +916,7 @@ pub trait AsContext {
     fn as_context(&self) -> StoreContext<Self::UserState>;
 }
 
-/// A trait used to get exclusive access to a [`Store`] in `wasmi`.
+/// A trait used to get exclusive access to a [`Store`] in Wasmi.
 pub trait AsContextMut: AsContext {
     /// Returns the store context that this type provides access to.
     fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState>;

--- a/crates/wasmi/tests/e2e/mod.rs
+++ b/crates/wasmi/tests/e2e/mod.rs
@@ -1,3 +1,3 @@
-//! End-to-end tests for `wasmi`.
+//! End-to-end tests for Wasmi.
 
 mod v1;

--- a/crates/wasmi/tests/e2e/v1/func.rs
+++ b/crates/wasmi/tests/e2e/v1/func.rs
@@ -1,4 +1,4 @@
-//! Tests for the `Func` type in `wasmi`.
+//! Tests for the `Func` type in Wasmi.
 
 use core::slice;
 

--- a/crates/wasmi/tests/spec/context.rs
+++ b/crates/wasmi/tests/spec/context.rs
@@ -24,7 +24,7 @@ use wast::token::{Id, Span};
 /// The context of a single Wasm test spec suite run.
 #[derive(Debug)]
 pub struct TestContext<'a> {
-    /// The `wasmi` engine used for executing functions used during the test.
+    /// The Wasmi engine used for executing functions used during the test.
     engine: Engine,
     /// The linker for linking together Wasm test modules.
     linker: Linker<()>,

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -61,7 +61,7 @@ fn mvp_config() -> Config {
     config
 }
 
-/// Create a [`Config`] with all Wasm feature supported by `wasmi` enabled.
+/// Create a [`Config`] with all Wasm feature supported by Wasmi enabled.
 ///
 /// # Note
 ///

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -66,7 +66,7 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
             }
             WastDirective::Wat(_) => {
                 test_context.profile().bump_quote_module();
-                // For the purpose of testing `wasmi` we are not
+                // For the purpose of testing Wasmi we are not
                 // interested in parsing `.wat` files, therefore
                 // we silently ignore this case for now.
                 // This might change once wasmi supports `.wat` files.
@@ -230,7 +230,7 @@ fn assert_results(context: &TestContext, span: Span, results: &[Value], expected
     let expected = expected.iter().map(|expected| match expected {
         WastRet::Core(expected) => expected,
         WastRet::Component(expected) => panic!(
-            "{:?}: `wasmi` does not support the Wasm `component-model` proposal but found {expected:?}",
+            "{:?}: Wasmi does not support the Wasm `component-model` proposal but found {expected:?}",
             context.spanned(span),
         ),
     });
@@ -375,7 +375,7 @@ fn execute_wast_invoke(
                 )
             }),
             wast::WastArg::Component(arg) => panic!(
-                "{}: `wasmi` does not support the Wasm `component-model` but found {arg:?}",
+                "{}: Wasmi does not support the Wasm `component-model` but found {arg:?}",
                 context.spanned(span)
             ),
         };

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -22,7 +22,7 @@ trait DifferentialTarget: Sized {
     fn call(&mut self, name: &str) -> Result<&[Self::Value], Self::Error>;
 }
 
-/// Differential fuzzing backend for the register-machine `wasmi`.
+/// Differential fuzzing backend for the register-machine Wasmi.
 struct WasmiRegister {
     store: wasmi_reg::Store<wasmi_reg::StoreLimits>,
     instance: wasmi_reg::Instance,
@@ -91,7 +91,7 @@ impl DifferentialTarget for WasmiRegister {
     }
 }
 
-/// Differential fuzzing backend for the stack-machine `wasmi`.
+/// Differential fuzzing backend for the stack-machine Wasmi.
 struct WasmiStack {
     store: wasmi_stack::Store<wasmi_stack::StoreLimits>,
     instance: wasmi_stack::Instance,

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -9,7 +9,7 @@ use wasmi::{Engine, Linker, Module, Store, StoreLimitsBuilder};
 
 fuzz_target!(|cfg_module: ConfiguredModule<ExecConfig>| {
     let mut smith_module = cfg_module.module;
-    // TODO: We could use `wasmi`'s built-in fuel metering instead.
+    // TODO: We could use Wasmi's built-in fuel metering instead.
     //       This would improve test coverage and may be more efficient
     //       given that `wasm-smith`'s fuel metering uses global variables
     //       to communicate used fuel.

--- a/fuzz/fuzz_targets/utils.rs
+++ b/fuzz/fuzz_targets/utils.rs
@@ -1,7 +1,7 @@
 use arbitrary::Arbitrary;
 use wasmi::{core::ValueType, Value};
 
-/// The configuration used to produce `wasmi` compatible fuzzing Wasm modules.
+/// The configuration used to produce Wasmi compatible fuzzing Wasm modules.
 #[derive(Debug, Arbitrary)]
 pub struct ExecConfig;
 


### PR DESCRIPTION
From now on we use "Wasmi" instead of "`wasmi`" since it is simpler and more standard as a name. Other Wasm runtimes such as Wasmer, Wasmtime and Wasm3 have the same spelling.