### PR TITLE
Fix conditional multi return bug in the Wasmi executor

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -297,6 +297,17 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         condition: Register,
         values: [Register; 2],
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, &values[..], Self::execute_return_many_impl)
+        let condition = self.get_register(condition);
+        match bool::from(condition) {
+            true => self.execute_return_many_impl(&values),
+            false => {
+                self.ip.add(1);
+                while let Instruction::RegisterList(_values) = self.ip.get() {
+                    self.ip.add(1);
+                }
+                self.ip.add(1);
+                ReturnOutcome::Wasm
+            }
+        }
     }
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_13.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_13.wat
@@ -1,0 +1,10 @@
+(module
+  (func (export "") (result i32 i32 i32)
+    (local i32)
+    local.get 0
+    local.get 0
+    local.get 0
+    local.get 0
+    br_if 0 (;@0;)
+  )
+)


### PR DESCRIPTION
This bug was caused by the execution of `Instruction::ReturnNezMany` (multi-value).
When the condition was `false` and the return therefore not taken, the instruction pointer was not properly updated which caused invalid behavior.