### PR TITLE
Fix bug with `global.get` translation of constant globals

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_14.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_14.wat
@@ -1,0 +1,10 @@
+(module
+  (func (param i32 i32) (result i32 i32)
+    local.get 0
+    local.get 1
+    i32.and
+    global.get 0
+    i32.eqz
+  )
+  (global i32 (i32.const -2))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -333,3 +333,23 @@ fn fuzz_regression_13_execute() {
     let (x, y, z) = func.call(&mut store, ()).unwrap();
     assert!(x == 0 && y == 0 && z == 0);
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn fuzz_regression_14() {
+    let wat = include_str!("fuzz_14.wat");
+    let wasm = wat2wasm(wat);
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::i32_and(
+                    Register::from_i16(2),
+                    Register::from_i16(0),
+                    Register::from_i16(1),
+                ),
+                Instruction::return_reg2(2, -1),
+            ])
+            .consts([0_i32]),
+        )
+        .run()
+}

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -856,6 +856,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 // Optmization: Access to immutable internally defined global variables
                 //              can be replaced with their constant initialization value.
                 self.alloc.stack.push_const(TypedValue::new(content, value));
+                self.alloc.instr_encoder.reset_last_instr();
                 return Ok(());
             }
             if let Some(func_index) = init_expr.funcref() {


### PR DESCRIPTION
This bug triggered miscompilation in cases where a `global.get g0` was surrounded by a pair of fusable instructions such as `i32.and` and `i32.eqz` and `g0` was an immutable global variable.
This caused the instructions to incorrectly fuse instead of being kept separate.