### PR TITLE
Make Wasm spec testsuite runnable via `miri`

### DIFF
--- a/crates/wasmi/tests/spec/descriptor.rs
+++ b/crates/wasmi/tests/spec/descriptor.rs
@@ -17,10 +17,7 @@ impl TestDescriptor {
     ///
     /// If the corresponding Wasm test spec file cannot properly be read.
     pub fn new(path: &'static str, file: &'static str) -> Self {
-        Self {
-            path,
-            file,
-        }
+        Self { path, file }
     }
 
     /// Returns the path of the Wasm spec test `.wast` file.

--- a/crates/wasmi/tests/spec/descriptor.rs
+++ b/crates/wasmi/tests/spec/descriptor.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Display},
-    fs,
-};
+use std::fmt::{self, Display};
 use wast::token::Span;
 
 /// The desciptor of a Wasm spec test suite run.
@@ -19,11 +16,11 @@ impl TestDescriptor {
     /// # Errors
     ///
     /// If the corresponding Wasm test spec file cannot properly be read.
-    pub fn new(name: &str) -> Self {
-        let path = format!("tests/spec/{name}.wast");
-        let file = fs::read_to_string(&path)
-            .unwrap_or_else(|error| panic!("{path}, failed to read `.wast` test file: {error}"));
-        Self { path, file }
+    pub fn new(path: &str, file: &str) -> Self {
+        Self {
+            path: path.into(),
+            file: file.into(),
+        }
     }
 
     /// Returns the path of the Wasm spec test `.wast` file.

--- a/crates/wasmi/tests/spec/descriptor.rs
+++ b/crates/wasmi/tests/spec/descriptor.rs
@@ -5,9 +5,9 @@ use wast::token::Span;
 #[derive(Debug)]
 pub struct TestDescriptor {
     /// The path of the Wasm spec test `.wast` file.
-    path: String,
+    path: &'static str,
     /// The contents of the Wasm spec test `.wast` file.
-    file: String,
+    file: &'static str,
 }
 
 impl TestDescriptor {
@@ -16,10 +16,10 @@ impl TestDescriptor {
     /// # Errors
     ///
     /// If the corresponding Wasm test spec file cannot properly be read.
-    pub fn new(path: &str, file: &str) -> Self {
+    pub fn new(path: &'static str, file: &'static str) -> Self {
         Self {
-            path: path.into(),
-            file: file.into(),
+            path,
+            file,
         }
     }
 

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -25,9 +25,7 @@ macro_rules! define_tests {
             $( #[$attr] )*
             fn $test_name() {
                 let name: &'static ::core::primitive::str = ::core::concat!($test_folder, "/", $file_name);
-                let file: &'static ::core::primitive::str = ::core::include_str!(
-                    ::core::concat!($test_folder, "/", $file_name, ".wast")
-                );
+                let file: &'static ::core::primitive::str = self::blobs::$test_name();
                 $runner_fn(name, file, $get_config)
             }
         )*
@@ -189,6 +187,31 @@ macro_rules! expand_tests {
             fn wasm_utf8_invalid_encoding("utf8-invalid-encoding");
         }
     };
+}
+
+macro_rules! include_wasm_blobs {
+    (
+        let folder = $test_folder:literal;
+
+        $( $(#[$attr:meta])* fn $test_name:ident($file_name:literal); )*
+    ) => {
+        $(
+            $( #[$attr] )*
+            pub fn $test_name() -> &'static str {
+                ::core::include_str!(
+                    ::core::concat!($test_folder, "/", $file_name, ".wast")
+                )
+            }
+        )*
+    };
+}
+
+mod blobs {
+    expand_tests! {
+        include_wasm_blobs,
+
+        let folder = "testsuite";
+    }
 }
 
 expand_tests! {

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -18,13 +18,17 @@ macro_rules! define_tests {
         let config = $get_config:expr;
         let runner = $runner_fn:path;
 
-        $( $(#[$attr:meta])* fn $test_name:ident($file_name:expr); )*
+        $( $(#[$attr:meta])* fn $test_name:ident($file_name:literal); )*
     ) => {
         $(
             #[test]
             $( #[$attr] )*
             fn $test_name() {
-                $runner_fn(&format!("{}/{}", $test_folder, $file_name), $get_config)
+                let name: &'static ::core::primitive::str = ::core::concat!($test_folder, "/", $file_name);
+                let file: &'static ::core::primitive::str = ::core::include_str!(
+                    ::core::concat!($test_folder, "/", $file_name, ".wast")
+                );
+                $runner_fn(name, file, $get_config)
             }
         )*
     };
@@ -35,7 +39,7 @@ macro_rules! define_spec_tests {
         let config = $get_config:expr;
         let runner = $runner_fn:path;
 
-        $( $(#[$attr:meta])* fn $test_name:ident($file_name:expr); )*
+        $( $(#[$attr:meta])* fn $test_name:ident($file_name:literal); )*
     ) => {
         define_tests! {
             let folder = "testsuite";

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -17,7 +17,7 @@ use wast::{
 };
 
 /// Runs the Wasm test spec identified by the given name.
-pub fn run_wasm_spec_test(name: &str, file: &str, config: Config) {
+pub fn run_wasm_spec_test(name: &'static str, file: &'static str, config: Config) {
     let test = TestDescriptor::new(name, file);
     let mut context = TestContext::new(&test, config);
 

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -17,8 +17,8 @@ use wast::{
 };
 
 /// Runs the Wasm test spec identified by the given name.
-pub fn run_wasm_spec_test(name: &str, config: Config) {
-    let test = TestDescriptor::new(name);
+pub fn run_wasm_spec_test(name: &str, file: &str, config: Config) {
+    let test = TestDescriptor::new(name, file);
     let mut context = TestContext::new(&test, config);
 
     let mut lexer = Lexer::new(test.file());


### PR DESCRIPTION
The only thing preventing `miri` from working was usage of the filesystem which we were able to eliminate by usage of the `include_str` macro.

Local compile time benchmarks signaled no significant change:
```shell
cargo clean && time cargo build --test spec_shim
```

- **Before:** `50.11s user 3.71s system 651% cpu 8.259 total`
- **After:** `49.74s user 3.64s system 652% cpu 8.179 total`

Running tests time also has not changed significantly:
```shell
cargo clean && time cargo test --test spec_shim
```

- **Before:** `11.36s user 0.10s system 339% cpu 3.378 total`
- **After:** `11.26s user 0.09s system 338% cpu 3.357 total`