### PR TITLE
Add `default-miri` `nextest` configuration

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default-miri]
+slow-timeout = { period = "120s", terminate-after = 4 }
+test-threads = "num-cpus"
+fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.default-miri]
-slow-timeout = { period = "120s", terminate-after = 4 }
+slow-timeout = { period = "150s", terminate-after = 2 }
 test-threads = "num-cpus"
 fail-fast = false

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -33,4 +33,4 @@ jobs:
             #       if cargo-nextest was already installed on the CI runner.
             cargo install cargo-nextest || true
         - name: Miri Testing - Wasm Spec Testsuite
-          run: cargo miri nextest run --test-threads "num-cpus" --no-fail-fast --target x86_64-unknown-linux-gnu --test spec_shim
+          run: cargo miri nextest run --target x86_64-unknown-linux-gnu --test spec_shim

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -306,14 +306,14 @@ jobs:
           #       if cargo-nextest was already installed on the CI runner.
           cargo install cargo-nextest || true
       - name: Miri (--lib)
-        run: cargo miri nextest run --test-threads "num-cpus" --no-fail-fast --target x86_64-unknown-linux-gnu --lib --workspace
+        run: cargo miri nextest run --target x86_64-unknown-linux-gnu --lib --workspace
       - name: Miri (--doc)
         run: cargo miri test --doc --workspace --target x86_64-unknown-linux-gnu
       - name: Miri - Wasm Spec Testsuite (store)
         # We just run the `store.wast` test since running the entire Wasm spec testsuite
         # simply takes too long to do on every pull request commit. There exists an entire
         # CRON job that runs the entire Wasm spec testsuite using miri every night.
-        run: cargo miri nextest run --test-threads "num-cpus" --no-fail-fast --target x86_64-unknown-linux-gnu ::wasm_store
+        run: cargo miri nextest run --target x86_64-unknown-linux-gnu ::wasm_store
 
   clippy:
     name: Clippy


### PR DESCRIPTION
This allows us to run `miri` testing with "num-cpus" threads without specifying that in the CLI.
Also this makes it possible to stop a test case after running for 2x150s (300s or 5 min).