### PR TITLE
Forward constants in `local.tee` translation with constant value inputs

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_set.rs
@@ -38,7 +38,7 @@ fn imm_tee() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::return_reg(Register::from_i16(0)),
+            Instruction::return_imm32(10_i32),
         ])
         .run()
 }
@@ -241,8 +241,8 @@ fn local_tee_chain() {
     TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
-            Instruction::return_reg(Register::from_i16(1)),
+            Instruction::copy_imm32(Register::from_i16(1), 10_i32),
+            Instruction::return_imm32(10_i32),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -833,8 +833,16 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     fn visit_local_tee(&mut self, local_index: u32) -> Self::Output {
         bail_unreachable!(self);
+        let input = self.alloc.stack.peek();
         self.visit_local_set(local_index)?;
-        self.alloc.stack.push_local(local_index)?;
+        match input {
+            Provider::Register(_register) => {
+                self.alloc.stack.push_local(local_index)?;
+            }
+            Provider::Const(value) => {
+                self.alloc.stack.push_const(value);
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Before this change the translator forwarded the assigned local variable instead of C. However, it is possible in this particular case to forward the constant value instead of the local variable which improves code generation of following instructions due to improved optimization opportunities.