### PR TITLE
Update `wast` to `v70.0.2`

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -29,7 +29,7 @@ num-derive = "0.4"
 [dev-dependencies]
 wat = "1"
 assert_matches = "1.5"
-wast = "65.0"
+wast = "70.0.2"
 anyhow = "1.0"
 criterion = { version = "0.5", default-features = false }
 

--- a/crates/wasmi/tests/spec/run.rs
+++ b/crates/wasmi/tests/spec/run.rs
@@ -191,6 +191,7 @@ fn execute_directives(wast: Wast, test_context: &mut TestContext) -> Result<()> 
                     )
                 }
             }
+            unsupported => panic!("encountered unsupported Wast directive: {unsupported:?}"),
         }
     }
     Ok(())


### PR DESCRIPTION
This fixes a potential UB in `miri` for our testing pipeline. Merging this PR makes our `miri` CI run for more tests.