### PR TITLE
Fix codegen bug with Wasm `br_table` translation

### DIFF
--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -69,6 +69,89 @@ use wasmi_core::TrapCode;
 /// - `cN`: Constant (immediate) value
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Instruction {
+    /// A [`TableIdx`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    TableIdx(TableIdx),
+    /// A [`DataSegmentIdx`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    DataSegmentIdx(DataSegmentIdx),
+    /// A [`ElementSegmentIdx`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    ElementSegmentIdx(ElementSegmentIdx),
+    /// A [`AnyConst32`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Const32(AnyConst32),
+    /// A [`Const32<i64>`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    I64Const32(Const32<i64>),
+    /// A [`Const32<f64>`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    F64Const32(Const32<f64>),
+    /// A [`Register`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Register(Register),
+    /// Two [`Register`] instruction parameters.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Register2([Register; 2]),
+    /// Three [`Register`] instruction parameters.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Register3([Register; 3]),
+    /// [`Register`] slice parameters.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    ///
+    /// # Encoding
+    ///
+    /// This must always be followed by one of
+    ///
+    /// - [`Instruction::Register`]
+    /// - [`Instruction::Register2`]
+    /// - [`Instruction::Register3`]
+    RegisterList([Register; 3]),
+    /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
+    CallIndirectParams(CallIndirectParams<Register>),
+    /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.
+    CallIndirectParamsImm16(CallIndirectParams<Const16<u32>>),
+
     /// Traps the execution with the given [`TrapCode`].
     ///
     /// # Note
@@ -3069,89 +3152,6 @@ pub enum Instruction {
     F64ConvertI64S(UnaryInstr),
     /// Wasm `f64.convert_i64_u` instruction.
     F64ConvertI64U(UnaryInstr),
-
-    /// A [`TableIdx`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    TableIdx(TableIdx),
-    /// A [`DataSegmentIdx`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    DataSegmentIdx(DataSegmentIdx),
-    /// A [`ElementSegmentIdx`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    ElementSegmentIdx(ElementSegmentIdx),
-    /// A [`AnyConst32`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Const32(AnyConst32),
-    /// A [`Const32<i64>`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    I64Const32(Const32<i64>),
-    /// A [`Const32<f64>`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    F64Const32(Const32<f64>),
-    /// A [`Register`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Register(Register),
-    /// Two [`Register`] instruction parameters.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Register2([Register; 2]),
-    /// Three [`Register`] instruction parameters.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Register3([Register; 3]),
-    /// [`Register`] slice parameters.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    ///
-    /// # Encoding
-    ///
-    /// This must always be followed by one of
-    ///
-    /// - [`Instruction::Register`]
-    /// - [`Instruction::Register2`]
-    /// - [`Instruction::Register3`]
-    RegisterList([Register; 3]),
-    /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
-    CallIndirectParams(CallIndirectParams<Register>),
-    /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.
-    CallIndirectParamsImm16(CallIndirectParams<Const16<u32>>),
 }
 
 impl Instruction {

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -637,8 +637,9 @@ pub enum Instruction {
     /// A Wasm `br_table` instruction.
     ///
     /// # Encoding
-    ///
-    /// Must be followed `len_targets` times by any of
+    /// 
+    /// 1. May be followed by one of the copy instructions.
+    /// 1. Must be followed `len_targets` times by any of:
     ///
     /// - [`Instruction::Branch`]
     /// - [`Instruction::Return`]

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -637,7 +637,7 @@ pub enum Instruction {
     /// A Wasm `br_table` instruction.
     ///
     /// # Encoding
-    /// 
+    ///
     /// 1. May be followed by one of the copy instructions.
     /// 1. Must be followed `len_targets` times by any of:
     ///

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -69,89 +69,6 @@ use wasmi_core::TrapCode;
 /// - `cN`: Constant (immediate) value
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Instruction {
-    /// A [`TableIdx`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    TableIdx(TableIdx),
-    /// A [`DataSegmentIdx`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    DataSegmentIdx(DataSegmentIdx),
-    /// A [`ElementSegmentIdx`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    ElementSegmentIdx(ElementSegmentIdx),
-    /// A [`AnyConst32`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Const32(AnyConst32),
-    /// A [`Const32<i64>`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    I64Const32(Const32<i64>),
-    /// A [`Const32<f64>`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    F64Const32(Const32<f64>),
-    /// A [`Register`] instruction parameter.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Register(Register),
-    /// Two [`Register`] instruction parameters.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Register2([Register; 2]),
-    /// Three [`Register`] instruction parameters.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    Register3([Register; 3]),
-    /// [`Register`] slice parameters.
-    ///
-    /// # Note
-    ///
-    /// This [`Instruction`] only acts as a parameter to another
-    /// one and will never be executed itself directly.
-    ///
-    /// # Encoding
-    ///
-    /// This must always be followed by one of
-    ///
-    /// - [`Instruction::Register`]
-    /// - [`Instruction::Register2`]
-    /// - [`Instruction::Register3`]
-    RegisterList([Register; 3]),
-    /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
-    CallIndirectParams(CallIndirectParams<Register>),
-    /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.
-    CallIndirectParamsImm16(CallIndirectParams<Const16<u32>>),
-
     /// Traps the execution with the given [`TrapCode`].
     ///
     /// # Note
@@ -3152,6 +3069,89 @@ pub enum Instruction {
     F64ConvertI64S(UnaryInstr),
     /// Wasm `f64.convert_i64_u` instruction.
     F64ConvertI64U(UnaryInstr),
+
+    /// A [`TableIdx`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    TableIdx(TableIdx),
+    /// A [`DataSegmentIdx`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    DataSegmentIdx(DataSegmentIdx),
+    /// A [`ElementSegmentIdx`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    ElementSegmentIdx(ElementSegmentIdx),
+    /// A [`AnyConst32`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Const32(AnyConst32),
+    /// A [`Const32<i64>`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    I64Const32(Const32<i64>),
+    /// A [`Const32<f64>`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    F64Const32(Const32<f64>),
+    /// A [`Register`] instruction parameter.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Register(Register),
+    /// Two [`Register`] instruction parameters.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Register2([Register; 2]),
+    /// Three [`Register`] instruction parameters.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    Register3([Register; 3]),
+    /// [`Register`] slice parameters.
+    ///
+    /// # Note
+    ///
+    /// This [`Instruction`] only acts as a parameter to another
+    /// one and will never be executed itself directly.
+    ///
+    /// # Encoding
+    ///
+    /// This must always be followed by one of
+    ///
+    /// - [`Instruction::Register`]
+    /// - [`Instruction::Register2`]
+    /// - [`Instruction::Register3`]
+    RegisterList([Register; 3]),
+    /// Auxiliary [`Instruction`] to encode table access information for indirect call instructions.
+    CallIndirectParams(CallIndirectParams<Register>),
+    /// Variant of [`Instruction::CallIndirectParams`] for 16-bit constant `index` parameter.
+    CallIndirectParamsImm16(CallIndirectParams<Const16<u32>>),
 }
 
 impl Instruction {

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -865,12 +865,14 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Returns the [`Register`] value.
+    #[inline]
     fn get_register(&self, register: Register) -> UntypedValue {
         // Safety: TODO
         unsafe { self.sp.get(register) }
     }
 
     /// Returns the [`Register`] value.
+    #[inline]
     fn get_register_as<T>(&self, register: Register) -> T
     where
         T: From<UntypedValue>,
@@ -879,6 +881,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Sets the [`Register`] value to `value`.
+    #[inline]
     fn set_register(&mut self, register: Register, value: impl Into<UntypedValue>) {
         // Safety: TODO
         unsafe { self.sp.set(register, value.into()) };

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -865,14 +865,12 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Returns the [`Register`] value.
-    #[inline]
     fn get_register(&self, register: Register) -> UntypedValue {
         // Safety: TODO
         unsafe { self.sp.get(register) }
     }
 
     /// Returns the [`Register`] value.
-    #[inline]
     fn get_register_as<T>(&self, register: Register) -> T
     where
         T: From<UntypedValue>,
@@ -881,7 +879,6 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Sets the [`Register`] value to `value`.
-    #[inline]
     fn set_register(&mut self, register: Register, value: impl Into<UntypedValue>) {
         // Safety: TODO
         unsafe { self.sp.set(register, value.into()) };

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -40,7 +40,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         self.branch_to(offset)
     }
 
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_branch_table(&mut self, index: Register, len_targets: Const32<u32>) {
         let index: u32 = self.get_register_as(index);
         // The index of the default target which is the last target of the slice.
@@ -57,7 +57,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// Executes an optional copy instruction at `ip`.
     ///
     /// Does nothing if there is no `copy` instruction at `ip`.
-    #[inline(never)]
+    #[inline(always)]
     fn execute_optional_copy_instr(&mut self) {
         match *self.ip.get() {
             Instruction::Copy { result, value } => self.execute_copy(result, value),

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -57,6 +57,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// Executes an optional copy instruction at `ip`.
     ///
     /// Does nothing if there is no `copy` instruction at `ip`.
+    #[inline(never)]
     fn execute_optional_copy_instr(&mut self) {
         match *self.ip.get() {
             Instruction::Copy { result, value } => self.execute_copy(result, value),

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -40,7 +40,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
         self.branch_to(offset)
     }
 
-    #[inline(never)]
+    #[inline(always)]
     pub fn execute_branch_table(&mut self, index: Register, len_targets: Const32<u32>) {
         let index: u32 = self.get_register_as(index);
         // The index of the default target which is the last target of the slice.
@@ -57,7 +57,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     /// Executes an optional copy instruction at `ip`.
     ///
     /// Does nothing if there is no `copy` instruction at `ip`.
-    #[inline(always)]
+    #[inline(never)]
     fn execute_optional_copy_instr(&mut self) {
         match *self.ip.get() {
             Instruction::Copy { result, value } => self.execute_copy(result, value),

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -283,7 +283,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Executes an [`Instruction::CallImported0`].
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_call_imported_0(
         &mut self,
         results: RegisterSpan,
@@ -294,7 +294,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Executes an [`Instruction::CallImported`].
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_call_imported(
         &mut self,
         results: RegisterSpan,
@@ -358,7 +358,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0`].
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_return_call_indirect_0(
         &mut self,
         func_type: SignatureIdx,
@@ -376,7 +376,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0`].
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_return_call_indirect(
         &mut self,
         func_type: SignatureIdx,
@@ -394,7 +394,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0`].
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_call_indirect_0(
         &mut self,
         results: RegisterSpan,
@@ -412,7 +412,7 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect`].
-    #[inline(always)]
+    #[inline(never)]
     pub fn execute_call_indirect(
         &mut self,
         results: RegisterSpan,

--- a/crates/wasmi/src/engine/translator/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_table.rs
@@ -134,8 +134,8 @@ fn reg_params_1_return() {
     let result = Register::from_i16(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(result, value),
             Instruction::branch_table(index, 5),
+            Instruction::copy(result, value),
             Instruction::return_reg(result),
             Instruction::branch(BranchOffset::from(10)),
             Instruction::branch(BranchOffset::from(7)),
@@ -185,8 +185,8 @@ fn reg_params_1_pass() {
     let result = Register::from_i16(2);
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(result, value),
             Instruction::branch_table(index, 3),
+            Instruction::copy(result, value),
             Instruction::branch(BranchOffset::from(7)),
             Instruction::branch(BranchOffset::from(4)),
             Instruction::branch(BranchOffset::from(1)),
@@ -229,8 +229,8 @@ fn reg_params_2_ops() {
     let result = Register::from_i16(3);
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
             Instruction::branch_table(index, 3),
+            Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
             Instruction::branch(BranchOffset::from(7)),
             Instruction::branch(BranchOffset::from(4)),
             Instruction::branch(BranchOffset::from(1)),
@@ -274,8 +274,8 @@ fn reg_params_2_return() {
     TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
                 Instruction::branch_table(index, 4),
+                Instruction::copy2(RegisterSpan::new(result), lhs, lhs.next()),
                 Instruction::return_span(results),
                 Instruction::branch(BranchOffset::from(7)),
                 Instruction::branch(BranchOffset::from(4)),

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_01.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_01.wat
@@ -3,7 +3,7 @@
     block (result f32) ;; label = @1
       block (result f32) ;; label = @2
         block (result f32) ;; label = @3
-          f32.const 1
+          f32.const 10
           local.get 0
           i32.wrap_i64
           br_table 0 (;@3;) 3 (;@0;) 0 (;@3;)

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_01.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_01.wat
@@ -1,0 +1,17 @@
+(module
+  (func (;0;) (param i64) (result f32)
+    block (result f32) ;; label = @1
+      block (result f32) ;; label = @2
+        block (result f32) ;; label = @3
+          f32.const 1
+          local.get 0
+          i32.wrap_i64
+          br_table 0 (;@3;) 3 (;@0;) 0 (;@3;)
+        end
+        unreachable
+      end
+    end
+    unreachable
+  )
+  (export "" (func 0))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_02.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_02.wat
@@ -1,0 +1,18 @@
+(module
+  (func (;0;) (param i64) (result f32 f32)
+    block (result f32 f32) ;; label = @1
+      block (result f32 f32) ;; label = @2
+        block (result f32 f32) ;; label = @3
+          f32.const 10
+          f32.const 20
+          local.get 0
+          i32.wrap_i64
+          br_table 0 (;@3;) 3 (;@0;) 0 (;@3;)
+        end
+        unreachable
+      end
+    end
+    unreachable
+  )
+  (export "" (func 0))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_03.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_15_03.wat
@@ -1,0 +1,27 @@
+(module
+  (func (;0;) (param i64) (result i32)
+    block (result i32 i32) ;; label = @1
+      global.get 0
+      block (result i32 i32) ;; label = @2
+        global.get 0
+        block (result i32 i32) ;; label = @3
+          i32.const 10
+          i32.const 20
+          local.get 0
+          i32.wrap_i64
+          br_table 0 (;@3;) 1 (;@2;) 0 (;@3;) 2 (;@1;)
+        end
+        i32.add
+        ;; drop
+        return
+      end
+      i32.mul
+      ;; drop
+      return
+    end
+    i32.xor
+    return
+  )
+  (global (mut i32) (i32.const 30))
+  (export "" (func 0))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -65,12 +65,12 @@ fn fuzz_regression_3() {
                 RegisterSpan::new(Register::from_i16(3)),
                 CompiledFunc::from_u32(0),
             ),
+            Instruction::branch_table(Register::from_i16(5), 2),
             Instruction::copy_span_non_overlapping(
                 RegisterSpan::new(Register::from_i16(0)),
                 RegisterSpan::new(Register::from_i16(2)),
                 3,
             ),
-            Instruction::branch_table(Register::from_i16(5), 2),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter_u16(3)),
             Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter_u16(3)),
         ])
@@ -369,7 +369,7 @@ fn fuzz_regression_15_01_codegen() {
             //   stores its `index` result.
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
-                Instruction::branch_table(Register::from_i16(0), 3),
+                Instruction::branch_table(Register::from_i16(1), 3),
                 Instruction::copy_imm32(Register::from_i16(1), 10.0_f32),
                 Instruction::branch(BranchOffset::from(3)),
                 Instruction::return_reg(1),
@@ -416,12 +416,12 @@ fn fuzz_regression_15_02() {
             // Note: The bug is that `copy2` overwrites `i32_wrap_i64` which is the `index` of the `br_table`.
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
+                Instruction::branch_table(Register::from_i16(1), 3),
                 Instruction::copy2(
                     RegisterSpan::new(Register::from_i16(1)),
                     Register::from_i16(-1),
                     Register::from_i16(-2),
                 ),
-                Instruction::branch_table(Register::from_i16(1), 3),
                 Instruction::branch(BranchOffset::from(3)),
                 Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter_u16(2)),
                 Instruction::branch(BranchOffset::from(1)),

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -357,7 +357,7 @@ fn fuzz_regression_14() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn fuzz_regression_15_01() {
+fn fuzz_regression_15_01_codegen() {
     let wat = include_str!("fuzz_15_01.wat");
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -369,8 +369,8 @@ fn fuzz_regression_15_01() {
             //   stores its `index` result.
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
-                Instruction::copy_imm32(Register::from_i16(1), 1.0_f32),
                 Instruction::branch_table(Register::from_i16(0), 3),
+                Instruction::copy_imm32(Register::from_i16(1), 10.0_f32),
                 Instruction::branch(BranchOffset::from(3)),
                 Instruction::return_reg(1),
                 Instruction::branch(BranchOffset::from(1)),

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -357,7 +357,7 @@ fn fuzz_regression_14() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn fuzz_regression_15_01_codegen() {
+fn fuzz_regression_15_01() {
     let wat = include_str!("fuzz_15_01.wat");
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)
@@ -382,7 +382,7 @@ fn fuzz_regression_15_01_codegen() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn fuzz_regression_15_02_codegen() {
+fn fuzz_regression_15_02() {
     let wat = include_str!("fuzz_15_02.wat");
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)


### PR DESCRIPTION
The bug caused the `index` register to be overwritten in case the translator recognized that all branching targets of the `br_table` have the same branch parameters and thus expect their branch parameters at the same set of registers. This allows the translator to produce more efficient code by inserting a `copy` instruction before an actual branch took place instead of pushing a `copy` in each branch. However, this resulted in a possibility to overwrite the `index` register.

To fix this we encoded the `copy` instruction after the `br_table` instead of before which required us to implement special handling for this in the `br_table` executor.