### PR TITLE
Update `wast`: `v0.64` -> `v0.65`

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -29,7 +29,7 @@ num-derive = "0.4"
 [dev-dependencies]
 wat = "1"
 assert_matches = "1.5"
-wast = "64.0"
+wast = "65.0"
 anyhow = "1.0"
 criterion = { version = "0.5", default-features = false }
 

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -272,13 +272,16 @@ fn assert_results(context: &TestContext, span: Span, results: &[Value], expected
             (Value::ExternRef(externref), WastRetCore::RefNull(Some(HeapType::Extern))) => {
                 assert!(externref.is_null());
             }
-            (Value::ExternRef(externref), WastRetCore::RefExtern(expected)) => {
+            (Value::ExternRef(externref), WastRetCore::RefExtern(Some(expected))) => {
                 let value = externref
                     .data(context.store())
                     .expect("unexpected null element")
                     .downcast_ref::<u32>()
                     .expect("unexpected non-u32 data");
                 assert_eq!(value, expected);
+            }
+            (Value::ExternRef(externref), WastRetCore::RefExtern(None)) => {
+                assert!(externref.is_null());
             }
             (result, expected) => panic!(
                 "{}: encountered mismatch in evaluation. expected {:?} but found {:?}",


### PR DESCRIPTION
The newest wast version is 0.70 but 0.66+ introduces some new wast directives that I personally have not yet fully understood and that may not actually be useful to Wasmi's current set of implemented Wasm proposals.