### PR TITLE
Fix bug found via fuzzing

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_11.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_11.wat
@@ -1,0 +1,15 @@
+(module
+  (func (param i32)
+    local.get 0
+    local.tee 0
+    local.tee 0
+    i32.const 2
+    i32.and
+    local.get 0
+    i32.eqz
+    local.tee 0
+    i32.and
+    br_if 0
+    unreachable
+  )
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -211,3 +211,23 @@ fn fuzz_regression_10() {
         ])
         .run()
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn fuzz_regression_11() {
+    let wat = include_str!("fuzz_11.wat");
+    let wasm = wat2wasm(wat);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::i32_and_imm16(Register::from_i16(1), Register::from_i16(0), 2),
+            Instruction::i32_eq_imm16(Register::from_i16(0), Register::from_i16(0), 0),
+            Instruction::i32_and(
+                Register::from_i16(1),
+                Register::from_i16(1),
+                Register::from_i16(0),
+            ),
+            Instruction::return_nez(1),
+            Instruction::Trap(TrapCode::UnreachableCodeReached),
+        ])
+        .run()
+}

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -801,6 +801,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_local_get(&mut self, local_index: u32) -> Self::Output {
         bail_unreachable!(self);
         self.alloc.stack.push_local(local_index)?;
+        self.alloc.instr_encoder.reset_last_instr();
         Ok(())
     }
 
@@ -1163,24 +1164,28 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_i32_const(&mut self, value: i32) -> Self::Output {
         bail_unreachable!(self);
         self.alloc.stack.push_const(value);
+        self.alloc.instr_encoder.reset_last_instr();
         Ok(())
     }
 
     fn visit_i64_const(&mut self, value: i64) -> Self::Output {
         bail_unreachable!(self);
         self.alloc.stack.push_const(value);
+        self.alloc.instr_encoder.reset_last_instr();
         Ok(())
     }
 
     fn visit_f32_const(&mut self, value: wasmparser::Ieee32) -> Self::Output {
         bail_unreachable!(self);
         self.alloc.stack.push_const(F32::from_bits(value.bits()));
+        self.alloc.instr_encoder.reset_last_instr();
         Ok(())
     }
 
     fn visit_f64_const(&mut self, value: wasmparser::Ieee64) -> Self::Output {
         bail_unreachable!(self);
         self.alloc.stack.push_const(F64::from_bits(value.bits()));
+        self.alloc.instr_encoder.reset_last_instr();
         Ok(())
     }
 
@@ -1193,6 +1198,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             _ => panic!("must be a Wasm reftype"),
         };
         self.alloc.stack.push_const(null);
+        self.alloc.instr_encoder.reset_last_instr();
         Ok(())
     }
 


### PR DESCRIPTION
The problem was that Wasm instructions such as `{i32,i64,f32,f64}.const`, `local.get` and `ref.null` did not reset the `InstrEncoder`'s last instruction thus not preventing invalid instruction fusion of `i32.and` and `i32.eqz` etc..