### PR TITLE
Fix heap buffer overflow due to Wasmi codegen bug

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_16.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_16.wat
@@ -7,7 +7,7 @@
     global.get 0
     local.tee 0
     global.set 0
-    i64.store ;; offender
+    i64.store
     unreachable
   )
   (memory 0 10)

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_16.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_16.wat
@@ -1,0 +1,16 @@
+(module
+  (func
+    (local f64)
+    i32.const 0x7FFFFFFF
+    local.get 0
+    i64.reinterpret_f64
+    global.get 0
+    local.tee 0
+    global.set 0
+    i64.store ;; offender
+    unreachable
+  )
+  (memory 0 10)
+  (global (mut f64) f64.const 1.0)
+  (export "" (func 0))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_16.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_16.wat
@@ -1,5 +1,5 @@
 (module
-  (func
+  (func (export "")
     (local f64)
     i32.const 0x7FFFFFFF
     local.get 0
@@ -12,5 +12,4 @@
   )
   (memory 0 10)
   (global (mut f64) f64.const 1.0)
-  (export "" (func 0))
 )

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_17.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_17.wat
@@ -1,0 +1,16 @@
+(module
+  (func (result i32 f64 f64)
+    (local i64 f32)
+    i32.const -1
+    local.get 0
+    f32.const -1.0
+    i64.const 2
+    i64.extend8_s
+    local.set 0
+    local.set 1
+    i64.store
+    unreachable
+  )
+  (memory 10)
+  (export "" (func 0))
+)

--- a/crates/wasmi/src/engine/translator/tests/regression/fuzz_17.wat
+++ b/crates/wasmi/src/engine/translator/tests/regression/fuzz_17.wat
@@ -1,5 +1,5 @@
 (module
-  (func (result i32 f64 f64)
+  (func (export "") (result i32 f64 f64)
     (local i64 f32)
     i32.const -1
     local.get 0
@@ -12,5 +12,4 @@
     unreachable
   )
   (memory 10)
-  (export "" (func 0))
 )

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -490,3 +490,35 @@ fn fuzz_regression_15_03() {
         )
         .run()
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn fuzz_regression_16() {
+    let wat = include_str!("fuzz_16.wat");
+    let wasm = wat2wasm(wat);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy(2, 0),
+            Instruction::global_get(Register::from_i16(0), GlobalIdx::from(0)),
+            Instruction::global_set(GlobalIdx::from(0), Register::from_i16(0)),
+            Instruction::i64_store_at(Const32::from(2147483647), Register::from_i16(2)),
+            Instruction::Trap(TrapCode::UnreachableCodeReached),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn fuzz_regression_17() {
+    let wat = include_str!("fuzz_17.wat");
+    let wasm = wat2wasm(wat);
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy(2, 0),
+            Instruction::copy_i64imm32(Register::from_i16(0), 2),
+            Instruction::copy_imm32(Register::from_i16(1), -1.0_f32),
+            Instruction::i64_store_at(Const32::from(4294967295), Register::from_i16(2)),
+            Instruction::Trap(TrapCode::UnreachableCodeReached),
+        ])
+        .run()
+}

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -494,6 +494,9 @@ fn fuzz_regression_15_03() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_16() {
+    // The bug in this regression test was a forgotten adjustment
+    // for the preserved local value causing the `value` register
+    // of the `i64_store_at` instruction to be 32676 instead of 2.
     let wat = include_str!("fuzz_16.wat");
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)
@@ -510,6 +513,9 @@ fn fuzz_regression_16() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_17() {
+    // The bug in this regression test was a forgotten adjustment
+    // for the preserved local value causing the `value` register
+    // of the `i64_store_at` instruction to be 32676 instead of 2.
     let wat = include_str!("fuzz_17.wat");
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -595,8 +595,8 @@ impl VisitInputRegisters for StoreInstr {
 }
 
 impl VisitInputRegisters for StoreAtInstr<Register> {
-    fn visit_input_registers(&mut self, _f: impl FnMut(&mut Register)) {
-        // Nothing to do.
+    fn visit_input_registers(&mut self, mut f: impl FnMut(&mut Register)) {
+        f(&mut self.value);
     }
 }
 


### PR DESCRIPTION
The problem was that an adjustment for preserved registers was forgotten. The fix thus was very simple.