### PR TITLE
Add Miri testing CRON job

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -33,4 +33,4 @@ jobs:
             #       if cargo-nextest was already installed on the CI runner.
             cargo install cargo-nextest || true
         - name: Miri Testing - Wasm Spec Testsuite
-          run: cargo miri nextest run --test-threads 4 --target x86_64-unknown-linux-gnu --test spec_shim
+          run: cargo miri nextest run --test-threads "num-cpus" --target x86_64-unknown-linux-gnu --test spec_shim

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -25,6 +25,8 @@ jobs:
               ~/target/
             key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
             restore-keys: ${{ runner.os }}-cargo-miri-
+        - name: Checkout Submodules
+          run: git submodule update --init --recursive
         - name: Install cargo-nextest
           run: |
             # Note: We use `|| true` because cargo install returns an error

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,29 @@
+name: Rust - Miri Testing (CRON)
+on:
+  schedule:
+    # Conduct Miri testing on 3:30 UTC every night.
+    - cron: "30 3 * * *"
+jobs:
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        - uses: dtolnay/rust-toolchain@nightly
+          with:
+            components: miri
+            targets: x86_64-unknown-linux-gnu
+        - name: Set up Cargo cache
+          uses: actions/cache@v4
+          continue-on-error: false
+          with:
+            path: |
+              ~/.cargo/bin/
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+              ~/target/
+            key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+            restore-keys: ${{ runner.os }}-cargo-miri-
+        - name: Miri Testing - Wasm Spec Testsuite
+          run: cargo miri nextest run --test-threads 4 --target x86_64-unknown-linux-gnu --test spec_shim

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -25,5 +25,10 @@ jobs:
               ~/target/
             key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
             restore-keys: ${{ runner.os }}-cargo-miri-
+        - name: Install cargo-nextest
+          run: |
+            # Note: We use `|| true` because cargo install returns an error
+            #       if cargo-nextest was already installed on the CI runner.
+            cargo install cargo-nextest || true
         - name: Miri Testing - Wasm Spec Testsuite
           run: cargo miri nextest run --test-threads 4 --target x86_64-unknown-linux-gnu --test spec_shim

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -33,4 +33,4 @@ jobs:
             #       if cargo-nextest was already installed on the CI runner.
             cargo install cargo-nextest || true
         - name: Miri Testing - Wasm Spec Testsuite
-          run: cargo miri nextest run --test-threads "num-cpus" --target x86_64-unknown-linux-gnu --test spec_shim
+          run: cargo miri nextest run --test-threads "num-cpus" --no-fail-fast --target x86_64-unknown-linux-gnu --test spec_shim

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -298,6 +298,11 @@ jobs:
             ~/target/
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-miri-
+      - name: Install cargo-nextest
+        run: |
+          # Note: We use `|| true` because cargo install returns an error
+          #       if cargo-nextest was already installed on the CI runner.
+          cargo install cargo-nextest || true
       - name: Miri (--lib)
         run: cargo miri test --lib --workspace
       - name: Miri (--doc)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -313,7 +313,7 @@ jobs:
         # We just run the `store.wast` test since running the entire Wasm spec testsuite
         # simply takes too long to do on every pull request commit. There exists an entire
         # CRON job that runs the entire Wasm spec testsuite using miri every night.
-        run: cargo miri nextest run --test-threads 2 --no-fail-fast --target x86_64-unknown-linux-gnu ::wasm_store
+        run: cargo miri nextest run --test-threads "num-cpus" --no-fail-fast --target x86_64-unknown-linux-gnu ::wasm_store
 
   clippy:
     name: Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -308,7 +308,7 @@ jobs:
       - name: Miri (--lib)
         run: cargo miri nextest run --test-threads "num-cpus" --target x86_64-unknown-linux-gnu --lib --workspace
       - name: Miri (--doc)
-        run: cargo miri test --doc --workspace
+        run: cargo miri test --doc --workspace --target x86_64-unknown-linux-gnu
       - name: Miri - Wasm Spec Testsuite (store)
         # We just run the `store.wast` test since running the entire Wasm spec testsuite
         # simply takes too long to do on every pull request commit. There exists an entire

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -306,14 +306,14 @@ jobs:
           #       if cargo-nextest was already installed on the CI runner.
           cargo install cargo-nextest || true
       - name: Miri (--lib)
-        run: cargo miri nextest run --test-threads "num-cpus" --target x86_64-unknown-linux-gnu --lib --workspace
+        run: cargo miri nextest run --test-threads "num-cpus" --no-fail-fast --target x86_64-unknown-linux-gnu --lib --workspace
       - name: Miri (--doc)
         run: cargo miri test --doc --workspace --target x86_64-unknown-linux-gnu
       - name: Miri - Wasm Spec Testsuite (store)
         # We just run the `store.wast` test since running the entire Wasm spec testsuite
         # simply takes too long to do on every pull request commit. There exists an entire
         # CRON job that runs the entire Wasm spec testsuite using miri every night.
-        run: cargo miri nextest run --test-threads 2 --target x86_64-unknown-linux-gnu ::wasm_store
+        run: cargo miri nextest run --test-threads 2 --no-fail-fast --target x86_64-unknown-linux-gnu ::wasm_store
 
   clippy:
     name: Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -298,6 +298,8 @@ jobs:
             ~/target/
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-miri-
+      - name: Checkout Submodules
+        run: git submodule update --init --recursive
       - name: Install cargo-nextest
         run: |
           # Note: We use `|| true` because cargo install returns an error

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -306,7 +306,7 @@ jobs:
           #       if cargo-nextest was already installed on the CI runner.
           cargo install cargo-nextest || true
       - name: Miri (--lib)
-        run: cargo miri test --lib --workspace
+        run: cargo miri nextest run --test-threads "num-cpus" --target x86_64-unknown-linux-gnu --lib --workspace
       - name: Miri (--doc)
         run: cargo miri test --doc --workspace
       - name: Miri - Wasm Spec Testsuite (store)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -285,6 +285,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
+          targets: x86_64-unknown-linux-gnu
       - name: Set up Cargo cache
         uses: actions/cache@v4
         continue-on-error: false
@@ -301,6 +302,11 @@ jobs:
         run: cargo miri test --lib --workspace
       - name: Miri (--doc)
         run: cargo miri test --doc --workspace
+      - name: Miri - Wasm Spec Testsuite (store)
+        # We just run the `store.wast` test since running the entire Wasm spec testsuite
+        # simply takes too long to do on every pull request commit. There exists an entire
+        # CRON job that runs the entire Wasm spec testsuite using miri every night.
+        run: cargo miri nextest run --test-threads 2 --target x86_64-unknown-linux-gnu ::wasm_store
 
   clippy:
     name: Clippy


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/901.

There currently is a `wast` bug reported by `miri` so this CRON job likely won't pass until we use the fixed `wast` version once published. (https://github.com/bytecodealliance/wasm-tools/pull/1386)